### PR TITLE
Option to specify storage class in kubectl-rabbitmq

### DIFF
--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -34,6 +34,7 @@ usage() {
     echo
     echo "  Create a RabbitMQ custom resource - INSTANCE name required, all other flags optional"
     echo "    kubectl rabbitmq create INSTANCE --replicas 1 --service ClusterIP --image rabbitmq:3.8.8 --image-pull-secret mysecret"
+    echo "      --tls-secret secret-name --storage-class mystorageclass"
     echo
     echo "  Get a RabbitMQ custom resource and dependant objects"
     echo "    kubectl rabbitmq get INSTANCE"
@@ -148,6 +149,12 @@ create() {
             shift 1
             echo "  tls:" >>"$rabbitmq_manifest_file"
             echo "    secretName: $1" >>"$rabbitmq_manifest_file"
+            shift 1
+            ;;
+        "--storage-class")
+            shift 1
+            echo "  persistence:" >>"$rabbitmq_manifest_file"
+            echo "    storageClassName: $1" >>"$rabbitmq_manifest_file"
             shift 1
             ;;
         *)


### PR DESCRIPTION

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Added an option to specify storage class name in kubectl-rabbitmq. This is useful in environments without a default storage class.
Added the `--tls-secret` to the usage output. This option was already implemented, but didn't show in the help output.

## Local Testing

No code changes.

Test using `kubectl rabbitmq create bunny --replicas 1 --storage-class <some-storage-class>`, then inspect the `RabbitmqCluster`
resource using `kubectl describe rmq bunny`. Observe the property `.spec.persistence.storageClassName` is set.

