### PR TITLE
Adds operator scope namespace env variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	// If the environment variable is not set Getenv returns an empty string which ctrl.Options.Namespace takes to mean all namespaces should be watched
 	operatorScopeNamespace := os.Getenv("OPERATOR_SCOPE_NAMESPACE")
 
 	options := ctrl.Options{


### PR DESCRIPTION
This change makes it possible to restrict the scope of the operator informer to a single namespace. With the namespace set, the operator can be deployed with a Rolebinding instead of requiring a ClusterRoleBinding. Changes to the resources we package are dependent on ongoing discussions regarding tooling (kustomize vs. helm vs. kapp) and will be added later.

I don't see much value in adding added system tests for this feature. It is sufficient that the current system tests pass.
