### PR TITLE
Fixes bug in Pod deletion

### DIFF
--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -343,13 +343,13 @@ func (r *RabbitmqClusterReconciler) prepareForDeletion(ctx context.Context, rabb
 					Namespace: rabbitmqCluster.Namespace,
 				},
 			}
-			// Delete StatefulSet so Pods aren't restarted after shutdown
-			if err := r.Client.Delete(ctx, sts); client.IgnoreNotFound(err) != nil {
-				return fmt.Errorf(fmt.Sprintf("Cannot delete StatefulSet: %s", err.Error()))
-			}
 			// Add label on all Pods to be picked up in pre-stop hook via Downward API
 			if err := r.addRabbitmqDeletionLabel(ctx, rabbitmqCluster); err != nil {
 				return fmt.Errorf(fmt.Sprintf("Failed to add deletion markers to RabbitmqCluster Pods: %s", err.Error()))
+			}
+			// Delete StatefulSet immediately after changing pod labels to minimize risk of them respawning. There is a window where the StatefulSet could respawn Pods without the deletion label in this order. But we can't delete it before because the DownwardAPI doesn't update once a Pod enters Terminating
+			if err := r.Client.Delete(ctx, sts); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf(fmt.Sprintf("Cannot delete StatefulSet: %s", err.Error()))
 			}
 
 			return nil
@@ -393,7 +393,7 @@ func (r *RabbitmqClusterReconciler) addRabbitmqDeletionLabel(ctx context.Context
 
 	for i := 0; i < len(pods.Items); i++ {
 		pod := &pods.Items[i]
-		pod.Labels[deletionFinalizer] = "true"
+		pod.Labels[resource.DeletionMarker] = "true"
 		if err := r.Client.Update(ctx, pod); client.IgnoreNotFound(err) != nil {
 			return fmt.Errorf(fmt.Sprintf("Cannot Update Pod %s in Namespace %s: %s", pod.Name, pod.Namespace, err.Error()))
 		}

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -18,7 +18,7 @@ const (
 	defaultGracePeriodTimeoutSeconds int64  = 60 * 60 * 24 * 7
 	initContainerCPU                 string = "100m"
 	initContainerMemory              string = "500Mi"
-	deletionMarker                   string = "skipPreStopChecks"
+	DeletionMarker                   string = "skipPreStopChecks"
 )
 
 func (builder *RabbitmqResourceBuilder) StatefulSet() *StatefulSetBuilder {
@@ -310,7 +310,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 						PreStop: &corev1.Handler{
 							Exec: &corev1.ExecAction{
 								Command: []string{
-									"/bin/bash", "-c", fmt.Sprintf("if [ ! -z \"$(cat /etc/pod-info/%s)\" ]; then exit 0; fi;", deletionMarker) +
+									"/bin/bash", "-c", fmt.Sprintf("if [ ! -z \"$(cat /etc/pod-info/%s)\" ]; then exit 0; fi;", DeletionMarker) +
 										" while true; do rabbitmq-queues check_if_node_is_quorum_critical" +
 										" 2>&1; if [ $(echo $?) -eq 69 ]; then sleep 2; continue; fi;" +
 										" rabbitmq-queues check_if_node_is_mirror_sync_critical" +
@@ -377,9 +377,9 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 						DownwardAPI: &corev1.DownwardAPIVolumeSource{
 							Items: []corev1.DownwardAPIVolumeFile{
 								{
-									Path: deletionMarker,
+									Path: DeletionMarker,
 									FieldRef: &corev1.ObjectFieldSelector{
-										FieldPath: fmt.Sprintf("metadata.labels['%s']", deletionMarker),
+										FieldPath: fmt.Sprintf("metadata.labels['%s']", DeletionMarker),
 									},
 								},
 							},


### PR DESCRIPTION
- Label set in controller did not match expected volume location for
DownardAPI used in Pod deletion

- DownardAPI does not appear to update once Pod enters Terminating. We
then need to delete the statefulSet (which triggers Pod deletion) after
we've set the downwardAPI volume value in the label. This introduces a
race condition where a Pod could be respawned that wouldn't terminate
immediately, but the window would be small.