### PR TITLE
Add example about import definitions

### DIFF
--- a/docs/examples/import-definitions/README.md
+++ b/docs/examples/import-definitions/README.md
@@ -1,6 +1,6 @@
 # Import Definitions Example
 
-You can import definitions, which contain definitions of all broker objects from a local file at Node Boot. (Learn more about export and import rabbitmq definitions)[https://www.rabbitmq.com/definitions.html#import].
+You can import definitions, which contain definitions of all broker objects from a local file at Node Boot. [Learn more about export and import rabbitmq definitions](https://www.rabbitmq.com/definitions.html#import).
 
 You can save the export definitions json file in a ConfigMap object like so
 
@@ -14,6 +14,11 @@ data:
 # exported definitions context
 ```
 
-and then leverage the StatefulSet Override to mount this additional ConfigMap `definitions` to your rabbitmqcluster instance. Check out `rabbitmq.yaml` as an example.
+or
+```bash
+kubectl create configmap definitions --from-file='def.json=/my/path/to/definitions.json'
+```
+
+Then, leverage the StatefulSet Override to mount this additional ConfigMap `definitions` to your rabbitmqcluster instance. Check out `rabbitmq.yaml` as an example.
 
 Keep in mind that exported definitions contain all broker objects, including users. This means that the admin user credentials will be imported from the definitions, and will not be the one which is generated at the creation of the deployment as a kubernetes secret object.

--- a/docs/examples/import-definitions/README.md
+++ b/docs/examples/import-definitions/README.md
@@ -1,8 +1,8 @@
 # Import Definitions Example
 
-You can import definitions, which contains definitions of all broker objects from a local file at Node Boot. (Learn more about export and import rabbitmq definitions)[https://www.rabbitmq.com/definitions.html#import].
+You can import definitions, which contain definitions of all broker objects from a local file at Node Boot. (Learn more about export and import rabbitmq definitions)[https://www.rabbitmq.com/definitions.html#import].
 
-You can save the export definitions json file in a ConfigMap object in like so
+You can save the export definitions json file in a ConfigMap object like so
 
 ```yaml
 kind: ConfigMap
@@ -16,4 +16,4 @@ data:
 
 and then leverage the StatefulSet Override to mount this additional ConfigMap `definitions` to your rabbitmqcluster instance. Check out `rabbitmq.yaml` as an example.
 
-Keep in mind that exported definitions contains all broker objects, including users. This means that the admin user credentials will be imported from the definitions, and will not be the one which is generated at the creation of the deployment as a kubernetes secret object.
+Keep in mind that exported definitions contain all broker objects, including users. This means that the admin user credentials will be imported from the definitions, and will not be the one which is generated at the creation of the deployment as a kubernetes secret object.

--- a/docs/examples/import-definitions/README.md
+++ b/docs/examples/import-definitions/README.md
@@ -1,0 +1,19 @@
+# Import Definitions Example
+
+You can import definitions, which contains definitions of all broker objects from a local file at Node Boot. (Learn more about export and import rabbitmq definitions)[https://www.rabbitmq.com/definitions.html#import].
+
+You can save the export definitions json file in a ConfigMap object in like so
+
+```yaml
+kind: ConfigMap
+metadata:
+  name: definitions
+  namespace: # should be the same namespace as the rabbitmqcluster instance you are importing the definitions to
+data:
+  def.json: |
+# exported definitions context
+```
+
+and then leverage the StatefulSet Override to mount this additional ConfigMap `definitions` to your rabbitmqcluster instance. Check out `rabbitmq.yaml` as an example.
+
+Keep in mind that exported definitions contains all broker objects, including users. This means that the admin user credentials will be imported from the definitions, and will not be the one which is generated at the creation of the deployment as a kubernetes secret object.

--- a/docs/examples/import-definitions/rabbitmq.yaml
+++ b/docs/examples/import-definitions/rabbitmq.yaml
@@ -1,0 +1,23 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: import-definitions
+spec:
+  replicas: 1
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              volumeMounts:
+              - mountPath: /tmp/definitions
+                name: definitions
+            volumes:
+            - name: definitions
+              configMap:
+                name: definitions # ConfigMap which contains the definitions you wish to import
+  rabbitmq:
+    additionalConfig: |
+      load_definitions = /tmp/definitions/def.json # Patch the the mounted definitions file

--- a/docs/examples/import-definitions/rabbitmq.yaml
+++ b/docs/examples/import-definitions/rabbitmq.yaml
@@ -12,12 +12,12 @@ spec:
             containers:
             - name: rabbitmq
               volumeMounts:
-              - mountPath: /tmp/definitions
+              - mountPath: /path/to/exported/definitions.json
                 name: definitions
             volumes:
             - name: definitions
               configMap:
-                name: definitions # ConfigMap which contains the definitions you wish to import
+                name: definitions # Name of the ConfigMap which contains definitions you wish to import
   rabbitmq:
     additionalConfig: |
-      load_definitions = /tmp/definitions/def.json # Patch the the mounted definitions file
+      load_definitions = /path/to/exported/definitions.json # Path to the mounted definitions file


### PR DESCRIPTION
This closes #104

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
- add an example that imports definitions json file at node boot leveraging statefulSet Override, and `additionalConfig`

## Additional Context

Exported definitions contains all broker objects, including users and permissions. When importing definitions, the admin user of the cluster will be the one recorded from the definitions file, and not the admin user that the operator generates at rabbitmqcluster creation. I've tried deleting the `users` field from the definitions file when importing, and that resulted in the rabbitmqcluster starting with **no user** at all. This is an interesting side effect that the k8s admin secret is not used when importing definitions, and it would be better if there is an easy way for users to signal that so the operator can skip creating admin secret for such rabbitmqclusters.

## Local Testing

Have verified that the example works against a gke cluster. After importing the definitions, queues and exchanges from previous queue all showed up and including the previous admin user.
