### PR TITLE
Add documentation for TLS & mTLS

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -232,7 +232,7 @@ type TLSSpec struct {
 	// The Secret must store these as tls.key and tls.crt, respectively.
 	SecretName string `json:"secretName,omitempty"`
 	// Name of a Secret in the same Namespace as the RabbitmqCluster, containing the Certificate Authority's public certificate for TLS.
-	// This Secret can be the same Secret as specified in SecretName.
+	// This can be the same as SecretName.
 	CaSecretName string `json:"caSecretName,omitempty"`
 	// The Secret defined in CaSecretName must store the Certificate Authority's public certificate under the key specified in CaCertName.
 	CaCertName string `json:"caCertName,omitempty"`

--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -9,9 +9,10 @@
 package v1beta1
 
 import (
-	appsv1 "k8s.io/api/apps/v1"
 	"reflect"
 	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/pivotal/rabbitmq-for-kubernetes/internal/status"
 	corev1 "k8s.io/api/core/v1"
@@ -227,9 +228,14 @@ type PersistentVolumeClaim struct {
 }
 
 type TLSSpec struct {
-	SecretName   string `json:"secretName,omitempty"`
+	// Name of a Secret in the same Namespace as the RabbitmqCluster, containing the server's private key & public certificate for TLS.
+	// The Secret must store these as tls.key and tls.crt, respectively.
+	SecretName string `json:"secretName,omitempty"`
+	// Name of a Secret in the same Namespace as the RabbitmqCluster, containing the Certificate Authority's public certificate for TLS.
+	// This Secret can be the same Secret as specified in SecretName.
 	CaSecretName string `json:"caSecretName,omitempty"`
-	CaCertName   string `json:"caCertName,omitempty"`
+	// The Secret defined in CaSecretName must store the Certificate Authority's public certificate under the key specified in CaCertName.
+	CaCertName string `json:"caCertName,omitempty"`
 }
 
 // kubebuilder validating tags 'Pattern' and 'MaxLength' must be specified on string type.

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -4652,10 +4652,18 @@ spec:
             tls:
               properties:
                 caCertName:
+                  description: The Secret defined in CaSecretName must store the Certificate
+                    Authority's public certificate under the key specified in CaCertName.
                   type: string
                 caSecretName:
+                  description: Name of a Secret in the same Namespace as the RabbitmqCluster,
+                    containing the Certificate Authority's public certificate for
+                    TLS. This Secret can be the same Secret as specified in SecretName.
                   type: string
                 secretName:
+                  description: Name of a Secret in the same Namespace as the RabbitmqCluster,
+                    containing the server's private key & public certificate for TLS.
+                    The Secret must store these as tls.key and tls.crt, respectively.
                   type: string
               type: object
             tolerations:

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -4658,7 +4658,7 @@ spec:
                 caSecretName:
                   description: Name of a Secret in the same Namespace as the RabbitmqCluster,
                     containing the Certificate Authority's public certificate for
-                    TLS. This Secret can be the same Secret as specified in SecretName.
+                    TLS. This can be the same as SecretName.
                   type: string
                 secretName:
                   description: Name of a Secret in the same Namespace as the RabbitmqCluster,

--- a/docs/examples/mtls/README.md
+++ b/docs/examples/mtls/README.md
@@ -5,13 +5,16 @@ You must set `.spec.tls.secretName` to the name of a secret containing the Rabbi
 and set `spec.tls.caSecretName` to the name of a secret containing the certificate of the Certificate Authority which
 has signed the certificates of your RabbitMQ clients.
 
-First, you need to create the server Secret like this (assuming you already have `server.pem` and `server-key.pem` files):
+First, you need to create the Secret which will contain the public certificate and private key to be used for TLS on the RabbitMQ nodes.
+Assuming you already have these created and accessible as `server.pem` and `server-key.pem`, respectively, this Secret can be created by running:
 
 ```shell
 kubectl create secret tls tls-secret --cert=server.pem --key=server-key.pem
 ```
 
-Next, you must create the Secret containing the CA's certificate like this (assuming you already have a `ca.pem` file):
+In order to use mTLS, the RabbitMQ nodes must trust a Certificate Authority which has signed the public certificates of any clients which try to connect.
+You must create a Secret containing the CA's public certificate so that the RabbitMQ nodes know to trust any certifiates signed by the CA.
+Assuming the CA's certificate is accessible as `ca.pem`, you can create this Secret by running:
 
 ```shell
 kubectl create secret generic ca-secret --from-file=ca.crt=ca.pem

--- a/docs/examples/mtls/README.md
+++ b/docs/examples/mtls/README.md
@@ -22,7 +22,7 @@ kubectl create secret generic ca-secret --from-file=ca.crt=ca.pem
 
 These Secrets can also be created by [Cert Manager](https://cert-manager.io/).
 
-Once the secrets exist, you can deploy this example like this:
+Once the secrets exist, you can deploy this example as follows:
 
 ```shell
 kubectl apply -f rabbitmq.yaml

--- a/docs/examples/mtls/README.md
+++ b/docs/examples/mtls/README.md
@@ -1,0 +1,43 @@
+# mTLS Example
+
+You can enable mTLS by providing the necessary TLS certificates and keys in Secret objects.
+You must set `.spec.tls.secretName` to the name of a secret containing the RabbitMQ server's TLS certificate and key,
+and set `spec.tls.caSecretName` to the name of a secret containing the certificate of the Certificate Authority which
+has signed the certificates of your RabbitMQ clients.
+
+First, you need to create the server Secret like this (assuming you already have `server.pem` and `server-key.pem` files):
+
+```shell
+kubectl create secret tls tls-secret --cert=server.pem --key=server-key.pem
+```
+
+Next, you must create the Secret containing the CA's certificate like this (assuming you already have a `ca.pem` file):
+
+```shell
+kubectl create secret generic ca-secret --from-file=ca.crt=ca.pem
+```
+
+These Secrets can also be created by [Cert Manager](https://cert-manager.io/).
+
+Once the secrets exist, you can deploy this example like this:
+
+```shell
+kubectl apply -f rabbitmq.yaml
+```
+
+## Peer verification
+
+With mTLS enabled, any clients that attempt to connect to the RabbitMQ server that present a TLS certificate will have that
+certificate verified against the CA certificate provided in `spec.tls.caSecretName`. This is because the RabbitMQ configuration option
+`ssl_options.verify_peer` is enabled with mTLS by default.
+
+If you require RabbitMQ to reject clients that do not present certificates by enabling `ssl.options.fail_if_no_peer_cert`,
+this can be done by editing the RabbitmqCluster object's spec to include the field in the `additionalConfig`:
+
+```yaml
+spec:
+  rabbitmq:
+    additionalConfig: |
+      ssl_options.fail_if_no_peer_cert = true
+```
+

--- a/docs/examples/mtls/rabbitmq.yaml
+++ b/docs/examples/mtls/rabbitmq.yaml
@@ -1,0 +1,10 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: mtls
+spec:
+  replicas: 1
+  tls:
+    secretName: tls-secret
+    caSecretName: ca-secret
+    caCertName: ca.crt

--- a/docs/examples/tls/README.md
+++ b/docs/examples/tls/README.md
@@ -2,7 +2,8 @@
 
 You can enable TLS by setting `.spec.tls.secretName` to the name of a secret containing TLS certificate and key.
 
-First, you need to create a secret like this (assuming you already have `server.pem` and `server-key.pem` files):
+First, you need to create the Secret which will contain the public certificate and private key to be used for TLS on the RabbitMQ nodes.
+Assuming you already have these created and accessible as `server.pem` and `server-key.pem`, respectively, this Secret can be created by running:
 
 ```shell
 kubectl create secret tls tls-secret --cert=server.pem --key=server-key.pem

--- a/docs/examples/tls/README.md
+++ b/docs/examples/tls/README.md
@@ -1,6 +1,6 @@
 # TLS Example
 
-You can enable TLS by setting `.spec.tls` to the name of a secret containing TLS certificate and key.
+You can enable TLS by setting `.spec.tls.secretName` to the name of a secret containing TLS certificate and key.
 
 First, you need to create a secret like this (assuming you already have `server.pem` and `server-key.pem` files):
 

--- a/docs/examples/tls/README.md
+++ b/docs/examples/tls/README.md
@@ -11,7 +11,7 @@ kubectl create secret tls tls-secret --cert=server.pem --key=server-key.pem
 
 This secret can also be created by [Cert Manager](https://cert-manager.io/).
 
-Once the secret exists, you can deploy this example like this:
+Once the secret exists, you can deploy this example as follows:
 
 ```shell
 kubectl apply -f rabbitmq.yaml


### PR DESCRIPTION
This closes #231, after some website changes.

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- [x] Update API documentation for `rabbitmq.com/v1beta1.TLSSpec` fields
- [x] Add example in docs/examples/ for mTLS usecase
- [x] Submit a PR to the rabbitmq-website to provide documentation for all of the fields in `rabbitmq.com/v1beta1.TLSSpec`

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
