### PR TITLE
Remove tolerations

### DIFF
--- a/cr-example.yaml
+++ b/cr-example.yaml
@@ -19,5 +19,3 @@ spec:
       memory: 2Gi
   service:
     type: ClusterIP
-  tolerations:
-  - {}


### PR DESCRIPTION
Before this commit, when deploying this example on a kind cluster, no pod got created and the stateful set contains the following event:

```
Warning  FailedCreate      103s (x19 over 23m)  statefulset-controller  create Pod example-rabbitmq-server-0 in StatefulSet example-rabbitmq-server failed error: Pod "example-rabbitmq-server-0" is invalid: spec.tolerations[0].operator: Invalid value: "": operator must be Exists when `key` is empty, which means "match all values and all keys"
```

After this commit, deploying works.