### PR TITLE
Refactor to extract out plugins

### DIFF
--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -357,10 +357,11 @@ func (r *RabbitmqClusterReconciler) allReplicasReady(ctx context.Context, rmq *r
 // enablePlugins - helper function to set the list of enabled plugins in a given RabbitmqCluster pods
 // `rabbitmq-plugins set` disables plugins that are not in the provided list
 func (r *RabbitmqClusterReconciler) enablePlugins(rmq *rabbitmqv1beta1.RabbitmqCluster) error {
+	plugins := resource.NewRabbitMQPlugins(rmq.Spec.Rabbitmq.AdditionalPlugins)
 	for i := int32(0); i < *rmq.Spec.Replicas; i++ {
 		podName := fmt.Sprintf("%s-%d", rmq.ChildResourceName("server"), i)
 		rabbitCommand := fmt.Sprintf("rabbitmq-plugins set %s",
-			strings.Join(resource.AppendIfUnique(resource.RequiredPlugins, rmq.Spec.Rabbitmq.AdditionalPlugins), " "))
+			strings.Join(plugins.DesiredPlugins(), " "))
 
 		stdout, stderr, err := r.exec(rmq.Namespace, podName, "rabbitmq", "sh", "-c", rabbitCommand)
 

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -53,25 +53,15 @@ var _ = Describe("GenerateServerConfigMap", func() {
 			Expect(configMap.Namespace).To(Equal(builder.Instance.Namespace))
 		})
 
-		It("returns a ConfigMap with required plugins", func() {
-			expectedEnabledPlugins := "[" +
-				"rabbitmq_peer_discovery_k8s," +
-				"rabbitmq_prometheus," +
-				"rabbitmq_management]."
-
-			Expect(configMap.Data).To(HaveKeyWithValue("enabled_plugins", expectedEnabledPlugins))
-		})
-
 		When("additionalPlugins are provided in instance spec", func() {
 			It("appends provided plugins to a list of required ones and removes duplicates", func() {
-				instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_management", "rabbitmq_shovel", "rabbitmq_top", "my_great_plugin"}
+				instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_management", "rabbitmq_shovel", "my_great_plugin"}
 
 				expectedEnabledPlugins := "[" +
 					"rabbitmq_peer_discovery_k8s," +
 					"rabbitmq_prometheus," +
 					"rabbitmq_management," +
 					"rabbitmq_shovel," +
-					"rabbitmq_top," +
 					"my_great_plugin]."
 
 				obj, err := configMapBuilder.Build()

--- a/internal/resource/rabbitmq_plugins.go
+++ b/internal/resource/rabbitmq_plugins.go
@@ -1,0 +1,40 @@
+package resource
+
+import rabbitmqv1beta1 "github.com/pivotal/rabbitmq-for-kubernetes/api/v1beta1"
+
+var requiredPlugins = []string{
+	"rabbitmq_peer_discovery_k8s", // required for clustering
+	"rabbitmq_prometheus",         // enforce prometheus metrics
+	"rabbitmq_management",
+}
+
+type RabbitMQPlugins struct {
+	requiredPlugins   []string
+	additionalPlugins []string
+}
+
+func NewRabbitMQPlugins(plugins []rabbitmqv1beta1.Plugin) RabbitMQPlugins {
+	additionalPlugins := make([]string, len(plugins))
+	for i := range additionalPlugins {
+		additionalPlugins[i] = string(plugins[i])
+	}
+
+	return RabbitMQPlugins{
+		requiredPlugins:   requiredPlugins,
+		additionalPlugins: additionalPlugins,
+	}
+}
+
+func (r *RabbitMQPlugins) DesiredPlugins() []string {
+	allPlugins := append(r.requiredPlugins, r.additionalPlugins...)
+
+	check := make(map[string]bool)
+	enabledPlugins := make([]string, 0)
+	for _, p := range allPlugins {
+		if _, ok := check[p]; !ok {
+			check[p] = true
+			enabledPlugins = append(enabledPlugins, p)
+		}
+	}
+	return enabledPlugins
+}

--- a/internal/resource/rabbitmq_plugins_test.go
+++ b/internal/resource/rabbitmq_plugins_test.go
@@ -1,0 +1,57 @@
+// RabbitMQ Cluster Operator
+//
+// Copyright 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Mozilla Public license, Version 2.0 (the "License").  You may not use this product except in compliance wit the Mozilla Public License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+//
+
+package resource_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	rabbitmqv1beta1 "github.com/pivotal/rabbitmq-for-kubernetes/api/v1beta1"
+	. "github.com/pivotal/rabbitmq-for-kubernetes/internal/resource"
+)
+
+var _ = Describe("RabbitMQPlugins", func() {
+
+	Context("DesiredPlugins", func() {
+		When("AdditionalPlugins is empty", func() {
+			It("returns list of required plugins", func() {
+				plugins := NewRabbitMQPlugins(nil)
+				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s", "rabbitmq_prometheus", "rabbitmq_management"}))
+			})
+		})
+
+		When("AdditionalPlugins are provided", func() {
+			It("returns a concatenated list of plugins", func() {
+				morePlugins := []rabbitmqv1beta1.Plugin{"rabbitmq_shovel", "my_great_plugin"}
+				plugins := NewRabbitMQPlugins(morePlugins)
+
+				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s",
+					"rabbitmq_prometheus",
+					"rabbitmq_management",
+					"my_great_plugin",
+					"rabbitmq_shovel",
+				}))
+			})
+		})
+
+		When("AdditionalPlugins are provided with duplicates", func() {
+			It("returns a unique list of plugins", func() {
+				morePlugins := []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_shovel", "my_great_plugin", "rabbitmq_shovel"}
+				plugins := NewRabbitMQPlugins(morePlugins)
+
+				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s",
+					"rabbitmq_prometheus",
+					"rabbitmq_management",
+					"my_great_plugin",
+					"rabbitmq_shovel",
+				}))
+			})
+		})
+	})
+})


### PR DESCRIPTION
Both config map and controller were accessing the same method to find
the list of plugins. Also, the config map contained RequiredPlugins
which was accessed in Controller. As a part of this commit,
rabbitmqPlugins are abstracted out to not expose the default or required
plugins and return a final list of user provided plugins and default
plugins.


**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
