### PR TITLE
Several fixes to statefulSet Override

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -563,20 +563,33 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 	}
 }
 
-func copyObjectMeta(dst *metav1.ObjectMeta, src rabbitmqv1beta1.EmbeddedObjectMeta) {
-	if src.Name != "" {
-		dst.Name = src.Name
+func copyObjectMeta(base *metav1.ObjectMeta, override rabbitmqv1beta1.EmbeddedObjectMeta) {
+	if override.Name != "" {
+		base.Name = override.Name
 	}
 
-	if src.Namespace != "" {
-		dst.Namespace = src.Namespace
+	if override.Namespace != "" {
+		base.Namespace = override.Namespace
 	}
 
-	if src.Labels != nil {
-		dst.Labels = src.Labels
+	if override.Labels != nil {
+		base.Labels = mergeMap(base.Labels, override.Labels)
 	}
 
-	if src.Annotations != nil {
-		dst.Annotations = src.Annotations
+	if override.Annotations != nil {
+		base.Annotations = mergeMap(base.Annotations, override.Annotations)
 	}
+}
+
+func mergeMap(base, override map[string]string) map[string]string {
+	result := base
+	if result == nil {
+		result = make(map[string]string)
+	}
+
+	for k, v := range override {
+		result[k] = v
+	}
+
+	return result
 }

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -150,14 +150,14 @@ func (builder *StatefulSetBuilder) Update(object runtime.Object) error {
 		logger.Info(fmt.Sprintf("Warning: Memory request and limit are not equal for \"%s\". It is recommended that they be set to the same value", sts.GetName()))
 	}
 
-	if err := controllerutil.SetControllerReference(builder.Instance, sts, builder.Scheme); err != nil {
-		return fmt.Errorf("failed setting controller reference: %v", err)
-	}
-
 	if builder.Instance.Spec.Override.StatefulSet != nil {
 		if err := builder.applyStsOverride(sts, builder.Instance.Spec.Override.StatefulSet); err != nil {
 			return fmt.Errorf("failed applying StatefulSet override: %v", err)
 		}
+	}
+
+	if err := controllerutil.SetControllerReference(builder.Instance, sts, builder.Scheme); err != nil {
+		return fmt.Errorf("failed setting controller reference: %v", err)
 	}
 	return nil
 }

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1048,26 +1048,6 @@ var _ = Describe("StatefulSet", func() {
 				Expect(statefulSet.ObjectMeta.Annotations).To(Equal(map[string]string{"my-key": "my-value"}))
 			})
 
-			It("overrides statefulSet.ObjectMeta.Namespace", func() {
-				instance.Annotations = map[string]string{"my-key": "my-value"}
-				instance.Spec.Override.StatefulSet = &rabbitmqv1beta1.StatefulSet{
-					EmbeddedObjectMeta: &rabbitmqv1beta1.EmbeddedObjectMeta{
-						Namespace: "my-ns",
-					},
-				}
-				stsBuilder := builder.StatefulSet()
-				Expect(stsBuilder.Update(statefulSet)).To(Succeed())
-				Expect(statefulSet.ObjectMeta.Name).To(Equal(instance.Name))
-				Expect(statefulSet.ObjectMeta.Namespace).To(Equal("my-ns"))
-				Expect(statefulSet.ObjectMeta.Labels).To(Equal(map[string]string{
-					"app.kubernetes.io/name":      instance.Name,
-					"app.kubernetes.io/component": "rabbitmq",
-					"app.kubernetes.io/part-of":   "rabbitmq",
-				}))
-
-				Expect(statefulSet.ObjectMeta.Annotations).To(Equal(map[string]string{"my-key": "my-value"}))
-			})
-
 			It("overrides statefulSet.ObjectMeta.Annotations", func() {
 				instance.Annotations = map[string]string{"replace-me-key": "replace-me-value"}
 				instance.Spec.Override.StatefulSet = &rabbitmqv1beta1.StatefulSet{

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1049,11 +1049,15 @@ var _ = Describe("StatefulSet", func() {
 			})
 
 			It("overrides statefulSet.ObjectMeta.Annotations", func() {
-				instance.Annotations = map[string]string{"replace-me-key": "replace-me-value"}
+				instance.Annotations = map[string]string{
+					"key1":    "value1",
+					"keep-me": "keep-me",
+				}
 				instance.Spec.Override.StatefulSet = &rabbitmqv1beta1.StatefulSet{
 					EmbeddedObjectMeta: &rabbitmqv1beta1.EmbeddedObjectMeta{
 						Annotations: map[string]string{
-							"keep-me-key": "keep-me-value",
+							"new-key": "new-value",
+							"key1":    "new-value",
 						},
 					},
 				}
@@ -1067,15 +1071,24 @@ var _ = Describe("StatefulSet", func() {
 					"app.kubernetes.io/part-of":   "rabbitmq",
 				}))
 
-				Expect(statefulSet.ObjectMeta.Annotations).To(Equal(map[string]string{"keep-me-key": "keep-me-value"}))
+				Expect(statefulSet.ObjectMeta.Annotations).To(Equal(map[string]string{
+					"new-key": "new-value",
+					"key1":    "new-value",
+					"keep-me": "keep-me",
+				}))
 			})
 
 			It("overrides statefulSet.ObjectMeta.Labels", func() {
 				instance.Annotations = map[string]string{"my-key": "my-value"}
+				instance.Labels = map[string]string{
+					"key1":    "value1",
+					"keep-me": "keep-me",
+				}
 				instance.Spec.Override.StatefulSet = &rabbitmqv1beta1.StatefulSet{
 					EmbeddedObjectMeta: &rabbitmqv1beta1.EmbeddedObjectMeta{
 						Labels: map[string]string{
-							"my-great-label": "my-great-label",
+							"new-label-key": "new-label-value",
+							"key1":          "new-value",
 						},
 					},
 				}
@@ -1083,8 +1096,15 @@ var _ = Describe("StatefulSet", func() {
 				Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 				Expect(statefulSet.ObjectMeta.Name).To(Equal(instance.Name))
 				Expect(statefulSet.ObjectMeta.Namespace).To(Equal(instance.Namespace))
-				Expect(statefulSet.ObjectMeta.Labels).To(Equal(map[string]string{"my-great-label": "my-great-label"}))
 				Expect(statefulSet.ObjectMeta.Annotations).To(Equal(map[string]string{"my-key": "my-value"}))
+				Expect(statefulSet.ObjectMeta.Labels).To(Equal(map[string]string{
+					"new-label-key":               "new-label-value",
+					"key1":                        "new-value",
+					"keep-me":                     "keep-me",
+					"app.kubernetes.io/component": "rabbitmq",
+					"app.kubernetes.io/part-of":   "rabbitmq",
+					"app.kubernetes.io/name":      "foo",
+				}))
 			})
 
 			It("overrides statefulSet.spec.replicas", func() {
@@ -1153,7 +1173,12 @@ var _ = Describe("StatefulSet", func() {
 					Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 					Expect(statefulSet.Spec.Template.ObjectMeta.Name).To(Equal("my-name"))
 					Expect(statefulSet.Spec.Template.ObjectMeta.Namespace).To(Equal("my-ns"))
-					Expect(statefulSet.Spec.Template.ObjectMeta.Labels).To(Equal(map[string]string{"my-label": "my-label"}))
+					Expect(statefulSet.Spec.Template.ObjectMeta.Labels).To(Equal(map[string]string{
+						"my-label":                    "my-label",
+						"app.kubernetes.io/component": "rabbitmq",
+						"app.kubernetes.io/part-of":   "rabbitmq",
+						"app.kubernetes.io/name":      "foo",
+					}))
 					Expect(statefulSet.Spec.Template.ObjectMeta.Annotations).To(Equal(map[string]string{"my-key": "my-value"}))
 				})
 				It("Overrides PodSpec", func() {


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Couples fixes to the current sts override implementation while looking at the code.

- SetControllerReference should be called after override is applied
- Labels and annotations override should be merged not replaced when patching

## Additional Context

## Local Testing

Have run unit and integration tests