### PR TITLE
[integration tests] Increase deletion timeout

### DIFF
--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	ClusterCreationTimeout = 5 * time.Second
-	ClusterDeletionTimeout = 2 * time.Second
+	ClusterDeletionTimeout = 5 * time.Second
 )
 
 var _ = Describe("RabbitmqclusterController", func() {


### PR DESCRIPTION
We noticed occasional failures locally (about 1 every 2-3 attempts when I tested) and in CI when a 2 second timeout was in place. Increasing this to 5 seconds has passed 14 runs in a row. 

## Local Testing

Ran `ginkgo -r -untilItFails controllers/`, to keep re-running the tests to check for an improvement. 