### PR TITLE
Declare Go 1.13 in module file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pivotal/rabbitmq-for-kubernetes
 
-go 1.12
+go 1.13
 
 require (
 	cloud.google.com/go v0.47.0 // indirect


### PR DESCRIPTION
This closes #137 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
We actively develop and build using Go 1.13. Our mod file should reflect this information.

## Local Testing

Run `make docker-build`.