### PR TITLE
Use Dev PivNet registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: list
 
 # Image URL to use all building/pushing image targets
-CONTROLLER_IMAGE=registry.pivotal.io/p-rabbitmq-for-kubernetes-staging/rabbitmq-for-kubernetes-operator
+CONTROLLER_IMAGE=dev.registry.pivotal.io/p-rabbitmq-for-kubernetes/rabbitmq-for-kubernetes-operator
 CI_IMAGE=us.gcr.io/cf-rabbitmq-for-k8s-bunny/rabbitmq-for-kubernetes-ci
 GCP_PROJECT=cf-rabbitmq-for-k8s-bunny
 RABBITMQ_USERNAME=guest
@@ -154,9 +154,9 @@ system-tests: ## run end-to-end tests against Kubernetes cluster defined in ~/.k
 	NAMESPACE="pivotal-rabbitmq-system" ginkgo -nodes=3 --randomizeAllSpecs -r system_tests/
 
 DOCKER_REGISTRY_SECRET=p-rmq-registry-access
-DOCKER_REGISTRY_SERVER=registry.pivotal.io
-DOCKER_REGISTRY_USERNAME_LOCAL=$(shell lpassd show "Shared-RabbitMQ for Kubernetes/pivnet-registry-ci" --notes | jq -r .name)
-DOCKER_REGISTRY_PASSWORD_LOCAL=$(shell lpassd show "Shared-RabbitMQ for Kubernetes/pivnet-registry-ci" --notes | jq -r .token)
+DOCKER_REGISTRY_SERVER=dev.registry.pivotal.io
+DOCKER_REGISTRY_USERNAME_LOCAL=$(shell lpassd show "Shared-RabbitMQ for Kubernetes/pivnet-dev-registry-ci" --notes | jq -r .name)
+DOCKER_REGISTRY_PASSWORD_LOCAL=$(shell lpassd show "Shared-RabbitMQ for Kubernetes/pivnet-dev-registry-ci" --notes | jq -r .token)
 docker-registry-secret: operator-namespace
 	echo "creating registry secret and patching default service account"
 	@kubectl -n $(K8S_OPERATOR_NAMESPACE) create secret docker-registry $(DOCKER_REGISTRY_SECRET) --docker-server='$(DOCKER_REGISTRY_SERVER)' --docker-username='$(DOCKER_REGISTRY_USERNAME_LOCAL)' --docker-password='$(DOCKER_REGISTRY_PASSWORD_LOCAL)' || true

--- a/config/default/base/manager_image_patch.yaml
+++ b/config/default/base/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: registry.pivotal.io/p-rabbitmq-for-kubernetes-staging/rabbitmq-for-kubernetes-operator:latest
+      - image: dev.registry.pivotal.io/p-rabbitmq-for-kubernetes/rabbitmq-for-kubernetes-operator:latest
         name: operator

--- a/config/default/overlays/dev/manager_image_patch.yaml
+++ b/config/default/overlays/dev/manager_image_patch.yaml
@@ -8,6 +8,6 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: registry.pivotal.io/p-rabbitmq-for-kubernetes-staging/rabbitmq-for-kubernetes-operator:e89ed15-
+      - image: dev.registry.pivotal.io/p-rabbitmq-for-kubernetes/rabbitmq-for-kubernetes-operator:e89ed15-
         name: operator
         imagePullPolicy: Always

--- a/config/default/overlays/kind/manager_image_patch.yaml
+++ b/config/default/overlays/kind/manager_image_patch.yaml
@@ -8,6 +8,6 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: registry.pivotal.io/p-rabbitmq-for-kubernetes-staging/rabbitmq-for-kubernetes-operator:15c2591-
+      - image: dev.registry.pivotal.io/p-rabbitmq-for-kubernetes/rabbitmq-for-kubernetes-operator:5a5e6bf-
         name: operator
         imagePullPolicy: IfNotPresent

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -44,7 +44,7 @@ var _ = Describe("Operator", func() {
 		BeforeEach(func() {
 			cluster = generateRabbitmqCluster(namespace, "basic-rabbit")
 			cluster.Spec.Service.Type = "LoadBalancer"
-			cluster.Spec.Image = "registry.pivotal.io/p-rabbitmq-for-kubernetes-staging/rabbitmq:latest"
+			cluster.Spec.Image = "dev.registry.pivotal.io/p-rabbitmq-for-kubernetes/rabbitmq:latest"
 			cluster.Spec.ImagePullSecret = "p-rmq-registry-access"
 			cluster.Spec.Resources = &corev1.ResourceRequirements{
 				Requests: map[corev1.ResourceName]k8sresource.Quantity{},
@@ -104,7 +104,7 @@ var _ = Describe("Operator", func() {
 		BeforeEach(func() {
 			cluster = generateRabbitmqCluster(namespace, "persistence-rabbit")
 			cluster.Spec.Service.Type = "LoadBalancer"
-			cluster.Spec.Image = "registry.pivotal.io/p-rabbitmq-for-kubernetes-staging/rabbitmq:latest"
+			cluster.Spec.Image = "dev.registry.pivotal.io/p-rabbitmq-for-kubernetes/rabbitmq:latest"
 			cluster.Spec.ImagePullSecret = "p-rmq-registry-access"
 			cluster.Spec.Resources = &corev1.ResourceRequirements{
 				Requests: map[corev1.ResourceName]k8sresource.Quantity{},


### PR DESCRIPTION
Related issue number: #25 

## Summary Of Changes
- Change `registry.pivotal.io` reference to `dev.registry.pivotal.io`
- Changed system test spec testing private images to use Dev PivNet registry

## Additional Context
We need to start using Dev PivNet registry in order to create image references in our PivNet releases. More context in [this Slack conversation](https://pivotal.slack.com/archives/CL98C3B6U/p1582301410119400) and in [this one](https://pivotal.slack.com/archives/CL98C3B6U/p1582025488109900).

## Local Testing

Tests are green locally. CI needs these changes merged to go gree 🙂