### PR TITLE
Support OpenShift

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -109,6 +109,12 @@ rules:
 - apiGroups:
   - rabbitmq.com
   resources:
+  - rabbitmqclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - rabbitmq.com
+  resources:
   - rabbitmqclusters/status
   verbs:
   - get

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -75,13 +75,13 @@ type RabbitmqClusterReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
 // +kubebuilder:rbac:groups="",resources=pods,verbs=update;get;list;watch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;watch
+// +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;watch;list
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups="",resources=endpoints,verbs=list
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters/status,verbs=get;update
+// +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;create;patch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update

--- a/go.mod
+++ b/go.mod
@@ -28,5 +28,6 @@ require (
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6
+	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
 	sigs.k8s.io/controller-runtime v0.6.2
 )

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const statefulSetSuffix   = "server"
+const statefulSetSuffix = "server"
 
 var _ = Describe("Operator", func() {
 	var (


### PR DESCRIPTION
Fixes #234 

### Changes:
1. Allow `rabbitmq-cluster-operator-role` to update `rabbitmqclusters/finalizers`
2. Do not `BlockOwnerDeletion` for PVCs (as done in https://github.com/elastic/cloud-on-k8s/pull/1891)
3. Change group owner of `/var/lib/rabbitmq/mnesia/` to `999`

### Docs:
https://github.com/ansd/rabbitmq-website/tree/k8s-openshift (need to create PR)

### Testing on OpenShift:
If you don't have an OpenShift cluster available, the easiest way to set one up within a few minutes is [CodeReady Containers](https://developers.redhat.com/products/codeready-containers/overview).

* Download CodeReady Containers
* `crc setup`
*  `crc config set memory 12000` (the default of 8192 MiB is too low to run the RabbitMQ operator and a RabbitMQ cluster instance since there isn't much memory left when starting crc)
* `crc start`
* `eval $(crc oc-env)`
* `oc login -u kubeadmin -p <password> https://api.crc.testing:6443`
* `make deploy-dev`
* Operator won’t deploy because
```
$ kubectl describe replicasets.apps
...
Events:
  Type     Reason        Age                From                   Message
  ----     ------        ----               ----                   -------
  Warning  FailedCreate  9s (x13 over 29s)  replicaset-controller  Error creating: pods "rabbitmq-cluster-rabbitmq-cluster-operator-6bb8fd7bf8-" is forbidden: unable to validate against any security context constraint: [fsGroup: Invalid value: []int64{1000}: 1000 is not an allowed group spec.containers[0].securityContext.securityContext.runAsUser: Invalid value: 1000: must be in the ranges: [1000610000, 1000619999]]
```
* As explained [here](https://access.redhat.com/solutions/2801791): `oc edit namespace rabbitmq-system` Change the `uid-range` and `supplemental-groups` for the operator:
```
apiVersion: v1
kind: Namespace
metadata:
  annotations:
...
    openshift.io/sa.scc.supplemental-groups: 1000/1
    openshift.io/sa.scc.uid-range: 1000/1
```
* Operator deploys successfully
* Change the `uid-range` and `supplemental-groups` for RabbitMQ (here we assume that the RabbitMQ cluster gets deployed into the `default` namespace):
`oc edit namespace default`
```
apiVersion: v1
kind: Namespace
metadata:
  annotations:
...
    openshift.io/sa.scc.supplemental-groups: 999/1
    openshift.io/sa.scc.uid-range: 999/1
```
* Create a RabbitMQ cluster instance `kubectl rabbitmq create test` in the `default` namespace.
* **Before this PR service creation fails because**
```
kubectl describe rabbitmqclusters.rabbitmq.com
...
Status:
  Conditions:
    Message:               services "test-rabbitmq-headless" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
    Reason:                Error
    Status:                False
    Type:                  ReconcileSuccess
```
**Fixed by change 1 above.**
* **Before this PR pod creation fails because**
```
kubectl describe statefulsets.apps
...
Events:
  Type     Reason        Age                 From                    Message
  ----     ------        ----                ----                    -------
  Warning  FailedCreate  72s (x12 over 83s)  statefulset-controller  create Pod test-rabbitmq-server-0 in StatefulSet test-rabbitmq-server failed error: failed to create PVC persistence-test-rabbitmq-server-0: persistentvolumeclaims "persistence-test-rabbitmq-server-0" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```
**Fixed by change 2 above.**
* **Before this PR pod fails because**
```
kubectl logs test-rabbitmq-server-0
10:05:14.190 [warning] Failed to write PID file "/var/lib/rabbitmq/mnesia/rabbit@test-rabbitmq-server-0.test-rabbitmq-headless.default.pid": permission denied
```
**Fixed by change 3 above.**
* RabbitMQ instance deploys successfully

I tested the above steps with the changes on this branch against
```
crc version
CodeReady Containers version: 1.15.0+e317bed
OpenShift version: 4.5.7 (embedded in binary)
```