### PR TITLE
Configure default user/password through conf.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Manage [RabbitMQ](https://www.rabbitmq.com/) clusters deployed to [Kubernetes](h
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.8.8`, and requires a Kubernetes cluster of `1.16` or above.
+The operator deploys RabbitMQ `3.8.8` by default, and supports versions from `3.8.4` upwards. The operator requires a Kubernetes cluster of `1.16` or above.
 
 ## Versioning
 

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -1218,19 +1218,15 @@ var _ = Describe("RabbitmqclusterController", func() {
 					},
 				},
 				corev1.Volume{
-					Name: "rabbitmq-admin",
+					Name: "rabbitmq-confd",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							DefaultMode: &defaultMode,
 							SecretName:  "rabbitmq-sts-override-rabbitmq-admin",
 							Items: []corev1.KeyToPath{
 								{
-									Key:  "username",
-									Path: "username",
-								},
-								{
-									Key:  "password",
-									Path: "password",
+									Key:  "default_user.conf",
+									Path: "default_user.conf",
 								},
 							},
 						},

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -1207,6 +1207,21 @@ var _ = Describe("RabbitmqclusterController", func() {
 			Expect(sts.Spec.Template.Spec.HostNetwork).To(BeFalse())
 			Expect(sts.Spec.Template.Spec.Volumes).To(ConsistOf(
 				corev1.Volume{
+					Name: "rabbitmq-admin",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							DefaultMode: &defaultMode,
+							SecretName:  "rabbitmq-sts-override-rabbitmq-admin",
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "default_user.conf",
+									Path: "default_user.conf",
+								},
+							},
+						},
+					},
+				},
+				corev1.Volume{
 					Name: "additional-config",
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -1220,16 +1235,7 @@ var _ = Describe("RabbitmqclusterController", func() {
 				corev1.Volume{
 					Name: "rabbitmq-confd",
 					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: &defaultMode,
-							SecretName:  "rabbitmq-sts-override-rabbitmq-admin",
-							Items: []corev1.KeyToPath{
-								{
-									Key:  "default_user.conf",
-									Path: "default_user.conf",
-								},
-							},
-						},
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
 				},
 				corev1.Volume{

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -1207,21 +1207,6 @@ var _ = Describe("RabbitmqclusterController", func() {
 			Expect(sts.Spec.Template.Spec.HostNetwork).To(BeFalse())
 			Expect(sts.Spec.Template.Spec.Volumes).To(ConsistOf(
 				corev1.Volume{
-					Name: "rabbitmq-admin",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: &defaultMode,
-							SecretName:  "rabbitmq-sts-override-rabbitmq-admin",
-							Items: []corev1.KeyToPath{
-								{
-									Key:  "default_user.conf",
-									Path: "default_user.conf",
-								},
-							},
-						},
-					},
-				},
-				corev1.Volume{
 					Name: "additional-config",
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -1235,7 +1220,24 @@ var _ = Describe("RabbitmqclusterController", func() {
 				corev1.Volume{
 					Name: "rabbitmq-confd",
 					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									Secret: &corev1.SecretProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "rabbitmq-sts-override-rabbitmq-admin",
+										},
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "default_user.conf",
+												Path: "default_user.conf",
+											},
+										},
+									},
+								},
+							},
+							DefaultMode: &defaultMode,
+						},
 					},
 				},
 				corev1.Volume{

--- a/internal/resource/admin_secret_test.go
+++ b/internal/resource/admin_secret_test.go
@@ -46,9 +46,9 @@ var _ = Describe("AdminSecret", func() {
 
 	Context("Build with defaults", func() {
 		It("creates the necessary admin secret", func() {
-			var decodedUsername []byte
-			var decodedPassword []byte
-			var err error
+			var username []byte
+			var password []byte
+			var ok bool
 
 			obj, err := adminSecretBuilder.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -64,18 +64,18 @@ var _ = Describe("AdminSecret", func() {
 			})
 
 			By("creating a rabbitmq username that is base64 encoded and 24 characters in length", func() {
-				username, ok := secret.Data["username"]
+				username, ok = secret.Data["username"]
 				Expect(ok).NotTo(BeFalse())
-				decodedUsername, err = b64.URLEncoding.DecodeString(string(username))
+				decodedUsername, err := b64.URLEncoding.DecodeString(string(username))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(decodedUsername)).To(Equal(24))
 
 			})
 
 			By("creating a rabbitmq password that is base64 encoded and 24 characters in length", func() {
-				password, ok := secret.Data["password"]
+				password, ok = secret.Data["password"]
 				Expect(ok).NotTo(BeFalse())
-				decodedPassword, err = b64.URLEncoding.DecodeString(string(password))
+				decodedPassword, err := b64.URLEncoding.DecodeString(string(password))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(decodedPassword)).To(Equal(24))
 			})
@@ -84,17 +84,14 @@ var _ = Describe("AdminSecret", func() {
 				defaultUserConf, ok := secret.Data["default_user.conf"]
 				Expect(ok).NotTo(BeFalse())
 
-				decodedDefaultUserConf, err := b64.URLEncoding.DecodeString(string(defaultUserConf))
-				Expect(err).NotTo(HaveOccurred())
-
-				cfg, err := ini.Load(decodedDefaultUserConf)
+				cfg, err := ini.Load(defaultUserConf)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(cfg.Section("").HasKey("default_user")).To(BeTrue())
 				Expect(cfg.Section("").HasKey("default_pass")).To(BeTrue())
 
-				Expect(cfg.Section("").Key("default_user").Value()).To(Equal(string(decodedUsername)))
-				Expect(cfg.Section("").Key("default_pass").Value()).To(Equal(string(decodedPassword)))
+				Expect(cfg.Section("").Key("default_user").Value()).To(Equal(string(username)))
+				Expect(cfg.Section("").Key("default_pass").Value()).To(Equal(string(password)))
 			})
 		})
 	})

--- a/internal/resource/admin_secret_test.go
+++ b/internal/resource/admin_secret_test.go
@@ -65,16 +65,15 @@ var _ = Describe("AdminSecret", func() {
 
 			By("creating a rabbitmq username that is base64 encoded and 24 characters in length", func() {
 				username, ok = secret.Data["username"]
-				Expect(ok).NotTo(BeFalse())
+				Expect(ok).NotTo(BeFalse(), "Failed to find a key \"username\" in the generated Secret")
 				decodedUsername, err := b64.URLEncoding.DecodeString(string(username))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(decodedUsername)).To(Equal(24))
-
 			})
 
 			By("creating a rabbitmq password that is base64 encoded and 24 characters in length", func() {
 				password, ok = secret.Data["password"]
-				Expect(ok).NotTo(BeFalse())
+				Expect(ok).NotTo(BeFalse(), "Failed to find a key \"password\" in the generated Secret")
 				decodedPassword, err := b64.URLEncoding.DecodeString(string(password))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(decodedPassword)).To(Equal(24))
@@ -82,7 +81,7 @@ var _ = Describe("AdminSecret", func() {
 
 			By("creating a default_user.conf file that contains the correct sysctl config format to be parsed by RabbitMQ", func() {
 				defaultUserConf, ok := secret.Data["default_user.conf"]
-				Expect(ok).NotTo(BeFalse())
+				Expect(ok).NotTo(BeFalse(), "Failed to find a key \"default_user.conf\" in the generated Secret")
 
 				cfg, err := ini.Load(defaultUserConf)
 				Expect(err).NotTo(HaveOccurred())

--- a/internal/resource/erlang_cookie.go
+++ b/internal/resource/erlang_cookie.go
@@ -63,18 +63,10 @@ func (builder *ErlangCookieBuilder) Update(object runtime.Object) error {
 	return nil
 }
 
-func randomBytes(dataLen int) ([]byte, error) {
+func randomEncodedString(dataLen int) (string, error) {
 	randomBytes := make([]byte, dataLen)
 	if _, err := rand.Read(randomBytes); err != nil {
-		return nil, err
-	}
-	return randomBytes, nil
-}
-
-func randomEncodedString(dataLen int) (string, error) {
-	generatedBytes, err := randomBytes(dataLen)
-	if err != nil {
 		return "", err
 	}
-	return base64.URLEncoding.EncodeToString(generatedBytes), nil
+	return base64.URLEncoding.EncodeToString(randomBytes), nil
 }

--- a/internal/resource/erlang_cookie.go
+++ b/internal/resource/erlang_cookie.go
@@ -63,10 +63,18 @@ func (builder *ErlangCookieBuilder) Update(object runtime.Object) error {
 	return nil
 }
 
-func randomEncodedString(dataLen int) (string, error) {
+func randomBytes(dataLen int) ([]byte, error) {
 	randomBytes := make([]byte, dataLen)
 	if _, err := rand.Read(randomBytes); err != nil {
+		return nil, err
+	}
+	return randomBytes, nil
+}
+
+func randomEncodedString(dataLen int) (string, error) {
+	generatedBytes, err := randomBytes(dataLen)
+	if err != nil {
 		return "", err
 	}
-	return base64.URLEncoding.EncodeToString(randomBytes), nil
+	return base64.URLEncoding.EncodeToString(generatedBytes), nil
 }

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -259,6 +259,20 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 
 	volumes := []corev1.Volume{
 		{
+			Name: "rabbitmq-admin",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: builder.Instance.ChildResourceName(AdminSecretName),
+					Items: []corev1.KeyToPath{
+						{
+							Key:  "default_user.conf",
+							Path: "default_user.conf",
+						},
+					},
+				},
+			},
+		},
+		{
 			Name: "server-conf",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -287,15 +301,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 		{
 			Name: "rabbitmq-confd",
 			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: builder.Instance.ChildResourceName(AdminSecretName),
-					Items: []corev1.KeyToPath{
-						{
-							Key:  "default_user.conf",
-							Path: "default_user.conf",
-						},
-					},
-				},
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
 		{

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -816,6 +816,20 @@ var _ = Describe("StatefulSet", func() {
 
 			Expect(statefulSet.Spec.Template.Spec.Volumes).To(ConsistOf(
 				corev1.Volume{
+					Name: "rabbitmq-admin",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: instance.ChildResourceName("admin"),
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "default_user.conf",
+									Path: "default_user.conf",
+								},
+							},
+						},
+					},
+				},
+				corev1.Volume{
 					Name: "server-conf",
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -844,15 +858,7 @@ var _ = Describe("StatefulSet", func() {
 				corev1.Volume{
 					Name: "rabbitmq-confd",
 					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: instance.ChildResourceName("admin"),
-							Items: []corev1.KeyToPath{
-								{
-									Key:  "default_user.conf",
-									Path: "default_user.conf",
-								},
-							},
-						},
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
 				},
 				corev1.Volume{


### PR DESCRIPTION
## Summary Of Changes

This commit stops the operator configuring the default username and
password for the cluster through environment variables. Instead, these
credentials are configured through `/etc/rabbitmq/conf.d/`. This is for
two reasons:

* RabbitMQ is moving away from configuration via env vars
* The operator should not be coupled to functionality in the entrypoint script in the docker-library/rabbitmq Docker image, as this prevents other RabbitMQ images being used

This effectively removes support for RabbitMQ images pre 3.8.4, where
the ability to configure RabbitMQ via sysctl-style `*.conf` files in
the conf.d directory.

See #340 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Local Testing

Unit, Integration & System tests passed. Also tested on kind with `rabbitmqctl authenticate_user`.



Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
