### PR TITLE
Make destroy should delete the CRD before anything else

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,14 +67,16 @@ configure-kubectl-ci: ci-cluster
 	gcloud container clusters get-credentials $(CI_CLUSTER) --region europe-west1 --project $(GCP_PROJECT)
 
 destroy: ## Cleanup all controller artefacts
-	kubectl delete -k config/default/base --ignore-not-found=true
-	kubectl delete -k config/namespace/base --ignore-not-found=true
-	kubectl delete -k config/crd --ignore-not-found=true
+	kubectl delete -k config/crd/ --ignore-not-found=true
+	kubectl delete -k config/default/base/ --ignore-not-found=true
+	kubectl delete -k config/rbac/ --ignore-not-found=true
+	kubectl delete -k config/namespace/base/ --ignore-not-found=true
 
 destroy-ci: configure-kubectl-ci
-	kubectl delete -k config/default/overlays/ci --ignore-not-found=true
-	kubectl delete -k config/namespace/base --ignore-not-found=true
 	kubectl delete -k config/crd --ignore-not-found=true
+	kubectl delete -k config/default/overlays/ci --ignore-not-found=true
+	kubectl delete -k config/rbac/ --ignore-not-found=true
+	kubectl delete -k config/namespace/base --ignore-not-found=true
 
 run: generate manifests fmt vet install deploy-namespace-rbac  ## Run operator binary locally against the configured Kubernetes cluster in ~/.kube/config
 	go run ./main.go


### PR DESCRIPTION
Related to #79 

## Summary Of Changes
- Make destroy now deletes the CRD before deleting the Operator and Namespace
- Make destroy now also destroys cluster scoped RBAC objects
   - It was leaving those "orphaned"

## Local Testing
```
kind create cluster
make deploy
k rabbitmq create foo --replicas 1
# wait for RabbitMQ pod to be ready
make destroy
```

It should not hang in the last step when it tries to delete the Namespace.