### PR TITLE
Add a note to reviewers to remind about squashing

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,7 @@
 This closes #
 
+**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
+
 ## Summary Of Changes
 
 ## Additional Context


### PR DESCRIPTION
In the spirit of keeping our commit history relevant and navigable, reviewers should also review the commit list presented in a PR. If some or all commits can be squashed, they should suggest so. If not all commits should be squashed, the reviewer should suggest to rebase the branch and re-push.

## Summary Of Changes
- Added a line to the PR template to remind reviewers to look at the commit list presented in a PR

## Additional Context
- This has been an action item in retro for a bit 😎 

## Local Testing
N/A only markdown changes