### PR TITLE
Add distribution port to headless service

### DIFF
--- a/internal/resource/headless_service.go
+++ b/internal/resource/headless_service.go
@@ -57,6 +57,11 @@ func (builder *HeadlessServiceBuilder) Update(object runtime.Object) error {
 				Port:     4369,
 				Name:     "epmd",
 			},
+			{
+				Protocol: corev1.ProtocolTCP,
+				Port:     25672,
+				Name:     "cluster-links", // aka distribution port
+			},
 		},
 		PublishNotReadyAddresses: true,
 	}

--- a/internal/resource/headless_service_test.go
+++ b/internal/resource/headless_service_test.go
@@ -178,6 +178,11 @@ var _ = Describe("HeadlessService", func() {
 						Port:     4369,
 						Name:     "epmd",
 					},
+					{
+						Protocol: corev1.ProtocolTCP,
+						Port:     25672,
+						Name:     "cluster-links",
+					},
 				},
 				PublishNotReadyAddresses: true,
 			}


### PR DESCRIPTION
As pointed out in #269 this port is used for inter-node communication.

See also
* https://github.com/rabbitmq/diy-kubernetes-examples/commit/62ee5952114f894e490d39a8580b93f515184b4f
* https://www.rabbitmq.com/networking.html#epmd-inet-dist-port-range