### PR TITLE
Mention community Slack in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -10,3 +10,5 @@ assignees: ''
 **For questions**, please start a discussion in [RabbitMQ Discussions](https://github.com/rabbitmq/rabbitmq-server/discussions)
 or send an email to [RabbitMQ Mailing list](https://groups.google.com/g/rabbitmq-users), stating that your question is regarding
 RabbitMQ Cluster Operator.
+
+There's also a `#kubernetes` channel in [RabbitMQ community Slack](https://rabbitmq-slack.herokuapp.com/).


### PR DESCRIPTION
This is a follow-up to https://github.com/rabbitmq/cluster-operator/commit/83d50c7a1b733e4914e835bd044afa8dd58c34a1, I thought we should mention `#kubernetes` in our community Slack. It is quite active.