### PR TITLE
Deploy rabbitmq 3.8.8 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Manage [RabbitMQ](https://www.rabbitmq.com/) clusters deployed to [Kubernetes](h
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.8.5`, and requires a Kubernetes cluster of `1.16` or above.
+The operator deploys RabbitMQ `3.8.8`, and requires a Kubernetes cluster of `1.16` or above.
 
 ## Versioning
 

--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	rabbitmqImage             string             = "rabbitmq:3.8.5"
+	rabbitmqImage             string             = "rabbitmq:3.8.8"
 	defaultPersistentCapacity string             = "10Gi"
 	defaultMemoryLimit        string             = "2Gi"
 	defaultCPULimit           string             = "2000m"

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -365,7 +365,7 @@ func generateRabbitmqClusterObject(clusterName string) *RabbitmqCluster {
 		},
 		Spec: RabbitmqClusterSpec{
 			Replicas: &one,
-			Image:    "rabbitmq:3.8.5",
+			Image:    "rabbitmq:3.8.8",
 			Service: RabbitmqClusterServiceSpec{
 				Type: "ClusterIP",
 			},

--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -33,7 +33,7 @@ usage() {
     echo "    kubectl rabbitmq delete INSTANCE ..."
     echo
     echo "  Create a RabbitMQ custom resource - INSTANCE name required, all other flags optional"
-    echo "    kubectl rabbitmq create INSTANCE --replicas 1 --service ClusterIP --image rabbitmq:3.8.5 --image-pull-secret mysecret"
+    echo "    kubectl rabbitmq create INSTANCE --replicas 1 --service ClusterIP --image rabbitmq:3.8.8 --image-pull-secret mysecret"
     echo
     echo "  Get a RabbitMQ custom resource and dependant objects"
     echo "    kubectl rabbitmq get INSTANCE"

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -11,7 +11,7 @@ name: rabbitmq
 description: RabbitMQ Cluster
 apiVersion: v2
 version: 0.8.0
-appVersion: 3.8.5
+appVersion: 3.8.8
 keywords:
 - rabbitmq
 - message queue


### PR DESCRIPTION
This closes #319 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Deploy rabbitmq 3.8.8 by default

## Additional Context

## Local Testing

Have run unit and integration tests