### PR TITLE
Do not exec into pods during rolling update

### DIFF
--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -167,16 +167,16 @@ var _ = Describe("RabbitmqclusterController", func() {
 			})
 			By("recording SuccessfullCreate events for all child resources", func() {
 				allEventMsgs := aggregateEventMsgs(ctx, rabbitmqCluster, "SuccessfulCreate")
-				Expect(allEventMsgs).To(ContainSubstring(fmt.Sprintf("created resource %s of Type *v1.StatefulSet", rabbitmqCluster.ChildResourceName("server"))))
-				Expect(allEventMsgs).To(ContainSubstring(fmt.Sprintf("created resource %s of Type *v1.Service", rabbitmqCluster.ChildResourceName("client"))))
-				Expect(allEventMsgs).To(ContainSubstring(fmt.Sprintf("created resource %s of Type *v1.Service", rabbitmqCluster.ChildResourceName("headless"))))
-				Expect(allEventMsgs).To(ContainSubstring(fmt.Sprintf("created resource %s of Type *v1.ConfigMap", rabbitmqCluster.ChildResourceName("plugins-conf"))))
-				Expect(allEventMsgs).To(ContainSubstring(fmt.Sprintf("created resource %s of Type *v1.ConfigMap", rabbitmqCluster.ChildResourceName("server-conf"))))
-				Expect(allEventMsgs).To(ContainSubstring(fmt.Sprintf("created resource %s of Type *v1.Secret", rabbitmqCluster.ChildResourceName("erlang-cookie"))))
-				Expect(allEventMsgs).To(ContainSubstring(fmt.Sprintf("created resource %s of Type *v1.Secret", rabbitmqCluster.ChildResourceName("admin"))))
-				Expect(allEventMsgs).To(ContainSubstring(fmt.Sprintf("created resource %s of Type *v1.ServiceAccount", rabbitmqCluster.ChildResourceName("server"))))
-				Expect(allEventMsgs).To(ContainSubstring(fmt.Sprintf("created resource %s of Type *v1.Role", rabbitmqCluster.ChildResourceName("peer-discovery"))))
-				Expect(allEventMsgs).To(ContainSubstring(fmt.Sprintf("created resource %s of Type *v1.RoleBinding", rabbitmqCluster.ChildResourceName("server"))))
+				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.StatefulSet", rabbitmqCluster.ChildResourceName("server")))
+				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.Service", rabbitmqCluster.ChildResourceName("client")))
+				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.Service", rabbitmqCluster.ChildResourceName("headless")))
+				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.ConfigMap", rabbitmqCluster.ChildResourceName("plugins-conf")))
+				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.ConfigMap", rabbitmqCluster.ChildResourceName("server-conf")))
+				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.Secret", rabbitmqCluster.ChildResourceName("erlang-cookie")))
+				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.Secret", rabbitmqCluster.ChildResourceName("admin")))
+				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.ServiceAccount", rabbitmqCluster.ChildResourceName("server")))
+				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.Role", rabbitmqCluster.ChildResourceName("peer-discovery")))
+				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.RoleBinding", rabbitmqCluster.ChildResourceName("server")))
 			})
 
 			By("adding the deletion finalizer", func() {
@@ -665,7 +665,7 @@ var _ = Describe("RabbitmqclusterController", func() {
 
 			// verify that SuccessfulUpdate event is recorded for the client service
 			Expect(aggregateEventMsgs(ctx, rabbitmqCluster, "SuccessfulUpdate")).To(
-				ContainSubstring(fmt.Sprintf("updated resource %s of Type *v1.Service", rabbitmqCluster.ChildResourceName("client"))))
+				ContainSubstring("updated resource %s of Type *v1.Service", rabbitmqCluster.ChildResourceName("client")))
 		})
 
 		It("the CPU and memory requirements are updated", func() {
@@ -699,7 +699,7 @@ var _ = Describe("RabbitmqclusterController", func() {
 
 			// verify that SuccessfulUpdate event is recorded for the StatefulSet
 			Expect(aggregateEventMsgs(ctx, rabbitmqCluster, "SuccessfulUpdate")).To(
-				ContainSubstring(fmt.Sprintf("updated resource %s of Type *v1.StatefulSet", rabbitmqCluster.ChildResourceName("server"))))
+				ContainSubstring("updated resource %s of Type *v1.StatefulSet", rabbitmqCluster.ChildResourceName("server")))
 		})
 
 		It("the rabbitmq image is updated", func() {

--- a/go.sum
+++ b/go.sum
@@ -702,6 +702,7 @@ google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1 h1:q4XQuHFC6I28BKZpo6IYyb3mNO+l7lSOxRuYTCiDfXk=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -50,7 +50,7 @@ func (builder *RabbitmqResourceBuilder) ServerConfigMap() *ServerConfigMapBuilde
 }
 
 func (builder *ServerConfigMapBuilder) UpdateRequiresStsRestart() bool {
-	return true
+	return true // because rabbitmq.conf and advanced.config changes take effect only after a node restart
 }
 
 func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {

--- a/internal/resource/rabbitmq_plugins.go
+++ b/internal/resource/rabbitmq_plugins.go
@@ -16,7 +16,7 @@ var requiredPlugins = []string{
 	"rabbitmq_management",
 }
 
-const pluginsConfig = "plugins-conf"
+const PluginsConfig = "plugins-conf"
 
 type RabbitmqPlugins struct {
 	requiredPlugins   []string
@@ -82,7 +82,7 @@ func (builder *RabbitmqPluginsConfigMapBuilder) Update(object runtime.Object) er
 func (builder *RabbitmqPluginsConfigMapBuilder) Build() (runtime.Object, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      builder.Instance.ChildResourceName(pluginsConfig),
+			Name:      builder.Instance.ChildResourceName(PluginsConfig),
 			Namespace: builder.Instance.Namespace,
 		},
 		Data: map[string]string{

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -291,7 +291,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: builder.Instance.ChildResourceName(pluginsConfig),
+						Name: builder.Instance.ChildResourceName(PluginsConfig),
 					},
 				},
 			},

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -17,13 +17,15 @@ import (
 	"gopkg.in/ini.v1"
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
-	"github.com/rabbitmq/cluster-operator/internal/resource"
 	corev1 "k8s.io/api/core/v1"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const statefulSetSuffix = "server"
+const (
+	statefulSetSuffix = "server"
+	pluginsConfig     = "plugins-conf"
+)
 
 var _ = Describe("Operator", func() {
 	var (
@@ -139,7 +141,7 @@ var _ = Describe("Operator", func() {
 				})).To(Succeed())
 
 				getConfigMapAnnotations := func() map[string]string {
-					configMapName := cluster.ChildResourceName(resource.PluginsConfig)
+					configMapName := cluster.ChildResourceName(pluginsConfig)
 					configMap, err := clientSet.CoreV1().ConfigMaps(cluster.Namespace).Get(ctx, configMapName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return configMap.Annotations


### PR DESCRIPTION
This closes #304

Exec into pods only if StatefulSet is ready and up to date.

Before this commit, we observed in #304 that the controller tried to exec into pods at the same time as the pods got updated due to a StatefulSet restart resulting in connection errors.

The main change is to not set plugins if
```
sts.Status.ReadyReplicas < desiredReplicas || sts.Status.UpdatedReplicas < desiredReplicas
```
because during a StatefulSet restart, it happened multiple times in #304 that since `sts.Status.ReadyReplicas == desiredReplicas`, the `exec` commands got executed and the connection got interrupted because the pod got updated.

The main finding is that `sts.Status.ReadyReplicas == desiredReplicas` can be `true` although the StatefulSet rolling update is still ongoing:
```
$ while true; do  kubectl get statefulsets.apps definition-rabbitmq-server --template={{.status}}; echo "" ; sleep 1; done

map[collisionCount:0 currentReplicas:2 currentRevision:definition-rabbitmq-server-56b65fdc4f observedGeneration:5 readyReplicas:3 replicas:3 updateRevision:definition-rabbitmq-server-6f667f5f7d]
…
map[collisionCount:0 currentReplicas:2 currentRevision:definition-rabbitmq-server-56b65fdc4f observedGeneration:5 readyReplicas:2 replicas:3 updateRevision:definition-rabbitmq-server-6f667f5f7d]
…
map[collisionCount:0 currentReplicas:2 currentRevision:definition-rabbitmq-server-56b65fdc4f observedGeneration:5 readyReplicas:2 replicas:3 updateRevision:definition-rabbitmq-server-6f667f5f7d updatedReplicas:1]
…
map[collisionCount:0 currentReplicas:1 currentRevision:definition-rabbitmq-server-56b65fdc4f observedGeneration:5 readyReplicas:3 replicas:3 updateRevision:definition-rabbitmq-server-6f667f5f7d updatedReplicas:1]
…
map[collisionCount:0 currentReplicas:1 currentRevision:definition-rabbitmq-server-56b65fdc4f observedGeneration:5 readyReplicas:2 replicas:3 updateRevision:definition-rabbitmq-server-6f667f5f7d updatedReplicas:1]
…
map[collisionCount:0 currentReplicas:1 currentRevision:definition-rabbitmq-server-56b65fdc4f observedGeneration:5 readyReplicas:2 replicas:3 updateRevision:definition-rabbitmq-server-6f667f5f7d updatedReplicas:2]
…
```

Thank you @Gsantomaggio for helping troubleshooting 🙂