### PR TITLE
Allow users to automatically run `rabbitmq-upgrade post_upgrade` after cluster restarts

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -65,6 +65,7 @@ type RabbitmqClusterSpec struct {
 	TLS         TLSSpec                          `json:"tls,omitempty"`
 	Override    RabbitmqClusterOverrideSpec      `json:"override,omitempty"`
 	// If set to true, the cluster will run `rabbitmq-upgrade post_upgrade` whenever the cluster is updated.
+	// Has no effect if the cluster only consists of one node.
 	// For more information, see https://www.rabbitmq.com/rabbitmq-upgrade.8.html#post_upgrade
 	RunPostUpgradeSteps bool `json:"runPostUpgradeSteps,omitempty"`
 }

--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -64,6 +64,9 @@ type RabbitmqClusterSpec struct {
 	Rabbitmq    RabbitmqClusterConfigurationSpec `json:"rabbitmq,omitempty"`
 	TLS         TLSSpec                          `json:"tls,omitempty"`
 	Override    RabbitmqClusterOverrideSpec      `json:"override,omitempty"`
+	// If set to true, the cluster will run `rabbitmq-upgrade post_upgrade` whenever the cluster is updated.
+	// For more information, see https://www.rabbitmq.com/rabbitmq-upgrade.8.html#post_upgrade
+	RunPostUpgradeSteps bool `json:"runPostUpgradeSteps,omitempty"`
 }
 
 type RabbitmqClusterOverrideSpec struct {

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -3304,6 +3304,8 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              runPostUpgradeSteps:
+                type: boolean
               service:
                 properties:
                   annotations:

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -151,7 +151,7 @@ func (r *RabbitmqClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if statefulSetBeingUpdated {
+	if statefulSetBeingUpdated && rabbitmqCluster.Spec.RunPostUpgradeSteps {
 		if err := r.markForPostUpgrade(ctx, rabbitmqCluster); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -151,7 +151,9 @@ func (r *RabbitmqClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if statefulSetBeingUpdated && rabbitmqCluster.Spec.RunPostUpgradeSteps {
+	if statefulSetBeingUpdated &&
+		rabbitmqCluster.Spec.RunPostUpgradeSteps &&
+		*rabbitmqCluster.Spec.Replicas > 1 {
 		if err := r.markForPostUpgrade(ctx, rabbitmqCluster); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -345,7 +347,7 @@ func (r *RabbitmqClusterReconciler) runPostRestartStepsIfNeeded(ctx context.Cont
 		return 0, err
 	}
 	if !ready {
-		r.Log.Info("not all replicas ready yet; requeuing request to set plugins on RabbitmqCluster",
+		r.Log.Info("not all replicas ready yet; requeuing request to run post upgrade steps",
 			"namespace", rmq.Namespace,
 			"name", rmq.Name)
 		return 15 * time.Second, err


### PR DESCRIPTION
This closes #90 & this closes #168 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
This PR introduces a new boolean field in the CR spec: `rabbitmqv1beta1/RabbitmqCluster.Spec.RunPostUpgradeSteps`. When set to `true`, whenever the cluster is restarted (either by a manifest change, or a manual restart e.g. `kubectl rollout restart sts <>`), the operator will run `rabbitmq-upgrade post_upgrade`.

Without this functionality, any restart of the cluster will result in an uneven distribution of queue leaders across the cluster, which has implications on cluster stability (if the leader-heavy nodes go down) and performance. Running post_upgrade will redistribute leaders across the cluster evenly by migrating queue leaders across nodes. In the future, this command may also extend to provide additional post-upgrade functionality if the core team make such a change to the command.

## Additional Context
The functionality works through utilisation of annotations on the RabbitmqCluster object in order to save state in the CR. When the Reconcile function detects that a rolling update is occuring, it adds the `rabbitmq.com/postUpgradeNeeded` annotation to the RabbitmqCluster object. Later, once all replicas are updated & ready, it removes the annotation and runs the command through `kubectl exec`.

It is possible to determine whether a rolling restart has occurred by observing changes in the StatefulSet. The Pods in the set are all restarted only when the 'revision' (version/generation) of the StatefulSet changes. We can observe this through the Status of the StatefulSet:

```
$ kubectl get sts sample-rabbitmq-server -ojsonpath='{.status}' | jq . 
{
"collisionCount": 0,
"currentReplicas": 2,
"currentRevision": "sample-rabbitmq-server-6fc5fff745",
"observedGeneration": 2,
"readyReplicas": 3,
"replicas": 3,
"updateRevision": "sample-rabbitmq-server-58f4db96c5"
}
```

This PR introduces new behaviour to facilitate integration testing. Previously, it was not possible to integration test any functionality requiring the use of `kubectl exec` in the controller. This PR allows for a call to Exec to be mocked out with a custom function. A test may override the value of `controllers.NewPodExecutor` in order to provide custom test logic. In this case, the integration tests provide an 'Executor' which logs any commands it has been instructed to carry out through `kubectl exec`, so that the tests can check that the correct calls are made.

We decided while doing this PR that it was not worth implementing the behaviour for #168 . It is possible to add a similar annotation where a node goes down without a StatefulSet update, however the impact of uneven queue leader distribution in this case is minimal, and users can still perform the rebalance manually by running `kubectl exec <podName> -- rabbitmq-queues rebalance`.

This PR does not include system test changes. This is because the only method we found of determining if the command had run was through scraping of rabbitmq-server logs, which feels too brittle to be compatible with future versions of RabbitMQ. The only scope which is not covered by the integration tests is the actual running of `kubectl exec` which is stubbed out. We deemed this acceptable risk as manual testing showed the successful running of the kubectl command (as well as the queue rebalance), and other system tests do cover the running of `kubectl exec`.

## Points of discussion / feedback

I am looking for discussion & feedback on the following points:
* Whether we should run `rabbitmq-upgrade post_upgrade` or `rabbitmq-queues rebalance` in cases where the StatefulSet updates, but not the RabbitMQ version
  * In my mind these two are functionally identical since post_upgrade (at least now) is idempotent, but happy to have feedback against this
* Whether including a example doc with images would help users
* General code quality (particularly about whether the pod exec stubbing is clear or not)

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
