### PR TITLE
Add `envConfig`, `advancedConfig` and `override` to the helm chart

### DIFF
--- a/charts/rabbitmq/example-configurations.yaml
+++ b/charts/rabbitmq/example-configurations.yaml
@@ -50,6 +50,15 @@ rabbitmq:
     - rabbitmq_shovel_management
   additionalConfig: |
     cluster_formation.peer_discovery_backend = rabbit_peer_discovery_k8s
+  envConfig: |
+    PLUGINS_DIR=/opt/rabbitmq/plugins:/opt/rabbitmq/community-plugins
+  advancedConfig: |
+    advancedConfig: |
+      [
+          {ra, [
+              {wal_data_dir, '/var/lib/rabbitmq/quorum-wal'}
+          ]}
+      ].
 
 affinity:
   nodeAffinity:
@@ -64,3 +73,15 @@ affinity:
 
 tls:
   secretName: tls-secret
+
+override:
+  statefulSet:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: rabbitmq
+              ports:
+                - containerPort: 12345 # opens an additional port on the rabbitmq server container
+                  name: additional-port
+                  protocol: TCP

--- a/charts/rabbitmq/expected-template-output
+++ b/charts/rabbitmq/expected-template-output
@@ -60,5 +60,27 @@ spec:
     additionalConfig:
     |
       cluster_formation.peer_discovery_backend = rabbit_peer_discovery_k8s
+    envConfig:
+    |
+      PLUGINS_DIR=/opt/rabbitmq/plugins:/opt/rabbitmq/community-plugins
+    advancedConfig:
+    |
+      advancedConfig: |
+        [
+            {ra, [
+                {wal_data_dir, '/var/lib/rabbitmq/quorum-wal'}
+            ]}
+        ].
   tls:
     secretName: tls-secret
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              ports:
+              - containerPort: 12345
+                name: additional-port
+                protocol: TCP

--- a/charts/rabbitmq/templates/rabbitmq.yaml
+++ b/charts/rabbitmq/templates/rabbitmq.yaml
@@ -68,14 +68,27 @@ spec:
 
   {{- if .Values.rabbitmq }}
   rabbitmq:
+    
     {{- if .Values.rabbitmq.additionalPlugins }}
     additionalPlugins:
 {{ toYaml .Values.rabbitmq.additionalPlugins | indent 4 }}
     {{- end }}
+    
     {{- if .Values.rabbitmq.additionalConfig }}
     additionalConfig:
 {{ toYaml .Values.rabbitmq.additionalConfig | indent 4 }}
     {{- end }}
+
+    {{- if .Values.rabbitmq.envConfig }}
+    envConfig:
+{{ toYaml .Values.rabbitmq.envConfig | indent 4 }}
+    {{- end }}
+
+    {{- if .Values.rabbitmq.advancedConfig }}
+    advancedConfig:
+{{ toYaml .Values.rabbitmq.advancedConfig | indent 4 }}
+    {{- end }}
+
   {{- end }}
 
   {{- if .Values.tls }}
@@ -83,4 +96,9 @@ spec:
     {{- if .Values.tls.secretName }}
     secretName: {{ .Values.tls.secretName }}
     {{- end }}
+  {{- end }}
+
+  {{- if .Values.override }}
+  override:
+{{ toYaml .Values.override | indent 4 }}
   {{- end }}


### PR DESCRIPTION
This closes #239 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

3 missing properties have been added to the template

## Local Testing

To run the unit and integration tests:

```
$ cd cluster-operator/charts/rabbitmq
$ ./test.sh
```

You can also `kubectl apply -f expected-template-output` (or actually use helm).