### PR TITLE
Remove 5 nodes system tests

### DIFF
--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -32,7 +32,7 @@ var _ = Describe("Operator", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("Publish and consume a message in a 3 nodes cluster", func() {
+	Context("Publish and consume a message in a single node cluster", func() {
 		var (
 			cluster  *rabbitmqv1beta1.RabbitmqCluster
 			hostname string
@@ -41,9 +41,9 @@ var _ = Describe("Operator", func() {
 		)
 
 		BeforeEach(func() {
-			three := int32(3)
+			one := int32(1)
 			cluster = generateRabbitmqCluster(namespace, "basic-rabbit")
-			cluster.Spec.Replicas = &three
+			cluster.Spec.Replicas = &one
 			cluster.Spec.Service.Type = "LoadBalancer"
 			cluster.Spec.Image = "dev.registry.pivotal.io/p-rabbitmq-for-kubernetes/rabbitmq:latest"
 			cluster.Spec.ImagePullSecret = "p-rmq-registry-access"
@@ -237,14 +237,14 @@ cluster_keepalive_interval = 10000`
 		})
 	})
 
-	Context("Clustering with 5 nodes", func() {
-		When("RabbitmqCluster is deployed with 5 nodes", func() {
+	Context("Clustering", func() {
+		When("RabbitmqCluster is deployed with 3 nodes", func() {
 			var cluster *rabbitmqv1beta1.RabbitmqCluster
 
 			BeforeEach(func() {
-				five := int32(5)
+				three := int32(3)
 				cluster = generateRabbitmqCluster(namespace, "ha-rabbit")
-				cluster.Spec.Replicas = &five
+				cluster.Spec.Replicas = &three
 				cluster.Spec.Service.Type = "LoadBalancer"
 				cluster.Spec.Resources = &corev1.ResourceRequirements{
 					Requests: map[corev1.ResourceName]k8sresource.Quantity{},


### PR DESCRIPTION
This is related to PR: https://github.com/pivotal/rabbitmq-for-kubernetes/pull/151

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Have the basic test context "Publish and consume a message" deploy a single node instead of a HA cluster
- Deploy a 3 node HA cluster for Clustering test context instead of 5 nodes

## Additional Context

Our operator does not need to test clustering with
5 nodes and 3 nodes differently; having one clustering test that can deploy a HA cluster
is enough

## Local Testing

n/a
