### PR TITLE
Update Operator Chart metadata

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -8,17 +8,17 @@
 #
 
 name: rabbitmq-operator
-version: 0.3
+version: 0.4
 appVersion: 0.7.0-build.41
-description: Pivotal RabbitMQ for Kubernetes
+description: RabbitMQ Cluster Operator
 keywords:
 - rabbitmq
 - operator
 - message queue
 - AMQP
-home: https://pivotal.io/rabbitmq
+home: https://tanzu.vmware.com/rabbitmq
 icon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
 maintainers:
-- name: Pivotal
-  email: rabbitmq-for-k8s@pivotal.com
+- name: VMware
+  email: rabbitmq-for-k8s@groups.vmware.com
 engine: gotpl


### PR DESCRIPTION
No issue associated to this PR

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
- Bump Chart version to 0.4
- Update links in chart metada to Tanzu site

## Additional Context
This was required in order to push a new version to PivNet registry, which only had published version 0.3, which did not had the improvements in #130.