### PR TITLE
Do not address by cluster domain

### DIFF
--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -12,7 +12,7 @@ import (
 const (
 	serverConfigMapName = "server-conf"
 	defaultRabbitmqConf = `cluster_formation.peer_discovery_backend = rabbit_peer_discovery_k8s
-cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
+cluster_formation.k8s.host = kubernetes.default
 cluster_formation.k8s.address_type = hostname
 cluster_formation.node_cleanup.interval = 30
 cluster_formation.node_cleanup.only_log_warning = true

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -92,7 +92,7 @@ var _ = Describe("GenerateServerConfigMap", func() {
 
 		It("returns the default rabbitmq conf when additionalConfig is not provided", func() {
 			defaultRabbitmqConf := `cluster_formation.peer_discovery_backend = rabbit_peer_discovery_k8s
-cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
+cluster_formation.k8s.host = kubernetes.default
 cluster_formation.k8s.address_type = hostname
 cluster_formation.node_cleanup.interval = 30
 cluster_formation.node_cleanup.only_log_warning = true
@@ -107,7 +107,7 @@ queue_master_locator = min-masters`
 
 		It("appends configurations to the default rabbitmq.conf when additionalConfig is provided", func() {
 			expectedRabbitmqConf := `cluster_formation.peer_discovery_backend = rabbit_peer_discovery_k8s
-cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
+cluster_formation.k8s.host = kubernetes.default
 cluster_formation.k8s.address_type = hostname
 cluster_formation.node_cleanup.interval = 30
 cluster_formation.node_cleanup.only_log_warning = true

--- a/internal/resource/headless_service.go
+++ b/internal/resource/headless_service.go
@@ -45,6 +45,7 @@ func (builder *HeadlessServiceBuilder) Update(object runtime.Object) error {
 				Name:     "epmd",
 			},
 		},
+		PublishNotReadyAddresses: true,
 	}
 
 	return nil

--- a/internal/resource/headless_service_test.go
+++ b/internal/resource/headless_service_test.go
@@ -167,6 +167,7 @@ var _ = Describe("HeadlessService", func() {
 						Name:     "epmd",
 					},
 				},
+				PublishNotReadyAddresses: true,
 			}
 
 			Expect(service.Spec).To(Equal(expectedSpec))

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -247,11 +247,11 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 						},
 						{
 							Name:  "RABBITMQ_NODENAME",
-							Value: "rabbit@$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.cluster.local",
+							Value: "rabbit@$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE)",
 						},
 						{
 							Name:  "K8S_HOSTNAME_SUFFIX",
-							Value: ".$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.cluster.local",
+							Value: ".$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE)",
 						},
 					},
 					Ports: []corev1.ContainerPort{

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -477,11 +477,11 @@ var _ = Describe("StatefulSet", func() {
 				},
 				{
 					Name:  "RABBITMQ_NODENAME",
-					Value: "rabbit@$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.cluster.local",
+					Value: "rabbit@$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE)",
 				},
 				{
 					Name:  "K8S_HOSTNAME_SUFFIX",
-					Value: ".$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.cluster.local",
+					Value: ".$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE)",
 				},
 			}
 


### PR DESCRIPTION
Co-authored-by: Aitor Perez Cedres <acedres@pivotal.io>

This closes #75

## Summary Of Changes
- the `PublishNotReadyAddresses` allows the pods to be addressable by
name before they are ready. This seems okay for the headless service
because it is only used by inter-node (epmd) communication
- dns names no longer include the suffix - `.svc.<cluster-domain>`. See commit delta for more info.

## Testing

### Calatrava Guest Cluster

This k8s environment has the cluster domain - `managedcluster.local`

We ran our system tests to make sure clustering still occurred with the changed domain.

In order to run the system tests, we created a new storage class and set it to be the default class (instead of changing the system tests to specify the storage class just for Calatrava).

### KIND Cluster with Changed domain

We used the following KIND configuration to create a cluster with domain - `foo.bar`.

```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
kubeadmConfigPatches:
- |
  kind: KubeletConfiguration
  clusterDomain: foo.bar
- |
  kind: ClusterConfiguration
  networking:
    dnsDomain: foo.bar
```

If your pods run into the "insufficient cpu" problem, you can modify the `resources.limits` and `resources.requests` to `{}` in the CR.

We saw clustering work fine here too.

The unit, integration and system tests on our gke dev bunny environment pass too.