### PR TITLE
Use CRD defaulting

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -322,6 +322,64 @@ var _ = Describe("RabbitmqCluster", func() {
 					}, fetchedRabbit)).To(Succeed())
 					Expect(fetchedRabbit.Spec).To(Equal(expectedClusterInstance.Spec))
 				})
+
+				It("sets spec.service.type if spec.service is partially set", func() {
+					rmqClusterInstance = RabbitmqCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "rabbit-service-type",
+							Namespace: "default",
+						},
+						Spec: RabbitmqClusterSpec{
+							Replicas: &one,
+							Service: RabbitmqClusterServiceSpec{
+								Annotations: map[string]string{"key": "value"},
+							},
+						},
+					}
+
+					expectedClusterInstance.Spec.Service = RabbitmqClusterServiceSpec{
+						Annotations: map[string]string{"key": "value"},
+						Type:        "ClusterIP",
+					}
+
+					Expect(k8sClient.Create(context.TODO(), &rmqClusterInstance)).To(Succeed())
+					fetchedRabbit := &RabbitmqCluster{}
+					Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+						Name:      "rabbit-service-type",
+						Namespace: "default",
+					}, fetchedRabbit)).To(Succeed())
+					Expect(fetchedRabbit.Spec).To(Equal(expectedClusterInstance.Spec))
+				})
+
+				It("sets spec.persistence.storage if spec.persistence is partially set", func() {
+					myStorage := "mystorage"
+					tenGi := k8sresource.MustParse("10Gi")
+					rmqClusterInstance = RabbitmqCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "rabbit-storage",
+							Namespace: "default",
+						},
+						Spec: RabbitmqClusterSpec{
+							Replicas: &one,
+							Persistence: RabbitmqClusterPersistenceSpec{
+								StorageClassName: &myStorage,
+							},
+						},
+					}
+
+					expectedClusterInstance.Spec.Persistence = RabbitmqClusterPersistenceSpec{
+						StorageClassName: &myStorage,
+						Storage:          &tenGi,
+					}
+
+					Expect(k8sClient.Create(context.TODO(), &rmqClusterInstance)).To(Succeed())
+					fetchedRabbit := &RabbitmqCluster{}
+					Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+						Name:      "rabbit-storage",
+						Namespace: "default",
+					}, fetchedRabbit)).To(Succeed())
+					Expect(fetchedRabbit.Spec).To(Equal(expectedClusterInstance.Spec))
+				})
 			})
 		})
 	})

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -27,6 +27,7 @@ import (
 var _ = Describe("RabbitmqCluster", func() {
 
 	var three int32 = 3
+	var one int32 = 1
 
 	Context("RabbitmqClusterSpec", func() {
 		It("can be created with a single replica", func() {
@@ -138,19 +139,33 @@ var _ = Describe("RabbitmqCluster", func() {
 
 		Context("Default settings", func() {
 			var (
-				rmqClusterInstance RabbitmqCluster
-				rmqClusterTemplate RabbitmqCluster
+				rmqClusterInstance      RabbitmqCluster
+				expectedClusterInstance RabbitmqCluster
 			)
-			BeforeEach(func() {
-				rmqClusterInstance = RabbitmqCluster{}
-				rmqClusterTemplate = *generateRabbitmqClusterObject("foo")
 
+			BeforeEach(func() {
+				expectedClusterInstance = *generateRabbitmqClusterObject("foo")
 			})
 
-			When("CR is empty", func() {
-				It("outputs the template", func() {
-					instance := MergeDefaults(rmqClusterInstance)
-					Expect(instance.Spec).To(Equal(rmqClusterTemplate.Spec))
+			When("CR spec is empty", func() {
+				It("creates CR with defaults", func() {
+					rmqClusterInstance = RabbitmqCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "rabbitmq-defaults",
+							Namespace: "default",
+						},
+						Spec: RabbitmqClusterSpec{
+							Replicas: &one,
+						},
+					}
+
+					Expect(k8sClient.Create(context.TODO(), &rmqClusterInstance)).To(Succeed())
+					fetchedRabbit := &RabbitmqCluster{}
+					Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+						Name:      "rabbitmq-defaults",
+						Namespace: "default",
+					}, fetchedRabbit)).To(Succeed())
+					Expect(fetchedRabbit.Spec).To(Equal(expectedClusterInstance.Spec))
 				})
 			})
 
@@ -158,101 +173,126 @@ var _ = Describe("RabbitmqCluster", func() {
 				It("outputs the CR", func() {
 					storage := k8sresource.MustParse("987Gi")
 					storageClassName := "some-class"
-					rmqClusterInstance.Spec = RabbitmqClusterSpec{
-						Replicas:        &three,
-						Image:           "rabbitmq-image-from-cr",
-						ImagePullSecret: "my-super-secret",
-						Service: RabbitmqClusterServiceSpec{
-							Type: "this-is-a-service",
-							Annotations: map[string]string{
-								"myannotation": "is-set",
-							},
+					rmqClusterInstance = RabbitmqCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "rabbitmq-full-manifest",
+							Namespace: "default",
 						},
-						Persistence: RabbitmqClusterPersistenceSpec{
-							StorageClassName: &storageClassName,
-							Storage:          &storage,
-						},
-						Resources: &corev1.ResourceRequirements{
-							Limits: map[corev1.ResourceName]k8sresource.Quantity{
-								"cpu":    k8sresource.MustParse("16"),
-								"memory": k8sresource.MustParse("16Gi"),
+						Spec: RabbitmqClusterSpec{
+							Replicas:        &three,
+							Image:           "rabbitmq-image-from-cr",
+							ImagePullSecret: "my-super-secret",
+							Service: RabbitmqClusterServiceSpec{
+								Type: "NodePort",
+								Annotations: map[string]string{
+									"myannotation": "is-set",
+								},
 							},
-							Requests: map[corev1.ResourceName]k8sresource.Quantity{
-								"cpu":    k8sresource.MustParse("15"),
-								"memory": k8sresource.MustParse("15Gi"),
+							Persistence: RabbitmqClusterPersistenceSpec{
+								StorageClassName: &storageClassName,
+								Storage:          &storage,
 							},
-						},
-						Affinity: &corev1.Affinity{
-							NodeAffinity: &corev1.NodeAffinity{
-								RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-									NodeSelectorTerms: []corev1.NodeSelectorTerm{
-										{
-											MatchExpressions: []corev1.NodeSelectorRequirement{
-												{
-													Key:      "somekey",
-													Operator: "Equal",
-													Values:   []string{"this-value"},
+							Resources: &corev1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]k8sresource.Quantity{
+									"cpu":    k8sresource.MustParse("16"),
+									"memory": k8sresource.MustParse("16Gi"),
+								},
+								Requests: map[corev1.ResourceName]k8sresource.Quantity{
+									"cpu":    k8sresource.MustParse("15"),
+									"memory": k8sresource.MustParse("15Gi"),
+								},
+							},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+										NodeSelectorTerms: []corev1.NodeSelectorTerm{
+											{
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      "somekey",
+														Operator: "Equal",
+														Values:   []string{"this-value"},
+													},
 												},
+												MatchFields: nil,
 											},
-											MatchFields: nil,
 										},
 									},
 								},
 							},
-						},
-						Tolerations: []corev1.Toleration{
-							{
-								Key:      "mykey",
-								Operator: "NotEqual",
-								Value:    "myvalue",
-								Effect:   "NoSchedule",
+							Tolerations: []corev1.Toleration{
+								{
+									Key:      "mykey",
+									Operator: "NotEqual",
+									Value:    "myvalue",
+									Effect:   "NoSchedule",
+								},
 							},
-						},
-						Rabbitmq: RabbitmqClusterConfigurationSpec{
-							AdditionalPlugins: []Plugin{
-								"my-plugins",
+							Rabbitmq: RabbitmqClusterConfigurationSpec{
+								AdditionalPlugins: []Plugin{
+									"my_plugins",
+								},
 							},
 						},
 					}
-					instance := MergeDefaults(rmqClusterInstance)
-					Expect(instance.Spec).To(Equal(rmqClusterInstance.Spec))
+
+					Expect(k8sClient.Create(context.TODO(), &rmqClusterInstance)).To(Succeed())
+					fetchedRabbit := &RabbitmqCluster{}
+					Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+						Name:      "rabbitmq-full-manifest",
+						Namespace: "default",
+					}, fetchedRabbit)).To(Succeed())
+					Expect(fetchedRabbit.Spec).To(Equal(rmqClusterInstance.Spec))
 				})
 			})
 
 			When("CR is partially set", func() {
-				It("applies default values to missing properties if replicas is set", func() {
-					rmqClusterInstance.Spec = RabbitmqClusterSpec{
-						Replicas: &three,
-					}
-					expectedClusterInstance := rmqClusterTemplate.DeepCopy()
-					expectedClusterInstance.Spec.Replicas = &three
-
-					instance := MergeDefaults(rmqClusterInstance)
-					Expect(instance.Spec).To(Equal(expectedClusterInstance.Spec))
-				})
 
 				It("applies default values to missing properties if image is set", func() {
-					rmqClusterInstance.Spec = RabbitmqClusterSpec{
-						Image: "test-image",
+					rmqClusterInstance = RabbitmqCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "rabbitmq-image",
+							Namespace: "default",
+						},
+						Spec: RabbitmqClusterSpec{
+							Image:    "test-image",
+							Replicas: &one,
+						},
 					}
-					expectedClusterInstance := rmqClusterTemplate.DeepCopy()
+
 					expectedClusterInstance.Spec.Image = "test-image"
 
-					instance := MergeDefaults(rmqClusterInstance)
-					Expect(instance.Spec).To(Equal(expectedClusterInstance.Spec))
+					Expect(k8sClient.Create(context.TODO(), &rmqClusterInstance)).To(Succeed())
+					fetchedRabbit := &RabbitmqCluster{}
+					Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+						Name:      "rabbitmq-image",
+						Namespace: "default",
+					}, fetchedRabbit)).To(Succeed())
+					Expect(fetchedRabbit.Spec).To(Equal(expectedClusterInstance.Spec))
 				})
 
 				It("does not apply resource defaults if the resource object is an empty non-nil struct", func() {
 					expectedResources := &corev1.ResourceRequirements{}
-					rmqClusterInstance.Spec = RabbitmqClusterSpec{
-						Resources: expectedResources,
+					rmqClusterInstance = RabbitmqCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "rabbitmq-empty-resource",
+							Namespace: "default",
+						},
+						Spec: RabbitmqClusterSpec{
+							Resources: expectedResources,
+							Replicas:  &one,
+						},
 					}
-					expectedClusterInstance := rmqClusterTemplate.DeepCopy()
+
 					expectedClusterInstance.Spec.Resources = expectedResources
 
-					instance := MergeDefaults(rmqClusterInstance)
-					Expect(instance.Spec).To(Equal(expectedClusterInstance.Spec))
-
+					Expect(k8sClient.Create(context.TODO(), &rmqClusterInstance)).To(Succeed())
+					fetchedRabbit := &RabbitmqCluster{}
+					Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+						Name:      "rabbitmq-empty-resource",
+						Namespace: "default",
+					}, fetchedRabbit)).To(Succeed())
+					Expect(fetchedRabbit.Spec).To(Equal(expectedClusterInstance.Spec))
 				})
 
 				It("does not apply resource defaults if the resource object is partially set", func() {
@@ -261,14 +301,26 @@ var _ = Describe("RabbitmqCluster", func() {
 							"cpu": k8sresource.MustParse("6"),
 						},
 					}
-					rmqClusterInstance.Spec = RabbitmqClusterSpec{
-						Resources: expectedResources,
+					rmqClusterInstance = RabbitmqCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "rabbitmq-partial-resource",
+							Namespace: "default",
+						},
+						Spec: RabbitmqClusterSpec{
+							Resources: expectedResources,
+							Replicas:  &one,
+						},
 					}
-					expectedClusterInstance := rmqClusterTemplate.DeepCopy()
+
 					expectedClusterInstance.Spec.Resources = expectedResources
 
-					instance := MergeDefaults(rmqClusterInstance)
-					Expect(instance.Spec).To(Equal(expectedClusterInstance.Spec))
+					Expect(k8sClient.Create(context.TODO(), &rmqClusterInstance)).To(Succeed())
+					fetchedRabbit := &RabbitmqCluster{}
+					Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+						Name:      "rabbitmq-partial-resource",
+						Namespace: "default",
+					}, fetchedRabbit)).To(Succeed())
+					Expect(fetchedRabbit.Spec).To(Equal(expectedClusterInstance.Spec))
 				})
 			})
 		})

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -643,6 +643,7 @@ spec:
                     type: object
                 type: object
               image:
+                default: rabbitmq:3.8.9
                 description: Image is the name of the RabbitMQ docker image to use
                   for RabbitMQ nodes in the RabbitmqCluster.
                 type: string
@@ -3594,6 +3595,8 @@ spec:
                     type: object
                 type: object
               persistence:
+                default:
+                  storage: 10Gi
                 description: The settings for the persistent storage desired for each
                   Pod in the RabbitmqCluster.
                 properties:
@@ -3601,6 +3604,7 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 10Gi
                     description: The requested size of the persistent volume attached
                       to each Pod in the RabbitmqCluster.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -3644,6 +3648,7 @@ spec:
                     type: string
                 type: object
               replicas:
+                default: 1
                 description: Replicas is the number of nodes in the RabbitMQ cluster.
                   Each node is deployed as a Replica in a StatefulSet. Only 1, 3,
                   5 replicas clusters are tested.
@@ -3651,6 +3656,13 @@ spec:
                 minimum: 0
                 type: integer
               resources:
+                default:
+                  limits:
+                    cpu: 2000m
+                    memory: 2Gi
+                  requests:
+                    cpu: 1000m
+                    memory: 2Gi
                 description: ResourceRequirements describes the compute resource requirements.
                 properties:
                   limits:
@@ -3677,6 +3689,8 @@ spec:
                     type: object
                 type: object
               service:
+                default:
+                  type: ClusterIP
                 description: Settable attributes for the Client Service resource.
                 properties:
                   annotations:
@@ -3685,6 +3699,7 @@ spec:
                     description: Annotations to add to the Client Service.
                     type: object
                   type:
+                    default: ClusterIP
                     description: Service Type string describes ingress methods for
                       a service
                     enum:

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -92,21 +92,13 @@ func (r *RabbitmqClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 	ctx := context.Background()
 	logger := r.Log
 
-	fetchedRabbitmqCluster, err := r.getRabbitmqCluster(ctx, req.NamespacedName)
+	rabbitmqCluster, err := r.getRabbitmqCluster(ctx, req.NamespacedName)
 
 	if client.IgnoreNotFound(err) != nil {
 		return ctrl.Result{}, err
 	} else if errors.IsNotFound(err) {
 		// No need to requeue if the resource no longer exists
 		return ctrl.Result{}, nil
-	}
-
-	rabbitmqCluster := rabbitmqv1beta1.MergeDefaults(*fetchedRabbitmqCluster)
-
-	if !reflect.DeepEqual(fetchedRabbitmqCluster.Spec, rabbitmqCluster.Spec) {
-		if err := r.Client.Update(ctx, rabbitmqCluster); err != nil {
-			return ctrl.Result{}, err
-		}
 	}
 
 	// Resource has been marked for deletion


### PR DESCRIPTION
## Summary Of Changes

This PR uses CRD defaulting ([related KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190426-crd-defaulting.md)) to set defaults for CRD fields. Leveraging CRD schema for defaulting reduces complexity of our code and controller logic. It also means that the operator doesn't need a defaulting admission webhook in the future. WIN!

- Defaults are directly set on CRDs so it preserves the default with new versions of CRD
- Defaults can be set for integer, string, slice, and objects, which covers all types
- CRD defaulting has been a feature that's included in CRD v1. It's not supported for CRD `v1beta1`
- Any kubernetes with CRD v1 will support this feature, which is k8s `1.17` and above

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
