### PR TITLE
Use default location for mnesia database

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -239,7 +239,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 		},
 		{
 			Name:      "persistence",
-			MountPath: "/var/lib/rabbitmq/db/",
+			MountPath: "/var/lib/rabbitmq/mnesia/",
 		},
 		{
 			Name:      "rabbitmq-etc",

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -403,10 +403,6 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 							Value: "/opt/rabbitmq-secret/username",
 						},
 						{
-							Name:  "RABBITMQ_MNESIA_BASE",
-							Value: "/var/lib/rabbitmq/db",
-						},
-						{
 							Name: "MY_POD_NAME",
 							ValueFrom: &corev1.EnvVarSource{
 								FieldRef: &corev1.ObjectFieldSelector{

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -649,7 +649,7 @@ var _ = Describe("StatefulSet", func() {
 				},
 				corev1.VolumeMount{
 					Name:      "persistence",
-					MountPath: "/var/lib/rabbitmq/db/",
+					MountPath: "/var/lib/rabbitmq/mnesia/",
 				},
 				corev1.VolumeMount{
 					Name:      "rabbitmq-etc",

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -86,7 +86,7 @@ var _ = Describe("StatefulSet", func() {
 			Expect(*statefulSet.Spec.VolumeClaimTemplates[0].Spec.StorageClassName).To(Equal("my-storage-class"))
 		})
 
-		It("creates the PersistentVolume template according to configurations in the  instance", func() {
+		It("creates the PersistentVolume template according to configurations in the instance", func() {
 			storage := k8sresource.MustParse("21Gi")
 			instance.Spec.Persistence.Storage = &storage
 			cluster = &resource.RabbitmqResourceBuilder{
@@ -596,10 +596,6 @@ var _ = Describe("StatefulSet", func() {
 				{
 					Name:  "RABBITMQ_DEFAULT_USER_FILE",
 					Value: "/opt/rabbitmq-secret/username",
-				},
-				{
-					Name:  "RABBITMQ_MNESIA_BASE",
-					Value: "/var/lib/rabbitmq/db",
 				},
 				{
 					Name: "MY_POD_NAME",


### PR DESCRIPTION
This closes #183 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

* Removed the environment variable which specified a non-default location for the mnesia database mount point
* The mount point for the mnesia persistent volume is now `/var/lib/rabbitmq/mnesia`

## Additional Context

We investigated using projection keys to mount both the mnesia database & the erlang cookie, but unfortunately PersistentVolumes are not supported in ProjectionVolumeSources.

## Local Testing

Ran unit, integration & system tests.