### PR TITLE
Removes 5 node system test

### DIFF
--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -236,40 +236,6 @@ cluster_keepalive_interval = 10000`
 		})
 	})
 
-	Context("Clustering with 5 nodes", func() {
-		When("RabbitmqCluster is deployed with 5 nodes", func() {
-			var cluster *rabbitmqv1beta1.RabbitmqCluster
-
-			BeforeEach(func() {
-				five := int32(5)
-				cluster = generateRabbitmqCluster(namespace, "ha-rabbit")
-				cluster.Spec.Replicas = &five
-				cluster.Spec.Service.Type = "LoadBalancer"
-				cluster.Spec.Resources = &corev1.ResourceRequirements{
-					Requests: map[corev1.ResourceName]k8sresource.Quantity{},
-					Limits:   map[corev1.ResourceName]k8sresource.Quantity{},
-				}
-				Expect(createRabbitmqCluster(rmqClusterClient, cluster)).To(Succeed())
-			})
-
-			AfterEach(func() {
-				Expect(rmqClusterClient.Delete(context.TODO(), cluster)).To(Succeed())
-			})
-
-			It("works", func() {
-				waitForRabbitmqRunning(cluster)
-				username, password, err := getRabbitmqUsernameAndPassword(clientSet, cluster.Namespace, cluster.Name)
-				waitForLoadBalancer(clientSet, cluster)
-				hostname := rabbitmqHostname(clientSet, cluster)
-				Expect(err).NotTo(HaveOccurred())
-
-				response, err := rabbitmqAlivenessTest(hostname, username, password)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(response.Status).To(Equal("ok"))
-			})
-		})
-	})
-
 	Context("TLS", func() {
 		When("TLS is correctly configured", func() {
 			var (


### PR DESCRIPTION
I don't think testing on 5 nodes achieves anything more than testing on 3. Given the running time of our system test suite I think we should be try to keep them to an absolute minimum in order to improve our time to deploy and reduce the chance for infra driven flakes