### PR TITLE
Add code convention to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Also, run the system tests against a Kubernetes cluster:
 - `make deploy`
 - `make system-tests`
 
+### Code Conventions
+
+This project follows the same code conventions as the [kubernetes golang code conventions](https://github.com/kubernetes/community/blob/master/contributors/guide/coding-conventions.md#code-conventions). The kuberentes golang code conventions mostly refer to [Effective Go](https://golang.org/doc/effective_go.html) and the [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments). Please ensure your pull requests follow these guidlines.
+
 ## License
 
 //TODO


### PR DESCRIPTION
[#170954291]

Related issue number: # n/a

## Summary Of Changes
Add a code convention block to README.

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
