### PR TITLE
Small refactorings for internal/resource

### DIFF
--- a/internal/resource/admin_secret_test.go
+++ b/internal/resource/admin_secret_test.go
@@ -26,7 +26,7 @@ var _ = Describe("AdminSecret", func() {
 	var (
 		secret             *corev1.Secret
 		instance           rabbitmqv1beta1.RabbitmqCluster
-		rabbitmqCluster    *resource.RabbitmqResourceBuilder
+		builder            *resource.RabbitmqResourceBuilder
 		adminSecretBuilder *resource.AdminSecretBuilder
 	)
 
@@ -37,10 +37,10 @@ var _ = Describe("AdminSecret", func() {
 				Namespace: "a namespace",
 			},
 		}
-		rabbitmqCluster = &resource.RabbitmqResourceBuilder{
+		builder = &resource.RabbitmqResourceBuilder{
 			Instance: &instance,
 		}
-		adminSecretBuilder = rabbitmqCluster.AdminSecret()
+		adminSecretBuilder = builder.AdminSecret()
 	})
 
 	Context("Build with defaults", func() {

--- a/internal/resource/client_service_test.go
+++ b/internal/resource/client_service_test.go
@@ -23,9 +23,9 @@ import (
 
 var _ = Context("ClientServices", func() {
 	var (
-		instance   rabbitmqv1beta1.RabbitmqCluster
-		rmqBuilder resource.RabbitmqResourceBuilder
-		scheme     *runtime.Scheme
+		instance rabbitmqv1beta1.RabbitmqCluster
+		builder  resource.RabbitmqResourceBuilder
+		scheme   *runtime.Scheme
 	)
 
 	Context("Build", func() {
@@ -34,14 +34,14 @@ var _ = Context("ClientServices", func() {
 			Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
 			Expect(defaultscheme.AddToScheme(scheme)).To(Succeed())
 			instance = generateRabbitmqCluster()
-			rmqBuilder = resource.RabbitmqResourceBuilder{
+			builder = resource.RabbitmqResourceBuilder{
 				Instance: &instance,
 				Scheme:   scheme,
 			}
 		})
 
 		It("Builds using the values from the CR", func() {
-			serviceBuilder := rmqBuilder.ClientService()
+			serviceBuilder := builder.ClientService()
 			obj, err := serviceBuilder.Build()
 			Expect(err).NotTo(HaveOccurred())
 			service := obj.(*corev1.Service)
@@ -63,7 +63,7 @@ var _ = Context("ClientServices", func() {
 			Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
 			Expect(defaultscheme.AddToScheme(scheme)).To(Succeed())
 			instance = generateRabbitmqCluster()
-			rmqBuilder = resource.RabbitmqResourceBuilder{
+			builder = resource.RabbitmqResourceBuilder{
 				Instance: &instance,
 				Scheme:   scheme,
 			}
@@ -82,8 +82,8 @@ var _ = Context("ClientServices", func() {
 						},
 					},
 				}
-				rmqBuilder.Instance = instance
-				serviceBuilder := rmqBuilder.ClientService()
+				builder.Instance = instance
+				serviceBuilder := builder.ClientService()
 				svc := &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo-service",
@@ -119,7 +119,7 @@ var _ = Context("ClientServices", func() {
 						"k8s.io/other":                     "i-like-this",
 					}
 
-					service := updateServiceWithAnnotations(rmqBuilder, nil, serviceAnno)
+					service := updateServiceWithAnnotations(builder, nil, serviceAnno)
 					Expect(service.ObjectMeta.Annotations).To(Equal(expectedAnnotations))
 				})
 			})
@@ -134,7 +134,7 @@ var _ = Context("ClientServices", func() {
 
 					var serviceAnnotations map[string]string = nil
 					var instanceAnnotations map[string]string = nil
-					service := updateServiceWithAnnotations(rmqBuilder, instanceAnnotations, serviceAnnotations)
+					service := updateServiceWithAnnotations(builder, instanceAnnotations, serviceAnnotations)
 					Expect(service.ObjectMeta.Annotations).To(Equal(expectedAnnotations))
 				})
 			})
@@ -149,7 +149,7 @@ var _ = Context("ClientServices", func() {
 					}
 
 					var serviceAnnotations map[string]string = nil
-					service := updateServiceWithAnnotations(rmqBuilder, instanceMetadataAnnotations, serviceAnnotations)
+					service := updateServiceWithAnnotations(builder, instanceMetadataAnnotations, serviceAnnotations)
 					expectedAnnotations := map[string]string{
 						"my-annotation":                    "i-like-this",
 						"app.kubernetes.io/part-of":        "rabbitmq",
@@ -190,7 +190,7 @@ var _ = Context("ClientServices", func() {
 						"this-was-the-previous-annotation": "should-be-preserved",
 					}
 
-					service := updateServiceWithAnnotations(rmqBuilder, instanceAnnotations, serviceAnnotations)
+					service := updateServiceWithAnnotations(builder, instanceAnnotations, serviceAnnotations)
 
 					Expect(service.ObjectMeta.Annotations).To(Equal(expectedAnnotations))
 				})
@@ -203,7 +203,7 @@ var _ = Context("ClientServices", func() {
 				svc            *corev1.Service
 			)
 			BeforeEach(func() {
-				serviceBuilder = rmqBuilder.ClientService()
+				serviceBuilder = builder.ClientService()
 				instance = rabbitmqv1beta1.RabbitmqCluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rabbit-labelled",
@@ -252,7 +252,7 @@ var _ = Context("ClientServices", func() {
 			)
 
 			BeforeEach(func() {
-				serviceBuilder = rmqBuilder.ClientService()
+				serviceBuilder = builder.ClientService()
 				instance = generateRabbitmqCluster()
 
 				svc = &corev1.Service{

--- a/internal/resource/erlang_cookie_test.go
+++ b/internal/resource/erlang_cookie_test.go
@@ -26,7 +26,7 @@ var _ = Describe("ErlangCookie", func() {
 	var (
 		secret              *corev1.Secret
 		instance            rabbitmqv1beta1.RabbitmqCluster
-		rabbitmqCluster     *resource.RabbitmqResourceBuilder
+		builder             *resource.RabbitmqResourceBuilder
 		erlangCookieBuilder *resource.ErlangCookieBuilder
 	)
 
@@ -37,10 +37,10 @@ var _ = Describe("ErlangCookie", func() {
 				Namespace: "a namespace",
 			},
 		}
-		rabbitmqCluster = &resource.RabbitmqResourceBuilder{
+		builder = &resource.RabbitmqResourceBuilder{
 			Instance: &instance,
 		}
-		erlangCookieBuilder = rabbitmqCluster.ErlangCookie()
+		erlangCookieBuilder = builder.ErlangCookie()
 	})
 
 	Context("Build with defaults", func() {

--- a/internal/resource/headless_service_test.go
+++ b/internal/resource/headless_service_test.go
@@ -21,7 +21,7 @@ import (
 var _ = Describe("HeadlessService", func() {
 	var (
 		instance       rabbitmqv1beta1.RabbitmqCluster
-		cluster        *resource.RabbitmqResourceBuilder
+		builder        *resource.RabbitmqResourceBuilder
 		serviceBuilder *resource.HeadlessServiceBuilder
 		service        *corev1.Service
 	)
@@ -30,10 +30,10 @@ var _ = Describe("HeadlessService", func() {
 		instance = rabbitmqv1beta1.RabbitmqCluster{}
 		instance.Namespace = "foo"
 		instance.Name = "foo"
-		cluster = &resource.RabbitmqResourceBuilder{
+		builder = &resource.RabbitmqResourceBuilder{
 			Instance: &instance,
 		}
-		serviceBuilder = cluster.HeadlessService()
+		serviceBuilder = builder.HeadlessService()
 	})
 
 	Context("Build", func() {

--- a/internal/resource/rabbitmq_resource_builder_test.go
+++ b/internal/resource/rabbitmq_resource_builder_test.go
@@ -29,22 +29,22 @@ var _ = Describe("RabbitmqResourceBuilder", func() {
 				},
 			}
 
-			rabbitmqCluster *resource.RabbitmqResourceBuilder
-			scheme          *runtime.Scheme
+			builder *resource.RabbitmqResourceBuilder
+			scheme  *runtime.Scheme
 		)
 
 		BeforeEach(func() {
 			scheme = runtime.NewScheme()
 			Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
 			Expect(defaultscheme.AddToScheme(scheme)).To(Succeed())
-			rabbitmqCluster = &resource.RabbitmqResourceBuilder{
+			builder = &resource.RabbitmqResourceBuilder{
 				Instance: &instance,
 				Scheme:   scheme,
 			}
 		})
 
 		It("returns the required resource builders in the expected order", func() {
-			resourceBuilders, err := rabbitmqCluster.ResourceBuilders()
+			resourceBuilders, err := builder.ResourceBuilders()
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(len(resourceBuilders)).To(Equal(9))


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Remove some unnecessary test setup in sts unit tests (per comments from PR: https://github.com/rabbitmq/cluster-operator/pull/175)
- Standardize on variable names for all resource.RabbitmqResourceBuilder types in internal/resource tests; it was called `cluster`, `builder`, or `rmqBuilder` and it was confusing to read. I picked `builder` in the end.

## Local Testing

Have run unit and integration tests.
