### PR TITLE
Consolidates operator naming in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ just a few small guidelines you need to follow.
 
 ## GitHub issues
 
-RabbitMQ for Kubernetes team uses GitHub issues for feature development and bug tracking.
+RabbitMQ Cluster Kubernetes Operator team uses GitHub issues for feature development and bug tracking.
 The issues have specific information as to what the feature should do and what problem or
 use case is trying to resolve. Bug reports have a description of the actual behaviour and
 the expected behaviour, along with repro steps when possible. It is important to provide

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# RabbitMQ for Kubernetes Operator
+# RabbitMQ Cluster Kubernetes Operator
 
-The RabbitMQ for Kubernetes Operator is a way of managing [RabbitMQ](https://www.rabbitmq.com/) clusters deployed to [Kubernetes](https://kubernetes.io/). RabbitMQ for Kubernetes has been built using the [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) implementation of the [operator pattern](https://coreos.com/blog/introducing-operators.html). This repository contains a [custom controller](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#custom-controllers) and [custom resource definition (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) designed for the lifecyle (creation, upgrade, graceful shutdown) of a RabbitMQ cluster.
+Manage [RabbitMQ](https://www.rabbitmq.com/) clusters deployed to [Kubernetes](https://kubernetes.io/). The RabbitMQ Cluster Kubernetes Operator has been built using the [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) implementation of the [operator pattern](https://coreos.com/blog/introducing-operators.html). This repository contains a [custom controller](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#custom-controllers) and [custom resource definition (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) designed for the lifecyle (creation, upgrade, graceful shutdown) of a RabbitMQ cluster.
 
 **Note**: this repository is under active development and is provided as **beta** software. Official support for this software is not provided; if you encounter any issues running this software, please feel free to [contribute to the project](#contributing).
 
@@ -24,7 +24,7 @@ The easiest way to set up a local development environment for running the Rabbit
 
 ### Documentation
 
-The RabbitMQ for Kubernetes [documentation](https://docs.pivotal.io/rabbitmq-kubernetes/0-7/index.html) has steps to deploy to a Kubernetes cluster:
+RabbitMQ Cluster Kubernetes Operator [documentation](https://docs.pivotal.io/rabbitmq-kubernetes/0-7/index.html) has steps to deploy to a Kubernetes cluster:
 - [Deploying an operator](https://docs.pivotal.io/rabbitmq-kubernetes/0-7/installing.html)
 - [Deploying a RabbitMQ cluster](https://docs.pivotal.io/rabbitmq-kubernetes/0-7/using.html)
 - [Monitoring the cluster](https://docs.pivotal.io/rabbitmq-kubernetes/0-7/monitoring.html)

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -12,7 +12,7 @@ description: RabbitMQ Cluster
 apiVersion: v2
 version: 0.8.0
 appVersion: 3.8.5
-description: Pivotal RabbitMQ for Kubernetes
+description: RabbitMQ Cluster Kubernetes Operator
 keywords:
 - rabbitmq
 - message queue


### PR DESCRIPTION
- also update helm chart description

This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
