### PR TITLE
Better log msg when not all replicas are ready to enable plugins

### DIFF
--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -234,7 +234,7 @@ func (r *RabbitmqClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 	if err, ok := r.allReplicasReady(ctx, rabbitmqCluster); !ok {
 		// only enable plugins when all pods of the StatefulSet become ready
 		// requeue request after 10 seconds without error
-		logger.Info("Not all replicas ready yet; Requeue request to enable plugins on RabbitmqCluster",
+		logger.Info("Not all replicas ready yet; requeuing request to enable plugins on RabbitmqCluster",
 			"namespace", rabbitmqCluster.Namespace,
 			"name", rabbitmqCluster.Name)
 		return ctrl.Result{RequeueAfter: time.Second * 10}, err


### PR DESCRIPTION
This closes #139 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

Commits are just minor changes and will be **squashed** to one

## Summary Of Changes

- Better log msg when not all replicas are ready to enable plugins

## Additional Context

