### PR TITLE
In KSM binding, return `hostname` if present

### DIFF
--- a/charts/rabbitmq/ksm/bind.yaml
+++ b/charts/rabbitmq/ksm/bind.yaml
@@ -1,23 +1,29 @@
 template: |
   local ingressFilterFunc(j) = std.length(std.findSubstr("rabbitmq-ingress", j.name)) > 0;
-  local ingress = std.filter(ingressFilterFunc, $.services);
+  local ingressService = std.filter(ingressFilterFunc, $.services)[0];
   local secretFilterFunc(j) = std.length(std.findSubstr("rabbitmq-admin", j.name)) > 0;
   local admin = std.filter(secretFilterFunc, $.secrets);
 
   local vhost = "%2F";
-  local ingressIP = if ingress[0].spec.type == "LoadBalancer" then ingress[0].status.loadBalancer.ingress[0].ip else ingress[0].spec.clusterIP;
+  local ingress = if ingressService.spec.type == "LoadBalancer" then
+      if std.objectHas(ingressService.status.loadBalancer.ingress[0], "hostname") then
+        ingressService.status.loadBalancer.ingress[0].hostname
+      else
+        ingressService.status.loadBalancer.ingress[0].ip
+    else
+      ingressService.spec.clusterIP;
   local adminUsername = admin[0].data['username'];
   local adminPassword = admin[0].data['password'];
-  local mgmtURI = "http://" + ingressIP + ":15672/#/login/" + adminUsername + "/" + adminPassword;
-  local apiURI = "http://" + adminUsername + ":" + adminPassword + "@" + ingressIP + ":15672/api/";
-  local amqpURI = "amqp://" + adminUsername + ":" + adminPassword + "@" + ingressIP + "/" + vhost;
+  local mgmtURI = "http://" + ingress + ":15672/#/login/" + adminUsername + "/" + adminPassword;
+  local apiURI = "http://" + adminUsername + ":" + adminPassword + "@" + ingress + ":15672/api/";
+  local amqpURI = "amqp://" + adminUsername + ":" + adminPassword + "@" + ingress + "/" + vhost;
   {
-    "hostname": ingressIP,
+    "hostname": ingress,
     "username": adminUsername,
     "password": adminPassword,
     "dashboard_url": mgmtURI,
     "hostnames": [
-      ingressIP
+      ingress
     ],
     "http_api_uri": apiURI,
     "http_api_uris": [
@@ -31,9 +37,9 @@ template: |
     "vhost": vhost,
     "protocols": {
       "amqp": {
-        "host": ingressIP,
+        "host": ingress,
         "hosts": [
-          ingressIP
+          ingress
         ],
         "password": adminPassword,
         "port": 5672,
@@ -46,9 +52,9 @@ template: |
         "vhost": vhost
       },
       "management": {
-        "host": ingressIP,
+        "host": ingress,
         "hosts": [
-          ingressIP
+          ingress
         ],
         "password": adminPassword,
         "path": "/api/",


### PR DESCRIPTION
Check for `hostname` property on the ingress service status. If it
exists - return it instead of the IP address

Additional changes:
- rename `ingressIP` to just `ingress` since it can be a hostname now
- simplify the file by adding `[0]` once, rather than on every reference
to the service

This closes #71 

## Local Testing

Unfortunately quite hard since you can't easily get a service with a hostname. However, validated with some manual testing that it works the same in the existing env with ClusterIP and LoadBalancer with an IP field (no regressions).
You can try that by deploying an instance and then running: 
```
$ template-tester default charts/rabbitmq/ksm/bind.yaml
```