### PR TITLE
Avoid dirty git state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ deploy-manager:  ## Deploy manager
 
 deploy-manager-dev:
 	kustomize build config/crd | kubectl apply -f -
-	kustomize build config/default/overlays/dev | kubectl apply -f -
+	kustomize build config/default/overlays/dev | sed 's@((operator_docker_image))@"$(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT)"@' | kubectl apply -f -
 
 deploy-sample: ## Deploy RabbitmqCluster defined in config/sample/base
 	kustomize build config/samples/base | kubectl apply -f -
@@ -82,13 +82,13 @@ deploy-namespace-rbac:
 
 deploy: manifests deploy-namespace-rbac deploy-manager ## Deploy operator in the configured Kubernetes cluster in ~/.kube/config
 
-deploy-dev: check-env-docker-credentials docker-build-dev patch-dev manifests deploy-namespace-rbac docker-registry-secret deploy-manager-dev ## Deploy operator in the configured Kubernetes cluster in ~/.kube/config, with local changes
+deploy-dev: check-env-docker-credentials docker-build-dev manifests deploy-namespace-rbac docker-registry-secret deploy-manager-dev ## Deploy operator in the configured Kubernetes cluster in ~/.kube/config, with local changes
 
-deploy-kind: check-env-docker-repo git-commit-sha patch-kind manifests deploy-namespace-rbac ## Load operator image and deploy operator into current KinD cluster
+deploy-kind: check-env-docker-repo git-commit-sha manifests deploy-namespace-rbac ## Load operator image and deploy operator into current KinD cluster
 	docker build --build-arg=GIT_COMMIT=$(GIT_COMMIT) -t $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT) .
 	kind load docker-image $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT)
 	kustomize build config/crd | kubectl apply -f -
-	kustomize build config/default/overlays/kind | kubectl apply -f -
+	kustomize build config/default/overlays/kind | sed 's@((operator_docker_image))@"$(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT)"@' | kubectl apply -f -
 
 generate-installation-manifests:
 	mkdir -p installation
@@ -113,22 +113,14 @@ docker-push: check-env-docker-repo
 
 git-commit-sha:
 ifeq ("", git diff --stat)
-GIT_COMMIT="$(shell git rev-parse --short HEAD)"
+GIT_COMMIT=$(shell git rev-parse --short HEAD)
 else
-GIT_COMMIT="$(shell git rev-parse --short HEAD)-"
+GIT_COMMIT=$(shell git rev-parse --short HEAD)-
 endif
 
 docker-build-dev: check-env-docker-repo  git-commit-sha
 	docker build --build-arg=GIT_COMMIT=$(GIT_COMMIT) -t $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT) .
 	docker push $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT)
-
-patch-dev: check-env-docker-repo  git-commit-sha
-	@echo "updating kustomize image patch file for manager resource"
-	sed -i'' -e 's@image: .*@image: '"$(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT)"'@' ./config/default/overlays/dev/manager_image_patch.yaml
-
-patch-kind: check-env-docker-repo  git-commit-sha
-	@echo "updating kustomize image patch file for manager resource"
-	sed -i'' -e 's@image: .*@image: '"$(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT)"'@' ./config/default/overlays/kind/manager_image_patch.yaml
 
 kind-prepare: ## Prepare KIND to support LoadBalancer services
 	# Note that created LoadBalancer services will have an unreachable external IP

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -1,3 +1,13 @@
+# RabbitMQ Cluster Operator
+#
+# Copyright 2020 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Mozilla Public license, Version 2.0 (the "License").  You may not use this product except in compliance with the Mozilla Public License.
+#
+# This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -1,13 +1,3 @@
-# RabbitMQ Cluster Operator
-#
-# Copyright 2020 VMware, Inc. All Rights Reserved.
-#
-# This product is licensed to you under the Mozilla Public license, Version 2.0 (the "License").  You may not use this product except in compliance with the Mozilla Public License.
-#
-# This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
-
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/default/overlays/dev/manager_image_patch.yaml
+++ b/config/default/overlays/dev/manager_image_patch.yaml
@@ -14,7 +14,6 @@ spec:
   template:
     spec:
       containers:
-      # Change the value of image field below to your controller image URL
-      - image: dev.registry.pivotal.io/p-rabbitmq-for-kubernetes/rabbitmq-for-kubernetes-operator:e89ed15-
+      - image: ((operator_docker_image))
         name: operator
         imagePullPolicy: Always

--- a/config/default/overlays/kind/manager_image_patch.yaml
+++ b/config/default/overlays/kind/manager_image_patch.yaml
@@ -14,7 +14,6 @@ spec:
   template:
     spec:
       containers:
-      # Change the value of image field below to your controller image URL
-      - image: dev.registry.pivotal.io/p-rabbitmq-for-kubernetes/rabbitmq-for-kubernetes-operator:5a5e6bf-
+      - image: ((operator_docker_image))
         name: operator
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Before this commit, when running `make deploy-dev` or `make deploy-kind` the files `config/default/overlays/dev/manager_image_patch.yaml` and `config/default/overlays/kind/manager_image_patch.yaml` showed local changes.

After this commit the git state won't be dirty anymore.