### PR TITLE
Increase timeout to get sts in integration tests and refactor

### DIFF
--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -613,7 +613,7 @@ var _ = Describe("RabbitmqclusterController", func() {
 func statefulSet(rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) *appsv1.StatefulSet {
 	stsName := rabbitmqCluster.ChildResourceName("server")
 	var sts *appsv1.StatefulSet
-	Eventually(func() error {
+	EventuallyWithOffset(1, func() error {
 		var err error
 		sts, err = clientSet.AppsV1().StatefulSets(rabbitmqCluster.Namespace).Get(stsName, metav1.GetOptions{})
 		return err
@@ -624,16 +624,16 @@ func statefulSet(rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) *appsv1.State
 func service(rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster, svcName string) *corev1.Service {
 	serviceName := rabbitmqCluster.ChildResourceName(svcName)
 	var svc *corev1.Service
-	Eventually(func() error {
+	EventuallyWithOffset(1, func() error {
 		var err error
 		svc, err = clientSet.CoreV1().Services(rabbitmqCluster.Namespace).Get(serviceName, metav1.GetOptions{})
 		return err
-	}, 1).Should(Succeed())
+	}, 2).Should(Succeed())
 	return svc
 }
 
 func waitForClusterCreation(rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster, client runtimeClient.Client) {
-	Eventually(func() string {
+	EventuallyWithOffset(1, func() string {
 		rabbitmqClusterCreated := rabbitmqv1beta1.RabbitmqCluster{}
 		err := client.Get(
 			context.TODO(),
@@ -655,7 +655,7 @@ func waitForClusterCreation(rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster, cl
 }
 
 func waitForClusterDeletion(rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster, client runtimeClient.Client) {
-	Eventually(func() bool {
+	EventuallyWithOffset(1, func() bool {
 		rabbitmqClusterCreated := rabbitmqv1beta1.RabbitmqCluster{}
 		err := client.Get(
 			context.TODO(),


### PR DESCRIPTION
Related issue number: #50 

## Summary Of Changes

- We used to have 1 second of a timeout to get statefulset, which is often not long enough. After updating timeout to 5 second, integration tests ran 20 times locally without failing.

- Add function `service()` which returns either ingress or the headless service object depends on the input. The function does an `EventuallyWithOffset` to get the service object. We are using the function everywhere in integration tests where we are getting service objects after creating a cluster.

- Use `EventuallyWithOffset` in helper function `statefulset()`, `waitForClusterCreation()`, ` 
 func waitForClusterDeletion()` in integration tests. [EventuallyWithOffset](https://github.com/onsi/gomega/blob/master/gomega_dsl.go#L213) takes an additional integer argument that is used to modify the call-stack offset when computing line numbers. This is useful in any helper functions that has assertions in ginkgo tests. There are also the `ExpectWithOffset` and `ConsistentlyWithOffset`

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
