### PR TITLE
Preserve copyright notice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ integration-tests: generate fmt vet manifests ## Run integration tests
 manifests: controller-gen ## Generate manifests e.g. CRD, RBAC etc.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=operator-role paths="./api/...;./controllers/..." output:crd:artifacts:config=config/crd/bases
 	./hack/add-notice-to-yaml.sh config/rbac/role.yaml
-	./hack/add-notice-to-yaml.sh config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
 # this is temporary workaround due to issue https://github.com/kubernetes/kubernetes/issues/91395
 # the hack ensures that "protocal" is a required value where this field is listed as x-kubernetes-list-map-keys
 # without the hack, our crd doesn't install on k8s 1.18 because of the issue above
 	./hack/patch-crd.sh
+	./hack/add-notice-to-yaml.sh config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
 
 # Run go fmt against code
 fmt:

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -6,8 +6,6 @@
 #
 # This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
 
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Before this commit `make manifests` removed the copyright notice from `config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml`.

After this commit, the copyright notice is preserved.