### PR TITLE
Rename ingress service to client service

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The easiest way to set up a local development environment for running the Rabbit
 1. Check that the operator is running by running `kubectl get all --namespace=rabbitmq-system`
 1. Deploy a `RabbitMQCluster` custom resource. Refer to the [example YAML](./cr-example.yaml) and [documentation](https://docs.pivotal.io/rabbitmq-kubernetes/0-7/using.html#configure) for available CR attributes
     1. Due to resource limitations on your Docker daemon, the Kubernetes might not be able to schedule all `RabbitmqCluter` nodes. Either [increase your Docker daemon's resource limits](https://docs.docker.com/docker-for-mac/#resources) or deploy the `RabbitmqCluster` custom resource with `resources: {}` to remove default `memory` and `cpu` resource settings.
-    1. If you set the `serviceType` to `LoadBalancer`, run `make prepare-kind` to deploy a [MetalLB](https://metallb.universe.tf/) load balancer. This will allow the operator to complete the `RabbitmqCluster` provisioning by assign an arbitrary local IP address to the cluster's ingress service. Proper [network configuration](https://metallb.universe.tf/installation/network-addons/) is required to route traffic via the assigned IP address.
+    1. If you set the `serviceType` to `LoadBalancer`, run `make prepare-kind` to deploy a [MetalLB](https://metallb.universe.tf/) load balancer. This will allow the operator to complete the `RabbitmqCluster` provisioning by assign an arbitrary local IP address to the cluster's client service. Proper [network configuration](https://metallb.universe.tf/installation/network-addons/) is required to route traffic via the assigned IP address.
 
 ### Documentation
 

--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -98,11 +98,11 @@ type RabbitmqClusterPersistenceSpec struct {
 	Storage *k8sresource.Quantity `json:"storage,omitempty"`
 }
 
-// Settable attributes for the Ingress Service resource.
+// Settable attributes for the Client Service resource.
 type RabbitmqClusterServiceSpec struct {
 	// +kubebuilder:validation:Enum=ClusterIP;LoadBalancer;NodePort
 	Type corev1.ServiceType `json:"type,omitempty"`
-	// Annotations to add to the Ingress Service.
+	// Annotations to add to the Client Service.
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 

--- a/charts/operator/templates/crd.yaml
+++ b/charts/operator/templates/crd.yaml
@@ -702,12 +702,12 @@ spec:
                   type: object
               type: object
             service:
-              description: Settable attributes for the Ingress Service resource.
+              description: Settable attributes for the Client Service resource.
               properties:
                 annotations:
                   additionalProperties:
                     type: string
-                  description: Annotations to add to the Ingress Service.
+                  description: Annotations to add to the Client Service.
                   type: object
                 type:
                   description: Service Type string describes ingress methods for a

--- a/charts/rabbitmq/ksm/bind.yaml
+++ b/charts/rabbitmq/ksm/bind.yaml
@@ -1,17 +1,17 @@
 template: |
-  local ingressFilterFunc(j) = std.length(std.findSubstr("rabbitmq-ingress", j.name)) > 0;
-  local ingressService = std.filter(ingressFilterFunc, $.services)[0];
+  local clientFilterFunc(j) = std.length(std.findSubstr("rabbitmq-client", j.name)) > 0;
+  local clientService = std.filter(clientFilterFunc, $.services)[0];
   local secretFilterFunc(j) = std.length(std.findSubstr("rabbitmq-admin", j.name)) > 0;
   local admin = std.filter(secretFilterFunc, $.secrets);
 
   local vhost = "%2F";
-  local ingress = if ingressService.spec.type == "LoadBalancer" then
-      if std.objectHas(ingressService.status.loadBalancer.ingress[0], "hostname") then
-        ingressService.status.loadBalancer.ingress[0].hostname
+  local ingress = if clientService.spec.type == "LoadBalancer" then
+      if std.objectHas(clientService.status.loadBalancer.ingress[0], "hostname") then
+        clientService.status.loadBalancer.ingress[0].hostname
       else
-        ingressService.status.loadBalancer.ingress[0].ip
+        clientService.status.loadBalancer.ingress[0].ip
     else
-      ingressService.spec.clusterIP;
+      clientService.spec.clusterIP;
   local adminUsername = admin[0].data['username'];
   local adminPassword = admin[0].data['password'];
   local mgmtURI = "http://" + ingress + ":15672/#/login/" + adminUsername + "/" + adminPassword;

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -446,12 +446,12 @@ spec:
                   type: object
               type: object
             service:
-              description: Settable attributes for the Ingress Service resource.
+              description: Settable attributes for the Client Service resource.
               properties:
                 annotations:
                   additionalProperties:
                     type: string
-                  description: Annotations to add to the Ingress Service.
+                  description: Annotations to add to the Client Service.
                   type: object
                 type:
                   description: Service Type string describes ingress methods for a service

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -256,7 +256,7 @@ func (r *RabbitmqClusterReconciler) setAdminStatus(ctx context.Context, rmq *rab
 	adminStatus := &rabbitmqv1beta1.RabbitmqClusterAdmin{}
 
 	serviceRef := &rabbitmqv1beta1.RabbitmqClusterServiceReference{
-		Name:      rmq.ChildResourceName("ingress"),
+		Name:      rmq.ChildResourceName("client"),
 		Namespace: rmq.Namespace,
 	}
 	adminStatus.ServiceReference = serviceRef
@@ -520,7 +520,7 @@ func (r *RabbitmqClusterReconciler) getChildResources(ctx context.Context, rmq r
 	}
 
 	if err := r.Client.Get(ctx,
-		types.NamespacedName{Name: rmq.ChildResourceName("ingress"), Namespace: rmq.Namespace},
+		types.NamespacedName{Name: rmq.ChildResourceName("client"), Namespace: rmq.Namespace},
 		endPoints); err != nil && !errors.IsNotFound(err) {
 		return nil, err
 	} else if errors.IsNotFound(err) {

--- a/docs/proposals/20200310-crd-spec-configurability.md
+++ b/docs/proposals/20200310-crd-spec-configurability.md
@@ -40,7 +40,7 @@ superseded-by:
 
 ## Summary
 
-Our current CRD spec has a limited number of exposed properties for users to configure which restricts supported use cases. This KEP proposes to add an override section as an additional way for users to configure their cluster. Users will be able to configure any field of the StatefulSet and ingress Service through editing the spec directly through this change.
+Our current CRD spec has a limited number of exposed properties for users to configure which restricts supported use cases. This KEP proposes to add an override section as an additional way for users to configure their cluster. Users will be able to configure any field of the StatefulSet and client Service through editing the spec directly through this change.
 
 ## Motivation
 
@@ -55,14 +55,14 @@ In our team roadmap we decided to coup the lack of user feedbacks by offering [d
 ## Non-Goals/Future Work
 
 * Increase flexibility at configuring RabbitMQ. We have already addressed this problem with the work on [rabbitmq conf](https://github.com/pivotal/rabbitmq-for-kubernetes/pull/91) and [enabled plugins](https://github.com/pivotal/rabbitmq-for-kubernetes/pull/87). In the future, we may add support for advanced configuration file. However that is out of scope for this KEP.
-* To provide detailed guidelines on how to configure each property. I assume that users who choose to configure the StatefulSet and ingress Service override know their specific use cases, and how to use kubernetes.
+* To provide detailed guidelines on how to configure each property. I assume that users who choose to configure the StatefulSet and client Service override know their specific use cases, and how to use kubernetes.
 
 ## Proposal
 
-This proposal adds the ability to override statefulSet and ingress service template directly through the CRD spec. Our operator creates 9 kubernetes child recourses directly for each `RabbitmqCluster`: ingress Service, headless Service, StatefulSet, ConfigMap, erlang cookie secret, admin secret, rbac role, role binding, service account. Among these resources, we allow users to partially configure the StatefulSet, the ingress Service, and the pods that StatefulSet creates. The proposal focuses on 2 child recourses: ingress Service and StatefulSet to increase configurability, since there is no obvious use case for now that involves configuring any of the other child resources. We can add overrides for other resources when we see fit in the future.
+This proposal adds the ability to override statefulSet and client service template directly through the CRD spec. Our operator creates 9 kubernetes child recourses directly for each `RabbitmqCluster`: client Service, headless Service, StatefulSet, ConfigMap, erlang cookie secret, admin secret, rbac role, role binding, service account. Among these resources, we allow users to partially configure the StatefulSet, the client Service, and the pods that StatefulSet creates. The proposal focuses on 2 child recourses: client Service and StatefulSet to increase configurability, since there is no obvious use case for now that involves configuring any of the other child resources. We can add overrides for other resources when we see fit in the future.
 
 A brief summary of the proposed plan:
-* Add an override section to CRD spec which supports statefulSetOverride and ingressServiceOverride
+* Add an override section to CRD spec which supports statefulSetOverride and clientServiceOverride
 * All existing CRD properties are kept and users can configure rabbitmq CRD through top level properties as before
 * When the same property is configured at the top level and the override level , override value wins
 
@@ -88,7 +88,7 @@ type RabbitmqClusterSpec struct {
 }
 
 type RabbitmqClusterOverrideSpec struct {
-	IngressService *corev1.Service     `json:"ingressService,omitempty"`
+	ClientService *corev1.Service     `json:"clientService,omitempty"`
 	StatefulSet    *appsv1.StatefulSet `json:"statefulSet,omitempty"`
 }
 ```
@@ -97,7 +97,7 @@ type RabbitmqClusterOverrideSpec struct {
 
 #### How do we apply overrides
 
-We should use [Strategic Merge Patch](https://github.com/kubernetes/apimachinery/tree/master/pkg/util/strategicpatch) from kubernetes. Specifically, the function [`StrategicMergePatch`](https://github.com/kubernetes/apimachinery/blob/030f3066cc768bdc3c23f2fc03de06d18bc8147d/pkg/util/strategicpatch/patch.go#L812) can be used to apply the user provided override on top of generated StatefulSet and ingress Service definitions. This kubernetes specific patch formats contains specialized directives to control how specific fields are merged. There are several properties that are lists where the controller currently set defaults for. When users provide overrides to configure a specific item in such list, our controller should merge values from the default generated definitions and values from overrides, rather than replacing the entire list. Strategic Merge Patch can do just that.
+We should use [Strategic Merge Patch](https://github.com/kubernetes/apimachinery/tree/master/pkg/util/strategicpatch) from kubernetes. Specifically, the function [`StrategicMergePatch`](https://github.com/kubernetes/apimachinery/blob/030f3066cc768bdc3c23f2fc03de06d18bc8147d/pkg/util/strategicpatch/patch.go#L812) can be used to apply the user provided override on top of generated StatefulSet and client Service definitions. This kubernetes specific patch formats contains specialized directives to control how specific fields are merged. There are several properties that are lists where the controller currently set defaults for. When users provide overrides to configure a specific item in such list, our controller should merge values from the default generated definitions and values from overrides, rather than replacing the entire list. Strategic Merge Patch can do just that.
 
 ```go
 
@@ -158,7 +158,7 @@ Here are all properties that are lists where the controller sets defaults:
 * spec.statefulSetTemplate.spec.template.spec.template.containers["rabbitmq"].ports (`patchMergeKey`: containerPort)
 * spec.statefulSetTemplate.spec.template.spec.template.containers["rabbitmq"].volumeMounts (`patchMergeKey`: mountPath)
 * spec.statefulSetTemplate.spec.template.initContainers (`patchMergeKey`: name)
-* spec.ingressServiceTemplate.spec.ports (`patchMergeKey`: ports)
+* spec.clientServiceTemplate.spec.ports (`patchMergeKey`: ports)
 
 Using [Strategic Merge Patch](https://github.com/kubernetes/apimachinery/tree/master/pkg/util/strategicpatch), we ensure that users have the flexibility to configure properties and that they do not need to specify properties that they don't modify.
 
@@ -166,9 +166,9 @@ _Side note_ Not all lists support this merging operation. For example, statefulS
 
 #### Override values take precedence
 
-Values we currently expose in CRD spec top level will be able to configure through StatefulSet and ingress Service override. When users provide values both in the top level properties and in override, values in override will win. For example, if both `spec.replicas` and `spec.replicas.override.statefulSet.spec.replicas` are provided, value provided in `spec.replicas.override.statefulSet.spec.replicas` will take precedence. On the other hand, if replicas value is not provided in statefulSet override, operator will use the provided `spec.replicas` value or the default value if `spec.replicas` is not set neither.
+Values we currently expose in CRD spec top level will be able to configure through StatefulSet and client Service override. When users provide values both in the top level properties and in override, values in override will win. For example, if both `spec.replicas` and `spec.replicas.override.statefulSet.spec.replicas` are provided, value provided in `spec.replicas.override.statefulSet.spec.replicas` will take precedence. On the other hand, if replicas value is not provided in statefulSet override, operator will use the provided `spec.replicas` value or the default value if `spec.replicas` is not set neither.
 
-This also applies for map values, like annotations. Right now, there are two places where people can specify ingress service annotations: `metadata.annotations`, which is for annotations applied to all child resources including ingress Service; `spec.service.annotations`, which is ingress Service only. Since `annotations` is a map value and not a list value, there is no "merging" behavior if ingress Service annotation is specified in the override. Whatever users provided in `spec.overide.ingressService.metadata.annotations` will be used for ingress Service.
+This also applies for map values, like annotations. Right now, there are two places where people can specify client service annotations: `metadata.annotations`, which is for annotations applied to all child resources including client Service; `spec.service.annotations`, which is client Service only. Since `annotations` is a map value and not a list value, there is no "merging" behavior if client Service annotation is specified in the override. Whatever users provided in `spec.overide.clientService.metadata.annotations` will be used for client Service.
 
 #### How should we handle reconciliation errors
 
@@ -177,7 +177,7 @@ By using kubernetes native types, we can get schema validations for free. Howeve
 Examples on reconcilation errors that happen during create and update:
  
 * Updates to StatefulSet spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden and will only return errors during update calls.
-* Set ingress Service ports protocol to values other than "TCP", "UDP", and "SCTP" will return an error on create or update.
+* Set client Service ports protocol to values other than "TCP", "UDP", and "SCTP" will return an error on create or update.
 
 We should revisit/prioritize [github issue #10](https://github.com/pivotal/rabbitmq-for-kubernetes/issues/10) which requests a new status.condition to surface reconciliation errors.
 
@@ -193,7 +193,7 @@ The proposal asks to use StatefulSet and Service k8s api objects directly in the
 
 ### Update
 
-Any update to the StatefulSet and ingress Service override will be reconciled by our controller. This means that certain updates will trigger reconciliation errors. In that case, reconciliation errors should be surfaced through status.conditions. Some updates on the pod template of the StatefulSet template will trigger a StatefulSet restart. My assumption here is that users who use these override knows what they are doing and triggering a StatefulSet restart won't be a concern for us.
+Any update to the StatefulSet and client Service override will be reconciled by our controller. This means that certain updates will trigger reconciliation errors. In that case, reconciliation errors should be surfaced through status.conditions. Some updates on the pod template of the StatefulSet template will trigger a StatefulSet restart. My assumption here is that users who use these override knows what they are doing and triggering a StatefulSet restart won't be a concern for us.
 
 ### Risks and Mitigation
 
@@ -215,7 +215,7 @@ Define our own StatefulSet and Service template to have better control over what
 
 A new structure for the CRD spec where it uses the StatefulSet and Service kubernetes templates directly in the spec. This has been explored from previous version of this KEP. It achieves the same level of flexibility and configurability as the this KEP's proposed solution.
 
-However, this alternative approach has the downside of increasing complexity. As users will need to understand  the internal resources behind the CRD to be able to configure common properties that we expose at top level today. For example, for users to configure rabbitmq image, instead of using `spec.image` at the top level, they will have to configure `spec.statefulSetTemplate.spec.template.spec.containers[0].image` with this alternative approach. In addition, if our controller fills in defaults for templates like what the controller currently does, CRD manifests will have the complete manifests of the statefulSet and ingress Service. CRD manifests will become harder to navigate and to modify for users after creation.
+However, this alternative approach has the downside of increasing complexity. As users will need to understand  the internal resources behind the CRD to be able to configure common properties that we expose at top level today. For example, for users to configure rabbitmq image, instead of using `spec.image` at the top level, they will have to configure `spec.statefulSetTemplate.spec.template.spec.containers[0].image` with this alternative approach. In addition, if our controller fills in defaults for templates like what the controller currently does, CRD manifests will have the complete manifests of the statefulSet and client Service. CRD manifests will become harder to navigate and to modify for users after creation.
 
 ## Upgrade Strategy
 

--- a/docs/proposals/20200408-tls-support-amqp.md
+++ b/docs/proposals/20200408-tls-support-amqp.md
@@ -64,8 +64,8 @@ As a RabbitMQ client (whether application or end user), I want to be sure that t
   - Mount the Secret as a volume on each RabbitMQ Pod
   - Set , `ssl_options.certfile`, `ssl_options.keyfile` in rabbitmq.conf to paths on the mount
   - Add `5671` to the Container Ports in the Pod Template
-  - Add `5671` to the port map in the Ingress Service
-- If we expose the Ingress Service template we can potentially depend on the user to specify the port
+  - Add `5671` to the port map in the Client Service
+- If we expose the Client Service template we can potentially depend on the user to specify the port
 - When deploying via KSM, a [Certificate Request](https://cert-manager.io/docs/concepts/certificaterequest/) is templated if the plan specified `tls: true`
 
 ### User Stories
@@ -94,7 +94,7 @@ And I can retrieve that message over the same port
 #### 'Turning on' TLS for a K8s deploy RabbitMQ cluster
 - (server-side) TLS for RabbitMQ protocols is enabled based on a set of settings in rabbitmq.conf. Two filepaths are the bare mimimum required configuration: `ssl_options.certfile`, `ssl_options.keyfile`, and `tls.ssl.default` (set to `5671`).
 - Our challenge is relating those settings to K8s resource configuration, and handling situations where they do not match.
-- With the proposed solution, when `tls.secretName` is set, we will set the relevant config in rabbitmq.conf, add the volume mount in the Pod Template, and add the Service Port in the Ingress Service. There are several potential or planned enhancements that create edge cases worth considering:
+- With the proposed solution, when `tls.secretName` is set, we will set the relevant config in rabbitmq.conf, add the volume mount in the Pod Template, and add the Service Port in the Client Service. There are several potential or planned enhancements that create edge cases worth considering:
   - Once we add the `additional_config` in the CR, the user could effectively disable TLS by setting their own values for `ssl_options`.
   - The user could also change `listeners.ssl.default` and the Service port would no longer be valid.
   - If we allow the Service to be templated the user could block the port neeeded for `listeners.ssl.default`

--- a/internal/resource/client_service.go
+++ b/internal/resource/client_service.go
@@ -11,28 +11,28 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (builder *RabbitmqResourceBuilder) IngressService() *IngressServiceBuilder {
-	return &IngressServiceBuilder{
+func (builder *RabbitmqResourceBuilder) ClientService() *ClientServiceBuilder {
+	return &ClientServiceBuilder{
 		Instance: builder.Instance,
 		Scheme:   builder.Scheme,
 	}
 }
 
-type IngressServiceBuilder struct {
+type ClientServiceBuilder struct {
 	Instance *rabbitmqv1beta1.RabbitmqCluster
 	Scheme   *runtime.Scheme
 }
 
-func (builder *IngressServiceBuilder) Build() (runtime.Object, error) {
+func (builder *ClientServiceBuilder) Build() (runtime.Object, error) {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      builder.Instance.ChildResourceName("ingress"),
+			Name:      builder.Instance.ChildResourceName("client"),
 			Namespace: builder.Instance.Namespace,
 		},
 	}, nil
 }
 
-func (builder *IngressServiceBuilder) Update(object runtime.Object) error {
+func (builder *ClientServiceBuilder) Update(object runtime.Object) error {
 	service := object.(*corev1.Service)
 	builder.setAnnotations(service)
 	service.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)
@@ -94,7 +94,7 @@ func updatePorts(servicePorts []corev1.ServicePort, tlsEnabled bool) []corev1.Se
 
 }
 
-func (builder *IngressServiceBuilder) setAnnotations(service *corev1.Service) {
+func (builder *ClientServiceBuilder) setAnnotations(service *corev1.Service) {
 	if builder.Instance.Spec.Service.Annotations != nil {
 		service.Annotations = metadata.ReconcileAnnotations(metadata.ReconcileAndFilterAnnotations(service.Annotations, builder.Instance.Annotations), builder.Instance.Spec.Service.Annotations)
 	} else {

--- a/internal/resource/rabbitmq_resource_builder.go
+++ b/internal/resource/rabbitmq_resource_builder.go
@@ -18,7 +18,7 @@ type ResourceBuilder interface {
 func (builder *RabbitmqResourceBuilder) ResourceBuilders() ([]ResourceBuilder, error) {
 	return []ResourceBuilder{
 		builder.HeadlessService(),
-		builder.IngressService(),
+		builder.ClientService(),
 		builder.ErlangCookie(),
 		builder.AdminSecret(),
 		builder.ServerConfigMap(),

--- a/internal/resource/rabbitmq_resource_builder_test.go
+++ b/internal/resource/rabbitmq_resource_builder_test.go
@@ -43,7 +43,7 @@ var _ = Describe("RabbitmqResourceBuilder", func() {
 			var ok bool
 			_, ok = resourceBuilders[0].(*resource.HeadlessServiceBuilder)
 			Expect(ok).Should(BeTrue())
-			_, ok = resourceBuilders[1].(*resource.IngressServiceBuilder)
+			_, ok = resourceBuilders[1].(*resource.ClientServiceBuilder)
 			Expect(ok).Should(BeTrue())
 			_, ok = resourceBuilders[2].(*resource.ErlangCookieBuilder)
 			Expect(ok).Should(BeTrue())

--- a/internal/status/cluster_available.go
+++ b/internal/status/cluster_available.go
@@ -41,7 +41,7 @@ func ClusterAvailableCondition(resources []runtime.Object,
 
 			condition.Status = corev1.ConditionFalse
 			condition.Reason = "NoEndpointsAvailable"
-			condition.Message = "The ingress service has no endpoints available"
+			condition.Message = "The client service has no endpoints available"
 		}
 	}
 

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	ingressServiceSuffix = "ingress"
-	statefulSetSuffix    = "server"
+	clientServiceSuffix = "client"
+	statefulSetSuffix   = "server"
 )
 
 var _ = Describe("Operator", func() {

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -397,7 +397,7 @@ func statefulSetPodName(cluster *rabbitmqv1beta1.RabbitmqCluster, index int) str
 }
 
 func rabbitmqHostname(clientSet *kubernetes.Clientset, cluster *rabbitmqv1beta1.RabbitmqCluster) string {
-	service, err := clientSet.CoreV1().Services(cluster.Namespace).Get(cluster.ChildResourceName(ingressServiceSuffix), metav1.GetOptions{})
+	service, err := clientSet.CoreV1().Services(cluster.Namespace).Get(cluster.ChildResourceName(clientServiceSuffix), metav1.GetOptions{})
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	ExpectWithOffset(1, len(service.Status.LoadBalancer.Ingress)).To(BeNumerically(">", 0))
 
@@ -517,7 +517,7 @@ func waitForLoadBalancer(clientSet *kubernetes.Clientset, cluster *rabbitmqv1bet
 	var err error
 
 	EventuallyWithOffset(1, func() string {
-		svc, err := clientSet.CoreV1().Services(cluster.Namespace).Get(cluster.ChildResourceName(ingressServiceSuffix), metav1.GetOptions{})
+		svc, err := clientSet.CoreV1().Services(cluster.Namespace).Get(cluster.ChildResourceName(clientServiceSuffix), metav1.GetOptions{})
 
 		if err != nil {
 			Expect(err).To(MatchError("not found"))
@@ -528,7 +528,7 @@ func waitForLoadBalancer(clientSet *kubernetes.Clientset, cluster *rabbitmqv1bet
 			return ""
 		}
 
-		endpoints, _ := clientSet.CoreV1().Endpoints(cluster.Namespace).Get(cluster.ChildResourceName(ingressServiceSuffix), metav1.GetOptions{})
+		endpoints, _ := clientSet.CoreV1().Endpoints(cluster.Namespace).Get(cluster.ChildResourceName(clientServiceSuffix), metav1.GetOptions{})
 
 		for _, e := range endpoints.Subsets {
 			if len(e.NotReadyAddresses) > 0 || int32(len(e.Addresses)) != *cluster.Spec.Replicas {


### PR DESCRIPTION
This closes #144

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Rename ingress service to client service

## Additional Context

I notice some refactor opportunities while doing the renaming. Plan to submit a separate PR to address the issue.

## Local Testing

Have run unit, integration, and system tests.