### PR TITLE
Fixes unit tests to reflect mnesia base change

### DIFF
--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1254,10 +1254,6 @@ var _ = Describe("StatefulSet", func() {
 							Value: "/opt/rabbitmq-secret/username",
 						},
 						corev1.EnvVar{
-							Name:  "RABBITMQ_MNESIA_BASE",
-							Value: "/var/lib/rabbitmq/db",
-						},
-						corev1.EnvVar{
 							Name: "MY_POD_NAME",
 							ValueFrom: &corev1.EnvVarSource{
 								FieldRef: &corev1.ObjectFieldSelector{
@@ -1306,7 +1302,7 @@ var _ = Describe("StatefulSet", func() {
 						},
 						corev1.VolumeMount{
 							Name:      "persistence",
-							MountPath: "/var/lib/rabbitmq/db/",
+							MountPath: "/var/lib/rabbitmq/mnesia/",
 						},
 						corev1.VolumeMount{
 							Name:      "rabbitmq-etc",


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
