### PR TITLE
Bump Dockerfile to latest ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ COPY go.sum go.sum
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Changed base image to ubuntu for OSL compliance
-FROM ubuntu@sha256:c303f19cfe9ee92badbbbd7567bc1ca47789f79303ddcef56f77687d4744cd7a
+FROM ubuntu:latest
 
 ARG GIT_COMMIT
 LABEL GitCommit=$GIT_COMMIT


### PR DESCRIPTION
Pinning to a specific SHA no longer makes sense with no OSL process.

This addresses #194 - some work still needs to be done to see if another base image is more suitable.

## Local Testing

All of unit, integration & system tests are 💚 