### PR TITLE
Remove deprecated `bases` from kustomization files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,21 +40,21 @@ manager: generate fmt vet
 	go build -o bin/manager main.go
 
 deploy-manager:  ## Deploy manager
-	kubectl apply -k config/crd
-	kubectl apply -k config/default/base
+	kustomize build config/crd | kubectl apply -f -
+	kustomize build config/default/base | kubectl apply -f -
 
 deploy-manager-dev:
-	kubectl apply -k config/crd
-	kubectl apply -k config/default/overlays/dev
+	kustomize build config/crd | kubectl apply -f -
+	kustomize build config/default/overlays/dev | kubectl apply -f -
 
 deploy-sample: ## Deploy RabbitmqCluster defined in config/sample/base
-	kubectl apply -k config/samples/base
+	kustomize build config/samples/base | kubectl apply -f -
 
 destroy: ## Cleanup all controller artefacts
-	kubectl delete -k config/crd/ --ignore-not-found=true
-	kubectl delete -k config/default/base/ --ignore-not-found=true
-	kubectl delete -k config/rbac/ --ignore-not-found=true
-	kubectl delete -k config/namespace/base/ --ignore-not-found=true
+	kustomize build config/crd/ | kubectl delete --ignore-not-found=true -f -
+	kustomize build config/default/base/ | kubectl delete --ignore-not-found=true -f -
+	kustomize build config/rbac/ | kubectl delete --ignore-not-found=true -f -
+	kustomize build config/namespace/base/ | kubectl delete --ignore-not-found=true -f -
 
 run: generate manifests fmt vet install deploy-namespace-rbac just-run ## Run operator binary locally against the configured Kubernetes cluster in ~/.kube/config
 
@@ -71,11 +71,11 @@ install: manifests
 	kubectl apply -f config/crd/bases
 
 deploy-namespace-rbac:
-	kubectl apply -k config/namespace/base
-	kubectl apply -k config/rbac
+	kustomize build config/namespace/base | kubectl apply -f -
+	kustomize build config/rbac | kubectl apply -f -
 
 deploy-master: install deploy-namespace-rbac docker-registry-secret
-	kubectl apply -k config/default/base
+	kustomize build config/default/base | kubectl apply -f -
 
 deploy: manifests deploy-namespace-rbac docker-registry-secret deploy-manager ## Deploy operator in the configured Kubernetes cluster in ~/.kube/config
 
@@ -84,8 +84,8 @@ deploy-dev: docker-build-dev patch-dev manifests deploy-namespace-rbac docker-re
 deploy-kind: git-commit-sha patch-kind manifests deploy-namespace-rbac ## Load operator image and deploy operator into current KinD cluster
 	docker build --build-arg=GIT_COMMIT=$(GIT_COMMIT) -t $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT) .
 	kind load docker-image $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT)
-	kubectl apply -k config/crd
-	kubectl apply -k config/default/overlays/kind
+	kustomize build config/crd | kubectl apply -f -
+	kustomize build config/default/overlays/kind | kubectl apply -f -
 
 generate-installation-manifests:
 	mkdir -p installation

--- a/config/default/base/kustomization.yaml
+++ b/config/default/base/kustomization.yaml
@@ -8,7 +8,7 @@
 
 namespace: rabbitmq-system
 namePrefix: rabbitmq-cluster-
-bases:
+resources:
 # - ../../rbac
 - ../../manager
 # [WEBHOOK] Uncomment all the sections with [WEBHOOK] prefix to enable webhook.

--- a/config/default/overlays/dev/kustomization.yaml
+++ b/config/default/overlays/dev/kustomization.yaml
@@ -7,7 +7,7 @@
 # This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
 namespace: rabbitmq-system
 
-bases:
+resources:
 - ../../base
 
 patches:

--- a/config/default/overlays/helm/kustomization.yaml
+++ b/config/default/overlays/helm/kustomization.yaml
@@ -7,11 +7,9 @@
 # This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
 namespace: rabbitmq-system
 
-bases:
-- ../../base
-
 resources:
 - image_pull_secret.yml
+- ../../base
 
 patches:
 - image_as_helm_template.yml

--- a/config/default/overlays/kind/kustomization.yaml
+++ b/config/default/overlays/kind/kustomization.yaml
@@ -7,7 +7,7 @@
 # This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
 namespace: rabbitmq-system
 
-bases:
+resources:
 - ../../base
 
 patches:

--- a/config/installation/kustomization.yaml
+++ b/config/installation/kustomization.yaml
@@ -7,7 +7,7 @@
 # This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
 #
 
-bases:
+resources:
 - ../default/base
 
 namespace: rabbitmq-system

--- a/config/installation/overlay/ci/kustomization.yaml
+++ b/config/installation/overlay/ci/kustomization.yaml
@@ -5,7 +5,7 @@
 # This product is licensed to you under the Mozilla Public license, Version 2.0 (the "License").  You may not use this product except in compliance with the Mozilla Public License.
 #
 # This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
-bases:
+resources:
 - ../../../default/base
 
 namespace: rabbitmq-system

--- a/config/samples/overlays/ci/kustomization.yaml
+++ b/config/samples/overlays/ci/kustomization.yaml
@@ -7,5 +7,5 @@
 #
 # This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
 namespace: rabbitmq-system-ci
-bases:
+resources:
 - ../../base


### PR DESCRIPTION
## Summary Of Changes

`bases` is a deprecated section of the kustomize API, and is replaced by
`resources` in v2.1.0 onwards. Since we use kustomize 3.X, this moves
our kustomization yamls to the new accepted format.

This also moves our Makefile away from using `kubectl <apply/delete>
-k`, which uses kubectl's older, bundled version of Kustomize v2.0.3
(see [this issue](https://github.com/kubernetes/kubectl/issues/818)).

This closes #67 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Additional Context

## Local Testing

Ran unit & integration tests. Also successfully deployed to kind using any make targets that I changed.