### PR TITLE
Add minor version pinning to controller-runtime dependencies.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,12 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  ignore:
+    - dependency-name: "k8s.io/api"
+      versions: ["0.18.x", "0.19.x"]
+    - dependency-name: "k8s.io/api-machinery"
+      versions: ["0.18.x", "0.19.x"]
+    - dependency-name: "k8s.io/client-go"
+      versions: ["0.18.x", "0.19.x"]
+    - dependency-name: "github.com/go-logr/logr"
+      versions: ["0.2.x"]


### PR DESCRIPTION
This closes #286 

## Summary Of Changes
Pins minor versions of controller-runtime dependencies. In particular, pins
k8s.io/api to 0.17.*
k8s.io/api-machinery to 0.17.*
k8s.io/client-go to 0.17.*
github.com/go-logr/logr to 0.1.*

## Additional Context
These are controller-runtime dependencies and should not be bumped without bumping controller-runtime. When controller-runtime is bumped, the pinned versions must also be updated.
