### PR TITLE
Run tests for PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,38 @@
+name: PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  unit_integration_tests:
+    name: unit and integration tests
+    runs-on: ubuntu-latest
+    container: us.gcr.io/cf-rabbitmq-for-k8s-bunny/rabbitmq-for-kubernetes-ci
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Unit tests
+      run: make unit-tests
+    - name: Integration tests
+      run: make integration-tests
+    - name: Helm chart tests
+      working-directory: charts/rabbitmq
+      run: ./test.sh
+
+  system_tests:
+    name: system tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: System tests
+      run: |
+        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+        export GOPATH=$HOME/go
+        export PATH=$PATH:$GOPATH/bin
+        make install-tools
+        kind create cluster
+        DOCKER_REGISTRY_SERVER=local-server OPERATOR_IMAGE=local-operator make deploy-kind
+        make system-tests

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -389,6 +389,10 @@ CONSOLE_LOG=new`
 		BeforeEach(func() {
 			instanceName := "mqtt-stomp-rabbit"
 			cluster = generateRabbitmqCluster(namespace, instanceName)
+			cluster.Spec.Resources = &corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]k8sresource.Quantity{},
+				Limits:   map[corev1.ResourceName]k8sresource.Quantity{},
+			}
 			cluster.Spec.Service.Type = "NodePort"
 			cluster.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{
 				"rabbitmq_mqtt",


### PR DESCRIPTION
Run unit, integration, helm chart, and system tests tests.

Closes to #270

System tests run against a kind cluster on a GitHub hosted Ubuntu VM.

### Why not running the system tests against GKE?
This would require to add a GitHub secret with the GCP key file for authentication: `gcloud auth activate-service-account [ACCOUNT] --key-file=KEY_FILE`.
This comes with two drawbacks:
1. PRs opened by forks won't be able to access this secret. Therefore, the action wouldn't be able to authenticate with GCP:

> secrets are not passed to the runner when a workflow is triggered from a forked repository

see https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets

2. The key-file has JSON format. The same site states:

> avoid creating secrets that contain JSON

When (accidentally) printing that JSON, the private key doesn't get redacted and would be accessible in the logs by every GitHub user:

```
2020-09-11T10:08:35.8906119Z   ***
2020-09-11T10:08:35.8907179Z   ***
2020-09-11T10:08:35.8907513Z   ***
2020-09-11T10:08:35.8907954Z   "private_key": "-----BEGIN PRIVATE KEY-----
2020-09-11T10:08:35.8908275Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8908597Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8908933Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8909238Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8909666Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8909985Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8910305Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8910636Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8910940Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8911249Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8911554Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8912259Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8912576Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8912890Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8913224Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8913541Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8913856Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8914175Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8914549Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8914858Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8915171Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8915522Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8915828Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8916138Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8916473Z aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2020-09-11T10:08:35.8916771Z aaaaaaaaaaaaaaaaaaaaaaa=
2020-09-11T10:08:35.8917271Z -----END PRIVATE KEY-----
2020-09-11T10:08:35.8917549Z ",
2020-09-11T10:08:35.8918130Z   ***
2020-09-11T10:08:35.8918420Z   ***
2020-09-11T10:08:35.8918801Z   ***
2020-09-11T10:08:35.8919144Z   ***
2020-09-11T10:08:35.8919494Z   ***
2020-09-11T10:08:35.8920362Z   ***
2020-09-11T10:08:35.8920647Z ***
```

The solution in https://github.com/GoogleCloudPlatform/github-actions/issues/134 to base64 encode the secret isn't convincing.