### PR TITLE
Fix perf-test argument passing

### DIFF
--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -79,7 +79,7 @@ perf_test() {
         --labels="app=perf-test,run=perf-test" \
         --image=pivotalrabbitmq/perf-test \
         -- --uri "amqp://${username}:${password}@${service}" \
-        --metrics-prometheus "${perftestopts}"
+        --metrics-prometheus ${perftestopts}
 }
 
 manage() {


### PR DESCRIPTION
I wanted to use the plugin to run perf test with `--rate 100` but perf-test failed to start with `Parsing failed. Reason: Unrecognized option: --rate 100`. While this change introduces a shellcheck warning, it is actually correct.