### PR TITLE
Add example for statefulSetOverride

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The RabbitMQ for Kubernetes Operator is a way of managing [RabbitMQ](https://www
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.8.5`, and requires a Kubernetes cluster of `1.16` or above.
+The operator deploys RabbitMQ `3.8.5`, and requires a Kubernetes cluster of `1.16` or `1.17`.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The RabbitMQ for Kubernetes Operator is a way of managing [RabbitMQ](https://www
 ## Supported Versions
 
 The operator deploys RabbitMQ `3.8.5`, and requires a Kubernetes cluster of `1.16` or `1.17`.
+`RabbitmqCluster` CRD cannot be installed in a kuberentes `1.18` cluster because of a schema validation that ensures that properties defined as `list-map-keys` must either be required or have a default value ([related github issue](https://github.com/kubernetes/kubernetes/issues/91395)).
 
 ## Quickstart
 

--- a/docs/examples/additionalVolumes/README.md
+++ b/docs/examples/additionalVolumes/README.md
@@ -1,0 +1,10 @@
+# Additional PersistentVolumeClaim Example
+
+You can leverage StatefulSet override (`spec.Override.StatefulSet`) to modify any property of the statefulSet deployed as part of a RabbitmqCluster instance. `spec.Override.StatefulSet` is in the format of appsv1.StatefulSetSpec. When provided, it will be applied as a patch to the RabbitmqCluster instance StatefulSet definition, using kubernetes [Strategic Merge Patch](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md).
+
+The example creates two PersistentVolumeClaim and mounts the additional PersistentVolumeClaim to the `rabbitmq` container.
+
+
+```shell
+kubectl apply -f rabbitmq.yaml
+```

--- a/docs/examples/additionalVolumes/rabbitmq.yaml
+++ b/docs/examples/additionalVolumes/rabbitmq.yaml
@@ -1,0 +1,45 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: sample
+spec:
+  replicas: 1
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+              - name: rabbitmq
+                volumeMounts:
+                  - name: additional-disk
+                    mountPath: /var/lib/log
+        volumeClaimTemplates:
+          - apiVersion: v1
+            kind: PersistentVolumeClaim
+            metadata:
+              name: persistence
+              namespace: rabbitmq-system
+             labels:
+                "app.kubernetes.io/name": "sample"
+            spec:
+              storageClassName: standard
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 3Gi
+          - apiVersion: v1
+            kind: PersistentVolumeClaim
+            metadata:
+              name: persistence-foo
+              namespace: rabbitmq-system
+              labels:
+                "app.kubernetes.io/name": "sample"
+            spec:
+              storageClassName: standard
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi

--- a/docs/proposals/20200310-crd-spec-configurability.md
+++ b/docs/proposals/20200310-crd-spec-configurability.md
@@ -2,17 +2,16 @@
 title: CRD Spec Refactor
 authors:
   - "@ChunyiLyu"
-reviewers:
-  -
 creation-date: 2020-03-10
-last-updated: 2020-05-12
-status: provisional
-see-also:
-replaces:
-superseded-by:
+last-updated: 2020-07-10
+status: implemented
 ---
 
 # CRD Spec Refactor
+
+## Status
+
+This KEP has already been implemented. For updated implementation details, refer to [PR #175](https://github.com/rabbitmq/cluster-operator/pull/175).
 
 ## Table of Contents
 
@@ -40,7 +39,7 @@ superseded-by:
 
 ## Summary
 
-Our current CRD spec has a limited number of exposed properties for users to configure which restricts supported use cases. This KEP proposes to add an override section as an additional way for users to configure their cluster. Users will be able to configure any field of the StatefulSet and client Service through editing the spec directly through this change.
+Our current CRD spec has a limited number of exposed properties for users to configure which restricts supported use cases. This KEP proposes to add an override section as an additional way for users to configure their cluster. Users will be able to configure any field of the StatefulSet and client Service through editing the spec directly through this change
 
 ## Motivation
 

--- a/docs/proposals/implemented/20200310-crd-spec-configurability.md
+++ b/docs/proposals/implemented/20200310-crd-spec-configurability.md
@@ -11,7 +11,7 @@ status: implemented
 
 ## Status
 
-This KEP has already been implemented. For updated implementation details, refer to [PR #175](https://github.com/rabbitmq/cluster-operator/pull/175).
+This KEP has already been implemented. Different from what's outlined in this KEP, we had to define some custome types instead of using `appsv1.StatefulSet` directly. For updated implementation details, refer to [PR #175](https://github.com/rabbitmq/cluster-operator/pull/175).
 
 ## Table of Contents
 
@@ -39,7 +39,7 @@ This KEP has already been implemented. For updated implementation details, refer
 
 ## Summary
 
-Our current CRD spec has a limited number of exposed properties for users to configure which restricts supported use cases. This KEP proposes to add an override section as an additional way for users to configure their cluster. Users will be able to configure any field of the StatefulSet and client Service through editing the spec directly through this change
+Our current CRD spec has a limited number of exposed properties for users to configure which restricts supported use cases. This KEP proposes to add an override section as an additional way for users to configure their cluster. Users will be able to configure any field of the StatefulSet and client Service through editing the spec directly through this change.
 
 ## Motivation
 


### PR DESCRIPTION
- related to issue #143 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- README updates about required kubernetes version
- example manifest on deploying with two PVCs using sts override

## Additional Context

Should be merged after https://github.com/rabbitmq/cluster-operator/pull/175
