### PR TITLE
use our public image by default

### DIFF
--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -8,13 +8,13 @@
 #
 
 global:
-  imageRegistry: myregistry.com
-  # These are credentials to myregistry.com
+  # provide these values if you want to pull the image from a local registry
+  imageRegistry:
   imageUsername:
   imagePassword:
 images:
   operator:
-    name: myregistry.com/rabbitmq-cluster-operator
+    name: rabbitmqoperator/rabbitmq-cluster-kubernetes-operator
     tag: "latest"
 leaseDuration:
 retryPeriod:


### PR DESCRIPTION
We can now default to our public image so that no chart configuration is necessary. Once we merge this, we should also update https://www.rabbitmq.com/kubernetes/operator/install-operator.html to basically say `helm install rabbitmq-operator charts/operator`.