### PR TITLE
Set RabbitMQ cluster name to CR name

### DIFF
--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -61,10 +61,12 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 	configMap := object.(*corev1.ConfigMap)
 	configMap.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)
 	configMap.Annotations = metadata.ReconcileAndFilterAnnotations(configMap.GetAnnotations(), builder.Instance.Annotations)
+
 	if configMap.Data == nil {
 		configMap.Data = make(map[string]string)
 	}
-	configMap.Data["rabbitmq.conf"] = defaultRabbitmqConf
+
+	configMap.Data["rabbitmq.conf"] = defaultRabbitmqConf + fmt.Sprintln("cluster_name = "+builder.Instance.Name)
 	if builder.Instance.TLSEnabled() {
 		configMap.Data["rabbitmq.conf"] = configMap.Data["rabbitmq.conf"] + defaultTLSConf
 	}


### PR DESCRIPTION
This closes #185 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
The `cluster_name` property will be set with value matching the CR name. Before this change, the cluster name was the name of the first node who formed the cluster, which resulted in very long names.

## Local Testing

Unit and integration tests 🟢

```
$ make unit-tests integration-tests
```

Deployed the Operator with this changes, created a 3-node cluster and verified in Management UI that cluster name matches the CR name.