### PR TITLE
Set default rabbit version to 3.8.5

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	rabbitmqImage             string             = "rabbitmq:3.8.3"
+	rabbitmqImage             string             = "rabbitmq:3.8.5"
 	defaultPersistentCapacity string             = "10Gi"
 	defaultMemoryLimit        string             = "2Gi"
 	defaultCPULimit           string             = "2000m"

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -365,7 +365,7 @@ func generateRabbitmqClusterObject(clusterName string) *RabbitmqCluster {
 		},
 		Spec: RabbitmqClusterSpec{
 			Replicas: &one,
-			Image:    "rabbitmq:3.8.3",
+			Image:    "rabbitmq:3.8.5",
 			Service: RabbitmqClusterServiceSpec{
 				Type: "ClusterIP",
 			},

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -9,7 +9,7 @@
 
 name: rabbitmq
 version: 0.1
-appVersion: 3.8.3
+appVersion: 3.8.5
 description: Pivotal RabbitMQ for Kubernetes
 keywords:
 - rabbitmq


### PR DESCRIPTION
This closes #167

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

CI changes is required as well.

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
