### PR TITLE
Short names for RabbitmqCluster resource

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -37,7 +37,7 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.clusterStatus"
-// +kubebuilder:resource:shortName={"rmq","rmqc"}
+// +kubebuilder:resource:shortName={"rmq"}
 type RabbitmqCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -37,6 +37,7 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.clusterStatus"
+// +kubebuilder:resource:shortName={"rmq","rmqc"}
 type RabbitmqCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -19,6 +19,9 @@ spec:
     kind: RabbitmqCluster
     listKind: RabbitmqClusterList
     plural: rabbitmqclusters
+    shortNames:
+    - rmq
+    - rmqc
     singular: rabbitmqcluster
   scope: Namespaced
   versions:

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -21,7 +21,6 @@ spec:
     plural: rabbitmqclusters
     shortNames:
     - rmq
-    - rmqc
     singular: rabbitmqcluster
   scope: Namespaced
   versions:


### PR DESCRIPTION
This PR has no related issue.

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
Provides short names `rmq` and `rmqc` as short version of `rabbitmqcluster`. 
The short hand `rc` is already taken by native object `ReplicationController`.

## Additional Context

Ever typo'ed `rabbitmqclsuter` or `rabbitqmclsuter`? Me too.
This PR allows to do `kubectl get rmq` or `kubectl get rmqc`. Never typo again!

## Local Testing

N/A no behavioural change, no change to how we deploy.