### PR TITLE
Do not log OperationResultNone

### DIFF
--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -423,11 +423,14 @@ func (r *RabbitmqClusterReconciler) exec(namespace, podName, containerName strin
 // logAndRecordOperationResult - helper function to log and record events with message and error
 // it logs and records 'updated' and 'created' OperationResult, and ignores OperationResult 'unchanged'
 func (r *RabbitmqClusterReconciler) logAndRecordOperationResult(rmq runtime.Object, resource runtime.Object, operationResult controllerutil.OperationResult, err error) {
+	if operationResult == controllerutil.OperationResultNone && err == nil {
+		return
+	}
+
 	var operation string
 	if operationResult == controllerutil.OperationResultCreated {
 		operation = "create"
 	}
-
 	if operationResult == controllerutil.OperationResultUpdated {
 		operation = "update"
 	}


### PR DESCRIPTION
Before this PR, many unnecessary lines are logged and events created:
```
2020-09-02T12:41:00.273Z        INFO    rabbitmqcluster-controller      d resource definition-rabbitmq-plugins-conf of Type *v1.ConfigMap
2020-09-02T12:41:00.273Z        DEBUG   controller-runtime.manager.events       Normal  {"object": {"kind":"RabbitmqCluster","namespace":"default","name":"definition","uid":"72e2f4c4-5002-4eb0-9d4e-e0d34b778000","apiVersion":"rabbitmq.com/v1beta1","resourceVersion":"4909"}, "reason": "Successful", "message": "d resource definition-rabbitmq-plugins-conf of Type *v1.ConfigMap"}
2020-09-02T12:41:00.274Z        INFO    rabbitmqcluster-controller      d resource definition-rabbitmq-server-conf of Type *v1.ConfigMap
2020-09-02T12:41:00.274Z        DEBUG   controller-runtime.manager.events       Normal  {"object": {"kind":"RabbitmqCluster","namespace":"default","name":"definition","uid":"72e2f4c4-5002-4eb0-9d4e-e0d34b778000","apiVersion":"rabbitmq.com/v1beta1","resourceVersion":"4909"}, "reason": "Successful", "message": "d resource definition-rabbitmq-server-conf of Type *v1.ConfigMap"}
2020-09-02T12:41:00.274Z        INFO    rabbitmqcluster-controller      d resource definition-rabbitmq-server of Type *v1.ServiceAccount
2020-09-02T12:41:00.275Z        DEBUG   controller-runtime.manager.events       Normal  {"object": {"kind":"RabbitmqCluster","namespace":"default","name":"definition","uid":"72e2f4c4-5002-4eb0-9d4e-e0d34b778000","apiVersion":"rabbitmq.com/v1beta1","resourceVersion":"4909"}, "reason": "Successful", "message": "d resource definition-rabbitmq-server of Type *v1.ServiceAccount"}
2020-09-02T12:41:00.275Z        INFO    rabbitmqcluster-controller      d resource definition-rabbitmq-peer-discovery of Type *v1.Role
2020-09-02T12:41:00.276Z        DEBUG   controller-runtime.manager.events       Normal  {"object": {"kind":"RabbitmqCluster","namespace":"default","name":"definition","uid":"72e2f4c4-5002-4eb0-9d4e-e0d34b778000","apiVersion":"rabbitmq.com/v1beta1","resourceVersion":"4909"}, "reason": "Successful", "message": "d resource definition-rabbitmq-peer-discovery of Type *v1.Role"}
2020-09-02T12:41:00.276Z        INFO    rabbitmqcluster-controller      d resource definition-rabbitmq-server of Type *v1.RoleBinding
2020-09-02T12:41:00.277Z        DEBUG   controller-runtime.manager.events       Normal  {"object": {"kind":"RabbitmqCluster","namespace":"default","name":"definition","uid":"72e2f4c4-5002-4eb0-9d4e-e0d34b778000","apiVersion":"rabbitmq.com/v1beta1","resourceVersion":"4909"}, "reason": "Successful", "message": "d resource definition-rabbitmq-server of Type *v1.RoleBinding"}
```

After this PR, these `unchanged` operation results are not logged anymore.
Instead only `created` and `updated` operation results are logged.