### PR TITLE
Mount configurations as projected keys

### DIFF
--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -1259,7 +1259,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 				},
 
 				corev1.Volume{
-					Name: "rabbitmq-etc",
+					Name: "rabbitmq-plugins",
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},


### PR DESCRIPTION
This closes #361

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

RabbitMQ configuration files (`rabbitmq.conf`, `advanced.config` and `rabbitmq-env.conf`) are mounted as files,
instead of mounting the directory `/etc/rabbitmq` itself. This is necessary to respect any vendor configuration
that may come in RabbitMQ images.

The plugins file had to move to a different location because it needs to be writable by the rabbitmq process.
Mounting the file from a ConfigMap makes it read-only. The solution is to copy this file to a dedicated empty
dir volume in the init container and pass this volume to rabbitmq container.

## Local Testing

Unit and integration tests are passing locally. Modified some unit tests in statefulset to reflect new behaviour.

```
make unit-tests integration-tests
```

System tests are passing in dev-bunny. No modifications were needed.

```
make system-tests
```

