### PR TITLE
Bump rabbitmq version

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	rabbitmqImage             string             = "rabbitmq:3.8.2"
+	rabbitmqImage             string             = "rabbitmq:3.8.3"
 	defaultPersistentCapacity string             = "10Gi"
 	defaultMemoryLimit        string             = "2Gi"
 	defaultCPULimit           string             = "2000m"

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -285,7 +285,7 @@ func generateRabbitmqClusterObject(clusterName string) *RabbitmqCluster {
 		},
 		Spec: RabbitmqClusterSpec{
 			Replicas: int32(1),
-			Image:    "rabbitmq:3.8.2",
+			Image:    "rabbitmq:3.8.3",
 			Service: RabbitmqClusterServiceSpec{
 				Type: "ClusterIP",
 			},

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 name: rabbitmq
 version: 0.1
-appVersion: 3.8.2
+appVersion: 3.8.3
 description: Pivotal RabbitMQ for Kubernetes
 keywords:
 - rabbitmq


### PR DESCRIPTION
Related issue number: #48

## Summary Of Changes
- Bump image version used by the operator
- Bump helm chart metadata version

## Additional Context
CI changed here: https://github.com/pivotal/rabbitmq-for-kubernetes-ci/commit/1591a53926a855a8a6753593077bc60c80ee7a97

## Local Testing

Has been tested locally by running the unit, integration and system tests.