### PR TITLE
If unset, set GOBIN to GOPATH/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,9 @@ ifeq (, $(shell which controller-gen))
 	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
+ifeq (, $(GOBIN))
+GOBIN=$(GOPATH)/bin
+endif
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)


### PR DESCRIPTION
It is not required to set the `GOBIN` env variable. In environments where it is not set, the value `$GOPATH/bin` should be used.

Fixes #133