### PR TITLE
Remove private registry test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,7 @@ deploy-namespace-rbac:
 	kustomize build config/namespace/base | kubectl apply -f -
 	kustomize build config/rbac | kubectl apply -f -
 
-deploy-master: install deploy-namespace-rbac docker-registry-secret
-	kustomize build config/default/base | kubectl apply -f -
-
-deploy: manifests deploy-namespace-rbac docker-registry-secret deploy-manager ## Deploy operator in the configured Kubernetes cluster in ~/.kube/config
+deploy: manifests deploy-namespace-rbac deploy-manager ## Deploy operator in the configured Kubernetes cluster in ~/.kube/config
 
 deploy-dev: docker-build-dev patch-dev manifests deploy-namespace-rbac docker-registry-secret deploy-manager-dev ## Deploy operator in the configured Kubernetes cluster in ~/.kube/config, with local changes
 

--- a/config/default/base/manager_image_patch.yaml
+++ b/config/default/base/manager_image_patch.yaml
@@ -16,5 +16,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: dev.registry.pivotal.io/p-rabbitmq-for-kubernetes/rabbitmq-for-kubernetes-operator:latest
+      - image: rabbitmqoperator/rabbitmq-cluster-kubernetes-operator:latest
         name: operator

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -46,8 +46,6 @@ var _ = Describe("Operator", func() {
 			cluster = generateRabbitmqCluster(namespace, "basic-rabbit")
 			cluster.Spec.Replicas = &one
 			cluster.Spec.Service.Type = "NodePort"
-			cluster.Spec.Image = "dev.registry.pivotal.io/p-rabbitmq-for-kubernetes/rabbitmq:latest"
-			cluster.Spec.ImagePullSecret = "p-rmq-registry-access"
 			cluster.Spec.Resources = &corev1.ResourceRequirements{
 				Requests: map[corev1.ResourceName]k8sresource.Quantity{},
 				Limits:   map[corev1.ResourceName]k8sresource.Quantity{},


### PR DESCRIPTION
This is related to #211. Some changes in 211 broke the system tests.

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Remove reference to PivNet registry for RabbitMQ image in basic system test.

## Additional Context

This test is too specific to a specific infrastructure setup. By testing that we template the image pull secret correctly in the StatefulSet it should give the same coverage.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
