### PR TITLE
Fix intermittent test failure

### DIFF
--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -139,6 +139,7 @@ var _ = Describe("Operator", func() {
 				Expect(rmqClusterClient.Get(context.Background(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, fetchedRabbit)).To(Succeed())
 				fetchedRabbit.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_top"}
 				Expect(rmqClusterClient.Update(context.TODO(), fetchedRabbit)).To(Succeed())
+				waitForRabbitmqRunning(fetchedRabbit)
 
 				Eventually(func() error {
 					_, err := kubectlExec(namespace,


### PR DESCRIPTION
We are seeing intermittent system test failures where the rabbitmq-plugins command
exits with status 69 (unavailable). The cluster update we're
triggering just before running this command will restart the Pod. We should be explicit in our test about waiting for the Pod to be ready to receive CLI commands.

Failing tests have the following output:
```
Timed out after 20.482s.
    Expected success, but got an error:
        <*exec.ExitError | 0xc00048d120>: {
            ProcessState: {
                pid: 7389,
                status: 17664,
                rusage: {
                    Utime: {Sec: 0, Usec: 128212},
                    Stime: {Sec: 0, Usec: 28046},
                    Maxrss: 39172,
                    Ixrss: 0,
                    Idrss: 0,
                    Isrss: 0,
                    Minflt: 3772,
                    Majflt: 0,
                    Nswap: 0,
                    Inblock: 0,
                    Oublock: 0,
                    Msgsnd: 0,
                    Msgrcv: 0,
                    Nsignals: 0,
                    Nvcsw: 524,
                    Nivcsw: 23,
                },
            },
            Stderr: nil,
        }
        exit status 69
```