### PR TITLE
Make CRD k8s 1.18 compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ manifests: controller-gen ## Generate manifests e.g. CRD, RBAC etc.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=operator-role paths="./api/...;./controllers/..." output:crd:artifacts:config=config/crd/bases
 	./hack/add-notice-to-yaml.sh config/rbac/role.yaml
 	./hack/add-notice-to-yaml.sh config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+# this is temporary workaround due to issue https://github.com/kubernetes/kubernetes/issues/91395
+# the hack ensures that "protocal" is a required value where this field is listed as x-kubernetes-list-map-keys
+# without the hack, our crd doesn't install on k8s 1.18 because of the issue above
+	./hack/patch-crd.sh
 
 # Run go fmt against code
 fmt:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Manage [RabbitMQ](https://www.rabbitmq.com/) clusters deployed to [Kubernetes](h
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.8.5`, and requires a Kubernetes cluster of `1.16` or `1.17`.
-`RabbitmqCluster` CRD cannot be installed in a Kubernetes `1.18` cluster because of a schema validation that ensures that properties defined as `list-map-keys` must either be required or have a default value ([related github issue](https://github.com/kubernetes/kubernetes/issues/91395)).
+The operator deploys RabbitMQ `3.8.5`, and requires a Kubernetes cluster of `1.16` or above.
 
 ## Quickstart
 

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -811,6 +811,7 @@ spec:
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -2543,6 +2544,7 @@ spec:
                                                 type: string
                                             required:
                                             - containerPort
+                                            - protocol
                                             type: object
                                           type: array
                                           x-kubernetes-list-map-keys:
@@ -5286,6 +5288,7 @@ spec:
                                                 type: string
                                             required:
                                             - containerPort
+                                            - protocol
                                             type: object
                                           type: array
                                           x-kubernetes-list-map-keys:

--- a/hack/crd-patch.json
+++ b/hack/crd-patch.json
@@ -1,0 +1,5 @@
+[
+    { "op": "replace", "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/override/properties/statefulSet/properties/spec/properties/template/properties/spec/properties/containers/items/properties/ports/items/required", "value": [ "containerPort", "protocol"]},
+        { "op": "replace", "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/override/properties/clientService/properties/spec/properties/ports/items/required", "value": [ "port", "protocol"]},
+    { "op": "replace", "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/override/properties/statefulSet/properties/spec/properties/template/properties/spec/properties/initContainers/items/properties/ports/items/required", "value": [ "containerPort", "protocol"]},
+]

--- a/hack/patch-crd.sh
+++ b/hack/patch-crd.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl patch -f config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml -p "$(cat hack/crd-patch.json)" --type json --local  -o yaml > /tmp/rabbitmq.com_rabbitmqclusters.yaml
+mv /tmp/rabbitmq.com_rabbitmqclusters.yaml config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml


### PR DESCRIPTION
This closes #230

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Add a workaround to make our crd 1.18 compatible.

There could be a upstream fix coming. However, we are unsure about their timeline, and I decide to add this workaround for now, so that we are not blocked.

## Additional Context

I looked at alternatives, like using `sed`. However, I think kubectl patch with jsonpatch is more readable here.

Related k8s issue: https://github.com/kubernetes/kubernetes/issues/91395

## Local Testing

`make install` succeeds on a local `1.18` kind cluster
