### PR TITLE
Add default annotations to all Pod templates

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -12,6 +12,7 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
+
 	rabbitmqv1beta1 "github.com/pivotal/rabbitmq-for-kubernetes/api/v1beta1"
 	"github.com/pivotal/rabbitmq-for-kubernetes/internal/metadata"
 	appsv1 "k8s.io/api/apps/v1"
@@ -137,7 +138,11 @@ func (builder *StatefulSetBuilder) Update(object runtime.Object) error {
 
 	//Annotations
 	sts.Annotations = metadata.ReconcileAndFilterAnnotations(sts.Annotations, builder.Instance.Annotations)
-	podAnnotations := metadata.ReconcileAndFilterAnnotations(sts.Spec.Template.Annotations, builder.Instance.Annotations)
+	defaultPodAnnotations := map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   "15692",
+	}
+	podAnnotations := metadata.ReconcileAnnotations(defaultPodAnnotations, metadata.ReconcileAndFilterAnnotations(sts.Spec.Template.Annotations, builder.Instance.Annotations))
 
 	//Labels
 	updatedLabels := metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)


### PR DESCRIPTION
## Summary Of Changes

Updates the StatefulSet Pod template to always contain the prometheus
scrape annotations.

This allows users of the default Prometheus helm chart to automatically
scrape any RabbitMQ Pods created by this CR.

This forms part of #118; there will be accompanying docs changes to the RabbitMQ website.

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Local Testing

All of unit, integration & system tests pass.

Also confirmed that deploying the operator with this change causes any existing pods to be teminated & brought back up with the new annotations.