### PR TITLE
Allow cluster replicas size of any number

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -53,8 +53,8 @@ type RabbitmqCluster struct {
 
 // Spec is the desired state of the RabbitmqCluster Custom Resource.
 type RabbitmqClusterSpec struct {
-	// Replicas is the number of nodes in the RabbitMQ cluster. Each node is deployed as a Replica in a StatefulSet.
-	// +kubebuilder:validation:Enum=1;3
+	// Replicas is the number of nodes in the RabbitMQ cluster. Each node is deployed as a Replica in a StatefulSet. Only 1, 3, 5 replicas clusters are tested.
+	// +kubebuilder:validation:Minimum:=0
 	Replicas *int32 `json:"replicas"`
 	// Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster.
 	Image string `json:"image,omitempty"`

--- a/config/crd/bases/rabbitmq.pivotal.io_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.pivotal.io_rabbitmqclusters.yaml
@@ -666,12 +666,9 @@ spec:
                   type: array
               type: object
             replicas:
-              description: Replicas is the number of nodes in the RabbitMQ cluster.
-                Each node is deployed as a Replica in a StatefulSet.
-              enum:
-              - 1
-              - 3
+              description: Replicas is the number of nodes in the RabbitMQ cluster. Each node is deployed as a Replica in a StatefulSet. Only 1, 3, 5 replicas clusters are tested.
               format: int32
+              minimum: 0
               type: integer
             resources:
               description: ResourceRequirements describes the compute resource requirements.

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -32,7 +32,7 @@ var _ = Describe("Operator", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("Publish and consume a message", func() {
+	Context("Publish and consume a message in a 3 nodes cluster", func() {
 		var (
 			cluster  *rabbitmqv1beta1.RabbitmqCluster
 			hostname string
@@ -41,7 +41,9 @@ var _ = Describe("Operator", func() {
 		)
 
 		BeforeEach(func() {
+			three := int32(3)
 			cluster = generateRabbitmqCluster(namespace, "basic-rabbit")
+			cluster.Spec.Replicas = &three
 			cluster.Spec.Service.Type = "LoadBalancer"
 			cluster.Spec.Image = "dev.registry.pivotal.io/p-rabbitmq-for-kubernetes/rabbitmq:latest"
 			cluster.Spec.ImagePullSecret = "p-rmq-registry-access"
@@ -234,14 +236,14 @@ cluster_keepalive_interval = 10000`
 		})
 	})
 
-	Context("Clustering", func() {
-		When("RabbitmqCluster is deployed with 3 nodes", func() {
+	Context("Clustering with 5 nodes", func() {
+		When("RabbitmqCluster is deployed with 5 nodes", func() {
 			var cluster *rabbitmqv1beta1.RabbitmqCluster
 
 			BeforeEach(func() {
-				three := int32(3)
+				five := int32(5)
 				cluster = generateRabbitmqCluster(namespace, "ha-rabbit")
-				cluster.Spec.Replicas = &three
+				cluster.Spec.Replicas = &five
 				cluster.Spec.Service.Type = "LoadBalancer"
 				cluster.Spec.Resources = &corev1.ResourceRequirements{
 					Requests: map[corev1.ResourceName]k8sresource.Quantity{},


### PR DESCRIPTION
This closes #131 

## Summary Of Changes

- Remove restriction on spec.replicas has to be 1 or 3
- Ensure to test 1, 3, 5 nodes clusters in system tests

## Additional Context

`spec.replicas` schema validation ensures that input has to be an int32 that is 0 or bigger. This is the same validation on StatefulSet.spec.replicas.

## Local Testing

Modify and add unit tests. 5 nodes cluster is tested in system tess.

Commit will be squashed when merging.
