### PR TITLE
Plugins

### DIFF
--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
@@ -355,10 +354,10 @@ func (r *RabbitmqClusterReconciler) allReplicasReady(ctx context.Context, rmq *r
 // enablePlugins - helper function to set the list of enabled plugins in a given RabbitmqCluster pods
 // `rabbitmq-plugins set` disables plugins that are not in the provided list
 func (r *RabbitmqClusterReconciler) enablePlugins(rmq *rabbitmqv1beta1.RabbitmqCluster) error {
+	plugins := resource.NewRabbitMQPlugins(rmq.Spec.Rabbitmq.AdditionalPlugins)
 	for i := int32(0); i < *rmq.Spec.Replicas; i++ {
 		podName := fmt.Sprintf("%s-%d", rmq.ChildResourceName("server"), i)
-		rabbitCommand := fmt.Sprintf("rabbitmq-plugins set %s",
-			strings.Join(resource.AppendIfUnique(resource.RequiredPlugins, rmq.Spec.Rabbitmq.AdditionalPlugins), " "))
+		rabbitCommand := fmt.Sprintf("rabbitmq-plugins set %s", plugins.AsString(" "))
 
 		stdout, stderr, err := r.exec(rmq.Namespace, podName, "rabbitmq", "sh", "-c", rabbitCommand)
 

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
@@ -422,28 +423,25 @@ func (r *RabbitmqClusterReconciler) exec(namespace, podName, containerName strin
 // logAndRecordOperationResult - helper function to log and record events with message and error
 // it logs and records 'updated' and 'created' OperationResult, and ignores OperationResult 'unchanged'
 func (r *RabbitmqClusterReconciler) logAndRecordOperationResult(rmq runtime.Object, resource runtime.Object, operationResult controllerutil.OperationResult, err error) {
-	if operationResult == controllerutil.OperationResultCreated && err == nil {
-		msg := fmt.Sprintf("created resource %s of Type %T", resource.(metav1.Object).GetName(), resource.(metav1.Object))
+	var operation string
+	if operationResult == controllerutil.OperationResultCreated {
+		operation = "create"
+	}
+
+	if operationResult == controllerutil.OperationResultUpdated {
+		operation = "update"
+	}
+
+	if err == nil {
+		msg := fmt.Sprintf("%sd resource %s of Type %T", operation, resource.(metav1.Object).GetName(), resource.(metav1.Object))
 		r.Log.Info(msg)
-		r.Recorder.Event(rmq, corev1.EventTypeNormal, "SuccessfulCreate", msg)
+		r.Recorder.Event(rmq, corev1.EventTypeNormal, fmt.Sprintf("Successful%s", strings.Title(operation)), msg)
 	}
 
-	if operationResult == controllerutil.OperationResultCreated && err != nil {
-		msg := fmt.Sprintf("failed to create resource %s of Type %T", resource.(metav1.Object).GetName(), resource.(metav1.Object))
+	if err != nil {
+		msg := fmt.Sprintf("failed to %s resource %s of Type %T", operation, resource.(metav1.Object).GetName(), resource.(metav1.Object))
 		r.Log.Error(err, msg)
-		r.Recorder.Event(rmq, corev1.EventTypeWarning, "FailedCreate", msg)
-	}
-
-	if operationResult == controllerutil.OperationResultUpdated && err == nil {
-		msg := fmt.Sprintf("updated resource %s of Type %T", resource.(metav1.Object).GetName(), resource.(metav1.Object))
-		r.Log.Info(msg)
-		r.Recorder.Event(rmq, corev1.EventTypeNormal, "SuccessfulUpdate", msg)
-	}
-
-	if operationResult == controllerutil.OperationResultUpdated && err != nil {
-		msg := fmt.Sprintf("failed to update resource %s of Type %T", resource.(metav1.Object).GetName(), resource.(metav1.Object))
-		r.Log.Error(err, msg)
-		r.Recorder.Event(rmq, corev1.EventTypeWarning, "FailedUpdate", msg)
+		r.Recorder.Event(rmq, corev1.EventTypeWarning, fmt.Sprintf("Failed%s", strings.Title(operation)), msg)
 	}
 }
 
@@ -591,69 +589,36 @@ func addResourceToIndex(rawObj runtime.Object) []string {
 	switch resourceObject := rawObj.(type) {
 	case *appsv1.StatefulSet:
 		owner := metav1.GetControllerOf(resourceObject)
-		if owner == nil {
-			return nil
-		}
-		if owner.APIVersion != apiGVStr || owner.Kind != ownerKind {
-			return nil
-		}
-		return []string{owner.Name}
+		return validateAndGetOwner(owner)
 	case *corev1.ConfigMap:
 		owner := metav1.GetControllerOf(resourceObject)
-		if owner == nil {
-			return nil
-		}
-		if owner.APIVersion != apiGVStr || owner.Kind != ownerKind {
-			return nil
-		}
-		return []string{owner.Name}
+		return validateAndGetOwner(owner)
 	case *corev1.Service:
 		owner := metav1.GetControllerOf(resourceObject)
-		if owner == nil {
-			return nil
-		}
-		if owner.APIVersion != apiGVStr || owner.Kind != ownerKind {
-			return nil
-		}
-		return []string{owner.Name}
+		return validateAndGetOwner(owner)
 	case *rbacv1.Role:
 		owner := metav1.GetControllerOf(resourceObject)
-		if owner == nil {
-			return nil
-		}
-		if owner.APIVersion != apiGVStr || owner.Kind != ownerKind {
-			return nil
-		}
-		return []string{owner.Name}
+		return validateAndGetOwner(owner)
 	case *rbacv1.RoleBinding:
 		owner := metav1.GetControllerOf(resourceObject)
-		if owner == nil {
-			return nil
-		}
-		if owner.APIVersion != apiGVStr || owner.Kind != ownerKind {
-			return nil
-		}
-		return []string{owner.Name}
+		return validateAndGetOwner(owner)
 	case *corev1.ServiceAccount:
 		owner := metav1.GetControllerOf(resourceObject)
-		if owner == nil {
-			return nil
-		}
-		if owner.APIVersion != apiGVStr || owner.Kind != ownerKind {
-			return nil
-		}
-		return []string{owner.Name}
+		return validateAndGetOwner(owner)
 	case *corev1.Secret:
 		owner := metav1.GetControllerOf(resourceObject)
-		if owner == nil {
-			return nil
-		}
-		if owner.APIVersion != apiGVStr || owner.Kind != ownerKind {
-			return nil
-		}
-		return []string{owner.Name}
-
+		return validateAndGetOwner(owner)
 	default:
 		return nil
 	}
+}
+
+func validateAndGetOwner(owner *metav1.OwnerReference) []string {
+	if owner == nil {
+		return nil
+	}
+	if owner.APIVersion != apiGVStr || owner.Kind != ownerKind {
+		return nil
+	}
+	return []string{owner.Name}
 }

--- a/internal/metadata/annotation.go
+++ b/internal/metadata/annotation.go
@@ -12,31 +12,18 @@ package metadata
 import "strings"
 
 func ReconcileAnnotations(existing map[string]string, defaults ...map[string]string) map[string]string {
-	if existing == nil {
-		existing = map[string]string{}
-	}
-
-	if len(defaults) == 0 {
-		return existing
-	}
-
 	return mergeWithFilter(func(k string) bool { return true }, existing, defaults...)
 }
 
 func ReconcileAndFilterAnnotations(existing map[string]string, defaults ...map[string]string) map[string]string {
-	if existing == nil {
-		existing = map[string]string{}
-	}
-
-	if len(defaults) == 0 {
-		return existing
-	}
-
 	return mergeWithFilter(isNotKubernetesAnnotation, existing, defaults...)
 }
 
 func mergeWithFilter(filterFn func(string) bool, base map[string]string, maps ...map[string]string) map[string]string {
-	result := base
+	result := map[string]string{}
+	if base != nil {
+		result = base
+	}
 
 	for _, m := range maps {
 		for k, v := range m {

--- a/internal/metadata/annotation_test.go
+++ b/internal/metadata/annotation_test.go
@@ -1,0 +1,92 @@
+package metadata_test
+
+import (
+	. "github.com/onsi/ginkgo/extensions/table"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/rabbitmq/cluster-operator/internal/metadata"
+)
+
+var _ = Describe("Annotation", func() {
+	defaultOne := map[string]string{"foo": "bar"}
+	defaultAnnotationsWithK8s := map[string]string{
+		"kubernetes.io.instance": "i1",
+		"k8s.io.namespace":       "ns",
+		"another-annotation":     "some-value",
+	}
+
+	DescribeTable("Reconcile annotations",
+		func(expectedAnnotations map[string]string, existingAnnotations map[string]string, defaultAnnotations ...map[string]string) {
+			reconciledAnnotations := ReconcileAnnotations(existingAnnotations, defaultAnnotations...)
+			Expect(reconciledAnnotations).To(Equal(expectedAnnotations))
+		},
+
+		Entry("existingAnnotations is nil return merged default annotations",
+			map[string]string{
+				"foo":                    "bar",
+				"kubernetes.io.instance": "i1",
+				"k8s.io.namespace":       "ns",
+				"another-annotation":     "some-value",
+			}, nil, defaultOne, defaultAnnotationsWithK8s),
+
+		Entry("no default annotations are present returns existing annotations",
+			map[string]string{
+				"existingAnnotation": "value",
+				"k8s.io.annotation":  "annot",
+			},
+			map[string]string{
+				"existingAnnotation": "value",
+				"k8s.io.annotation":  "annot",
+			}),
+
+		Entry("merges default and existing annotations",
+			map[string]string{
+				"existingAnnotation":     "value",
+				"k8s.io.annotation":      "annot",
+				"foo":                    "bar",
+				"kubernetes.io.instance": "i1",
+				"k8s.io.namespace":       "ns",
+				"another-annotation":     "some-value",
+			},
+			map[string]string{
+				"existingAnnotation": "value",
+				"k8s.io.annotation":  "annot",
+			}, defaultOne, defaultAnnotationsWithK8s),
+	)
+
+	DescribeTable("Reconcile and filter annotations",
+		func(expectedAnnotations map[string]string, existingAnnotations map[string]string, defaultAnnotations ...map[string]string) {
+			reconciledAnnotations := ReconcileAndFilterAnnotations(existingAnnotations, defaultAnnotations...)
+			Expect(reconciledAnnotations).To(Equal(expectedAnnotations))
+		},
+
+		Entry("existingAnnotations is nil return merged and filtered default annotations",
+			map[string]string{
+				"foo":                "bar",
+				"another-annotation": "some-value",
+			}, nil, defaultOne, defaultAnnotationsWithK8s),
+
+		Entry("no default annotations are present returns existing annotations",
+			map[string]string{
+				"existingAnnotation": "value",
+				"k8s.io.annotation":  "annot",
+			},
+			map[string]string{
+				"existingAnnotation": "value",
+				"k8s.io.annotation":  "annot",
+			}),
+
+		Entry("filter default annotations and merge with existing annotations",
+			map[string]string{
+				"existingAnnotation": "value",
+				"k8s.io.annotation":  "annot",
+				"foo":                "bar",
+				"another-annotation": "some-value",
+			},
+			map[string]string{
+				"existingAnnotation": "value",
+				"k8s.io.annotation":  "annot",
+			}, defaultOne, defaultAnnotationsWithK8s),
+	)
+})

--- a/internal/metadata/metadata_suite_test.go
+++ b/internal/metadata/metadata_suite_test.go
@@ -1,0 +1,31 @@
+// RabbitMQ Cluster Operator
+//
+// Copyright 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Mozilla Public license, Version 2.0 (the "License").  You may not use this product except in compliance with the Mozilla Public License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+//
+
+package metadata_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestResource(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metadata Suite")
+}
+
+func testLabels(labels map[string]string) {
+	ExpectWithOffset(1, labels).To(SatisfyAll(
+		HaveKeyWithValue("foo", "bar"),
+		HaveKeyWithValue("rabbitmq", "is-great"),
+		HaveKeyWithValue("foo/app.kubernetes.io", "edgecase"),
+		Not(HaveKey("app.kubernetes.io/foo")),
+	))
+}

--- a/internal/resource/admin_secret.go
+++ b/internal/resource/admin_secret.go
@@ -31,6 +31,10 @@ func (builder *RabbitmqResourceBuilder) AdminSecret() *AdminSecretBuilder {
 	}
 }
 
+func (builder *AdminSecretBuilder) UpdateRequiresStsRestart() bool {
+	return false
+}
+
 func (builder *AdminSecretBuilder) Update(object runtime.Object) error {
 	secret := object.(*corev1.Secret)
 	secret.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/client_service.go
+++ b/internal/resource/client_service.go
@@ -12,6 +12,7 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
@@ -32,6 +33,10 @@ func (builder *RabbitmqResourceBuilder) ClientService() *ClientServiceBuilder {
 type ClientServiceBuilder struct {
 	Instance *rabbitmqv1beta1.RabbitmqCluster
 	Scheme   *runtime.Scheme
+}
+
+func (builder *ClientServiceBuilder) UpdateRequiresStsRestart() bool {
+	return false
 }
 
 func (builder *ClientServiceBuilder) Build() (runtime.Object, error) {

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -52,6 +52,10 @@ func (builder *RabbitmqResourceBuilder) ServerConfigMap() *ServerConfigMapBuilde
 	}
 }
 
+func (builder *ServerConfigMapBuilder) UpdateRequiresStsRestart() bool {
+	return true
+}
+
 func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 	configMap := object.(*corev1.ConfigMap)
 	configMap.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)
@@ -100,14 +104,10 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 }
 
 func (builder *ServerConfigMapBuilder) Build() (runtime.Object, error) {
-	plugins := NewRabbitMQPlugins(builder.Instance.Spec.Rabbitmq.AdditionalPlugins)
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      builder.Instance.ChildResourceName(serverConfigMapName),
 			Namespace: builder.Instance.Namespace,
-		},
-		Data: map[string]string{
-			"enabled_plugins": "[" + plugins.AsString(",") + "].",
 		},
 	}, nil
 }

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -42,12 +42,6 @@ ssl_options.verify = verify_peer
 `
 )
 
-var RequiredPlugins = []string{
-	"rabbitmq_peer_discovery_k8s", // required for clustering
-	"rabbitmq_prometheus",         // enforce prometheus metrics
-	"rabbitmq_management",
-}
-
 type ServerConfigMapBuilder struct {
 	Instance *rabbitmqv1beta1.RabbitmqCluster
 }
@@ -106,33 +100,16 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 }
 
 func (builder *ServerConfigMapBuilder) Build() (runtime.Object, error) {
+	plugins := NewRabbitMQPlugins(builder.Instance.Spec.Rabbitmq.AdditionalPlugins)
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      builder.Instance.ChildResourceName(serverConfigMapName),
 			Namespace: builder.Instance.Namespace,
 		},
 		Data: map[string]string{
-			"enabled_plugins": "[" + strings.Join(AppendIfUnique(RequiredPlugins, builder.Instance.Spec.Rabbitmq.AdditionalPlugins), ",") + "].",
+			"enabled_plugins": "[" + plugins.AsString(",") + "].",
 		},
 	}, nil
-}
-
-func AppendIfUnique(a []string, b []rabbitmqv1beta1.Plugin) []string {
-	data := make([]string, len(b))
-	for i := range data {
-		data[i] = string(b[i])
-	}
-
-	check := make(map[string]bool)
-	list := append(a, data...)
-	set := make([]string, 0)
-	for _, s := range list {
-		if _, value := check[s]; !value {
-			check[s] = true
-			set = append(set, s)
-		}
-	}
-	return set
 }
 
 func updateProperty(configMapData map[string]string, key string, value string) {

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -53,25 +53,15 @@ var _ = Describe("GenerateServerConfigMap", func() {
 			Expect(configMap.Namespace).To(Equal(builder.Instance.Namespace))
 		})
 
-		It("returns a ConfigMap with required plugins", func() {
-			expectedEnabledPlugins := "[" +
-				"rabbitmq_peer_discovery_k8s," +
-				"rabbitmq_prometheus," +
-				"rabbitmq_management]."
-
-			Expect(configMap.Data).To(HaveKeyWithValue("enabled_plugins", expectedEnabledPlugins))
-		})
-
 		When("additionalPlugins are provided in instance spec", func() {
 			It("appends provided plugins to a list of required ones and removes duplicates", func() {
-				instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_management", "rabbitmq_shovel", "rabbitmq_top", "my_great_plugin"}
+				instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_management", "rabbitmq_shovel", "my_great_plugin"}
 
 				expectedEnabledPlugins := "[" +
 					"rabbitmq_peer_discovery_k8s," +
 					"rabbitmq_prometheus," +
 					"rabbitmq_management," +
 					"rabbitmq_shovel," +
-					"rabbitmq_top," +
 					"my_great_plugin]."
 
 				obj, err := configMapBuilder.Build()

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -52,24 +52,6 @@ var _ = Describe("GenerateServerConfigMap", func() {
 			Expect(configMap.Name).To(Equal(builder.Instance.ChildResourceName("server-conf")))
 			Expect(configMap.Namespace).To(Equal(builder.Instance.Namespace))
 		})
-
-		When("additionalPlugins are provided in instance spec", func() {
-			It("appends provided plugins to a list of required ones and removes duplicates", func() {
-				instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_management", "rabbitmq_shovel", "my_great_plugin"}
-
-				expectedEnabledPlugins := "[" +
-					"rabbitmq_peer_discovery_k8s," +
-					"rabbitmq_prometheus," +
-					"rabbitmq_management," +
-					"rabbitmq_shovel," +
-					"my_great_plugin]."
-
-				obj, err := configMapBuilder.Build()
-				configMap = obj.(*corev1.ConfigMap)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(configMap.Data).To(HaveKeyWithValue("enabled_plugins", expectedEnabledPlugins))
-			})
-		})
 	})
 
 	Context("Update", func() {

--- a/internal/resource/erlang_cookie.go
+++ b/internal/resource/erlang_cookie.go
@@ -34,6 +34,10 @@ func (builder *RabbitmqResourceBuilder) ErlangCookie() *ErlangCookieBuilder {
 	}
 }
 
+func (builder *ErlangCookieBuilder) UpdateRequiresStsRestart() bool {
+	return false
+}
+
 func (builder *ErlangCookieBuilder) Build() (runtime.Object, error) {
 	cookie, err := randomEncodedString(24)
 	if err != nil {

--- a/internal/resource/headless_service.go
+++ b/internal/resource/headless_service.go
@@ -31,6 +31,10 @@ func (builder *RabbitmqResourceBuilder) HeadlessService() *HeadlessServiceBuilde
 	}
 }
 
+func (builder *HeadlessServiceBuilder) UpdateRequiresStsRestart() bool {
+	return false
+}
+
 func (builder *HeadlessServiceBuilder) Build() (runtime.Object, error) {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/resource/rabbitmq_plugins.go
+++ b/internal/resource/rabbitmq_plugins.go
@@ -1,0 +1,48 @@
+package resource
+
+import (
+	"strings"
+
+	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
+)
+
+var requiredPlugins = []string{
+	"rabbitmq_peer_discovery_k8s", // required for clustering
+	"rabbitmq_prometheus",         // enforce prometheus metrics
+	"rabbitmq_management",
+}
+
+type RabbitMQPlugins struct {
+	requiredPlugins   []string
+	additionalPlugins []string
+}
+
+func NewRabbitMQPlugins(plugins []rabbitmqv1beta1.Plugin) RabbitMQPlugins {
+	additionalPlugins := make([]string, len(plugins))
+	for i := range additionalPlugins {
+		additionalPlugins[i] = string(plugins[i])
+	}
+
+	return RabbitMQPlugins{
+		requiredPlugins:   requiredPlugins,
+		additionalPlugins: additionalPlugins,
+	}
+}
+
+func (r *RabbitMQPlugins) DesiredPlugins() []string {
+	allPlugins := append(r.requiredPlugins, r.additionalPlugins...)
+
+	check := make(map[string]bool)
+	enabledPlugins := make([]string, 0)
+	for _, p := range allPlugins {
+		if _, ok := check[p]; !ok {
+			check[p] = true
+			enabledPlugins = append(enabledPlugins, p)
+		}
+	}
+	return enabledPlugins
+}
+
+func (r *RabbitMQPlugins) AsString(sep string) string {
+	return strings.Join(r.DesiredPlugins(), sep)
+}

--- a/internal/resource/rabbitmq_plugins.go
+++ b/internal/resource/rabbitmq_plugins.go
@@ -4,6 +4,10 @@ import (
 	"strings"
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
+	"github.com/rabbitmq/cluster-operator/internal/metadata"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var requiredPlugins = []string{
@@ -12,9 +16,15 @@ var requiredPlugins = []string{
 	"rabbitmq_management",
 }
 
+const pluginsConfig = "plugins-conf"
+
 type RabbitMQPlugins struct {
 	requiredPlugins   []string
 	additionalPlugins []string
+}
+
+type RabbitmqPluginsConfigMapBuilder struct {
+	Instance *rabbitmqv1beta1.RabbitmqCluster
 }
 
 func NewRabbitMQPlugins(plugins []rabbitmqv1beta1.Plugin) RabbitMQPlugins {
@@ -45,4 +55,43 @@ func (r *RabbitMQPlugins) DesiredPlugins() []string {
 
 func (r *RabbitMQPlugins) AsString(sep string) string {
 	return strings.Join(r.DesiredPlugins(), sep)
+}
+
+func (builder *RabbitmqResourceBuilder) RabbitmqPluginsConfigMap() *RabbitmqPluginsConfigMapBuilder {
+	return &RabbitmqPluginsConfigMapBuilder{
+		Instance: builder.Instance,
+	}
+}
+
+func (builder *RabbitmqPluginsConfigMapBuilder) UpdateRequiresStsRestart() bool {
+	return false
+}
+
+func (builder *RabbitmqPluginsConfigMapBuilder) Update(object runtime.Object) error {
+	configMap := object.(*corev1.ConfigMap)
+	configMap.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)
+	configMap.Annotations = metadata.ReconcileAndFilterAnnotations(configMap.GetAnnotations(), builder.Instance.Annotations)
+
+	if configMap.Data == nil {
+		configMap.Data = make(map[string]string)
+	}
+	configMap.Data["enabled_plugins"] = desiredPluginsAsString(builder.Instance.Spec.Rabbitmq.AdditionalPlugins)
+	return nil
+}
+
+func (builder *RabbitmqPluginsConfigMapBuilder) Build() (runtime.Object, error) {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      builder.Instance.ChildResourceName(pluginsConfig),
+			Namespace: builder.Instance.Namespace,
+		},
+		Data: map[string]string{
+			"enabled_plugins": desiredPluginsAsString([]rabbitmqv1beta1.Plugin{}),
+		},
+	}, nil
+}
+
+func desiredPluginsAsString(additionalPlugins []rabbitmqv1beta1.Plugin) string {
+	plugins := NewRabbitMQPlugins(additionalPlugins)
+	return "[" + plugins.AsString(",") + "]."
 }

--- a/internal/resource/rabbitmq_plugins_test.go
+++ b/internal/resource/rabbitmq_plugins_test.go
@@ -13,7 +13,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
+	"github.com/rabbitmq/cluster-operator/internal/resource"
 	. "github.com/rabbitmq/cluster-operator/internal/resource"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("RabbitMQPlugins", func() {
@@ -51,6 +55,110 @@ var _ = Describe("RabbitMQPlugins", func() {
 					"my_great_plugin",
 					"rabbitmq_shovel",
 				}))
+			})
+		})
+	})
+
+	Context("PluginsConfigMap", func() {
+		var (
+			instance         rabbitmqv1beta1.RabbitmqCluster
+			configMapBuilder *resource.RabbitmqPluginsConfigMapBuilder
+			builder          *resource.RabbitmqResourceBuilder
+		)
+
+		BeforeEach(func() {
+			instance = rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "a name",
+					Namespace: "a namespace",
+				},
+			}
+			builder = &resource.RabbitmqResourceBuilder{
+				Instance: &instance,
+			}
+			configMapBuilder = builder.RabbitmqPluginsConfigMap()
+		})
+
+		Context("Build", func() {
+			var configMap *corev1.ConfigMap
+
+			BeforeEach(func() {
+				obj, err := configMapBuilder.Build()
+				configMap = obj.(*corev1.ConfigMap)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("generates a ConfigMap with the correct name and namespace", func() {
+				Expect(configMap.Name).To(Equal(builder.Instance.ChildResourceName("plugins-conf")))
+				Expect(configMap.Namespace).To(Equal(builder.Instance.Namespace))
+			})
+
+			It("adds list of default plugins", func() {
+				expectedEnabledPlugins := "[" +
+					"rabbitmq_peer_discovery_k8s," +
+					"rabbitmq_prometheus," +
+					"rabbitmq_management]."
+
+				obj, err := configMapBuilder.Build()
+				Expect(err).NotTo(HaveOccurred())
+
+				configMap = obj.(*corev1.ConfigMap)
+				Expect(configMap.Data).To(HaveKeyWithValue("enabled_plugins", expectedEnabledPlugins))
+			})
+		})
+
+		Context("Update", func() {
+			var configMap *corev1.ConfigMap
+
+			BeforeEach(func() {
+				configMap = &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      instance.Name,
+						Namespace: instance.Namespace,
+					},
+				}
+			})
+
+			When("additionalPlugins are provided in instance spec", func() {
+				When("no previous data is present", func() {
+					It("creates data and sets enabled_plugins", func() {
+						builder.Instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_management", "rabbitmq_shovel", "my_great_plugin"}
+
+						expectedEnabledPlugins := "[" +
+							"rabbitmq_peer_discovery_k8s," +
+							"rabbitmq_prometheus," +
+							"rabbitmq_management," +
+							"rabbitmq_shovel," +
+							"my_great_plugin]."
+
+						err := configMapBuilder.Update(configMap)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(configMap.Data).To(HaveKeyWithValue("enabled_plugins", expectedEnabledPlugins))
+					})
+				})
+
+				When("previous data is present", func() {
+					BeforeEach(func() {
+						configMap.Data = map[string]string{
+							"enabled_plugins": "[rabbitmq_peer_discovery_k8s,rabbitmq_shovel]",
+						}
+					})
+
+					It("updates enabled_plugins with unique list of default and additionalPlugins", func() {
+						builder.Instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_management", "rabbitmq_shovel", "my_great_plugin"}
+
+						expectedEnabledPlugins := "[" +
+							"rabbitmq_peer_discovery_k8s," +
+							"rabbitmq_prometheus," +
+							"rabbitmq_management," +
+							"rabbitmq_shovel," +
+							"my_great_plugin]."
+
+						err := configMapBuilder.Update(configMap)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(configMap.Data).To(HaveKeyWithValue("enabled_plugins", expectedEnabledPlugins))
+					})
+				})
 			})
 		})
 	})

--- a/internal/resource/rabbitmq_plugins_test.go
+++ b/internal/resource/rabbitmq_plugins_test.go
@@ -1,0 +1,57 @@
+// RabbitMQ Cluster Operator
+//
+// Copyright 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Mozilla Public license, Version 2.0 (the "License").  You may not use this product except in compliance wit the Mozilla Public License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+//
+
+package resource_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
+	. "github.com/rabbitmq/cluster-operator/internal/resource"
+)
+
+var _ = Describe("RabbitMQPlugins", func() {
+
+	Context("DesiredPlugins", func() {
+		When("AdditionalPlugins is empty", func() {
+			It("returns list of required plugins", func() {
+				plugins := NewRabbitMQPlugins(nil)
+				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s", "rabbitmq_prometheus", "rabbitmq_management"}))
+			})
+		})
+
+		When("AdditionalPlugins are provided", func() {
+			It("returns a concatenated list of plugins", func() {
+				morePlugins := []rabbitmqv1beta1.Plugin{"rabbitmq_shovel", "my_great_plugin"}
+				plugins := NewRabbitMQPlugins(morePlugins)
+
+				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s",
+					"rabbitmq_prometheus",
+					"rabbitmq_management",
+					"my_great_plugin",
+					"rabbitmq_shovel",
+				}))
+			})
+		})
+
+		When("AdditionalPlugins are provided with duplicates", func() {
+			It("returns a unique list of plugins", func() {
+				morePlugins := []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_shovel", "my_great_plugin", "rabbitmq_shovel"}
+				plugins := NewRabbitMQPlugins(morePlugins)
+
+				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s",
+					"rabbitmq_prometheus",
+					"rabbitmq_management",
+					"my_great_plugin",
+					"rabbitmq_shovel",
+				}))
+			})
+		})
+	})
+})

--- a/internal/resource/rabbitmq_resource_builder.go
+++ b/internal/resource/rabbitmq_resource_builder.go
@@ -22,6 +22,7 @@ type RabbitmqResourceBuilder struct {
 type ResourceBuilder interface {
 	Update(runtime.Object) error
 	Build() (runtime.Object, error)
+	UpdateRequiresStsRestart() bool
 }
 
 func (builder *RabbitmqResourceBuilder) ResourceBuilders() ([]ResourceBuilder, error) {
@@ -30,6 +31,7 @@ func (builder *RabbitmqResourceBuilder) ResourceBuilders() ([]ResourceBuilder, e
 		builder.ClientService(),
 		builder.ErlangCookie(),
 		builder.AdminSecret(),
+		builder.RabbitmqPluginsConfigMap(),
 		builder.ServerConfigMap(),
 		builder.ServiceAccount(),
 		builder.Role(),

--- a/internal/resource/rabbitmq_resource_builder_test.go
+++ b/internal/resource/rabbitmq_resource_builder_test.go
@@ -48,7 +48,7 @@ var _ = Describe("RabbitmqResourceBuilder", func() {
 			resourceBuilders, err := builder.ResourceBuilders()
 			Expect(err).NotTo(HaveOccurred())
 
-			expectedLen := 9
+			expectedLen := 10
 			Expect(len(resourceBuilders)).To(Equal(expectedLen))
 
 			expectedBuildersInOrder := []ResourceBuilder{
@@ -56,6 +56,7 @@ var _ = Describe("RabbitmqResourceBuilder", func() {
 				&ClientServiceBuilder{},
 				&ErlangCookieBuilder{},
 				&AdminSecretBuilder{},
+				&RabbitmqPluginsConfigMapBuilder{},
 				&ServerConfigMapBuilder{},
 				&ServiceAccountBuilder{},
 				&RoleBuilder{},

--- a/internal/resource/rabbitmq_resource_builder_test.go
+++ b/internal/resource/rabbitmq_resource_builder_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"
+	. "github.com/rabbitmq/cluster-operator/internal/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
@@ -47,27 +48,24 @@ var _ = Describe("RabbitmqResourceBuilder", func() {
 			resourceBuilders, err := builder.ResourceBuilders()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(len(resourceBuilders)).To(Equal(9))
+			expectedLen := 9
+			Expect(len(resourceBuilders)).To(Equal(expectedLen))
 
-			var ok bool
-			_, ok = resourceBuilders[0].(*resource.HeadlessServiceBuilder)
-			Expect(ok).Should(BeTrue())
-			_, ok = resourceBuilders[1].(*resource.ClientServiceBuilder)
-			Expect(ok).Should(BeTrue())
-			_, ok = resourceBuilders[2].(*resource.ErlangCookieBuilder)
-			Expect(ok).Should(BeTrue())
-			_, ok = resourceBuilders[3].(*resource.AdminSecretBuilder)
-			Expect(ok).Should(BeTrue())
-			_, ok = resourceBuilders[4].(*resource.ServerConfigMapBuilder)
-			Expect(ok).Should(BeTrue())
-			_, ok = resourceBuilders[5].(*resource.ServiceAccountBuilder)
-			Expect(ok).Should(BeTrue())
-			_, ok = resourceBuilders[6].(*resource.RoleBuilder)
-			Expect(ok).Should(BeTrue())
-			_, ok = resourceBuilders[7].(*resource.RoleBindingBuilder)
-			Expect(ok).Should(BeTrue())
-			_, ok = resourceBuilders[8].(*resource.StatefulSetBuilder)
-			Expect(ok).Should(BeTrue())
+			expectedBuildersInOrder := []ResourceBuilder{
+				&HeadlessServiceBuilder{},
+				&ClientServiceBuilder{},
+				&ErlangCookieBuilder{},
+				&AdminSecretBuilder{},
+				&ServerConfigMapBuilder{},
+				&ServiceAccountBuilder{},
+				&RoleBuilder{},
+				&RoleBindingBuilder{},
+				&StatefulSetBuilder{},
+			}
+
+			for i := 0; i < expectedLen; i++ {
+				Expect(resourceBuilders[i]).To(BeAssignableToTypeOf(expectedBuildersInOrder[i]))
+			}
 		})
 	})
 })

--- a/internal/resource/role.go
+++ b/internal/resource/role.go
@@ -31,6 +31,10 @@ func (builder *RabbitmqResourceBuilder) Role() *RoleBuilder {
 	}
 }
 
+func (builder *RoleBuilder) UpdateRequiresStsRestart() bool {
+	return false
+}
+
 func (builder *RoleBuilder) Update(object runtime.Object) error {
 	role := object.(*rbacv1.Role)
 	role.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/role_binding.go
+++ b/internal/resource/role_binding.go
@@ -32,6 +32,10 @@ func (builder *RabbitmqResourceBuilder) RoleBinding() *RoleBindingBuilder {
 	}
 }
 
+func (builder *RoleBindingBuilder) UpdateRequiresStsRestart() bool {
+	return false
+}
+
 func (builder *RoleBindingBuilder) Update(object runtime.Object) error {
 	roleBinding := object.(*rbacv1.RoleBinding)
 	roleBinding.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/service_account.go
+++ b/internal/resource/service_account.go
@@ -31,6 +31,10 @@ func (builder *RabbitmqResourceBuilder) ServiceAccount() *ServiceAccountBuilder 
 	}
 }
 
+func (builder *ServiceAccountBuilder) UpdateRequiresStsRestart() bool {
+	return false
+}
+
 func (builder *ServiceAccountBuilder) Update(object runtime.Object) error {
 	serviceAccount := object.(*corev1.ServiceAccount)
 	serviceAccount.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -833,6 +833,16 @@ var _ = Describe("StatefulSet", func() {
 					},
 				},
 				corev1.Volume{
+					Name: "plugins-conf",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: instance.ChildResourceName("plugins-conf"),
+							},
+						},
+					},
+				},
+				corev1.Volume{
 					Name: "rabbitmq-etc",
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
@@ -923,7 +933,7 @@ var _ = Describe("StatefulSet", func() {
 					"cp /tmp/erlang-cookie-secret/.erlang.cookie /var/lib/rabbitmq/.erlang.cookie " +
 					"&& chown 999:999 /var/lib/rabbitmq/.erlang.cookie " +
 					"&& chmod 600 /var/lib/rabbitmq/.erlang.cookie ; " +
-					"cp /tmp/rabbitmq/enabled_plugins /etc/rabbitmq/enabled_plugins " +
+					"cp /tmp/rabbitmq-plugins/enabled_plugins /etc/rabbitmq/enabled_plugins " +
 					"&& chown 999:999 /etc/rabbitmq/enabled_plugins",
 			}))
 
@@ -932,6 +942,11 @@ var _ = Describe("StatefulSet", func() {
 					Name:      "server-conf",
 					MountPath: "/tmp/rabbitmq/",
 				},
+				corev1.VolumeMount{
+					Name:      "plugins-conf",
+					MountPath: "/tmp/rabbitmq-plugins/",
+				},
+
 				corev1.VolumeMount{
 					Name:      "rabbitmq-etc",
 					MountPath: "/etc/rabbitmq/",


### PR DESCRIPTION
This closes #224, #259

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
- Create a new plugins builder
- Add it to the ordered list of builder alongwith the server configmap
- Add new configmap for plugins to sts
- Refactor annotations and add unit tests
- Updates the plugins before updating server conf
- Modifies controller to restart stateful set based on the builder
- Refactors controller tests to remove duplication

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
