### PR TITLE
Move base operator image to scratch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pivotal/rabbitmq-for-kubernetes
 
-go 1.13
+go 1.15
 
 require (
 	cloud.google.com/go v0.47.0 // indirect
@@ -28,7 +28,6 @@ require (
 	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
-	google.golang.org/api v0.9.0
 	google.golang.org/appengine v1.6.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.7 // indirect


### PR DESCRIPTION
This closes #194 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Moves the base image from Ubuntu to scratch.

## Additional Context

There's a few additional requirements on the image other than just running the binary:

* Access to tzdata - provided by Golang 1.15 with the `-tags timetzdata` flag
* Access to CA certs for TLS - provided by installing on Alpine, then copying over to the manager image
* Running as a specified User, with a UID / GID of 1000 - provided by creating a custom `/etc/passwd` & `/etc/group` file

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
