### PR TITLE
Use default for replicas

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -38,6 +38,7 @@ type RabbitmqCluster struct {
 // Spec is the desired state of the RabbitmqCluster Custom Resource.
 type RabbitmqClusterSpec struct {
 	// Replicas is the number of nodes in the RabbitMQ cluster. Each node is deployed as a Replica in a StatefulSet. Only 1, 3, 5 replicas clusters are tested.
+	// +optional
 	// +kubebuilder:validation:Minimum:=0
 	// +kubebuilder:default:=1
 	Replicas *int32 `json:"replicas"`

--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -115,7 +115,7 @@ create() {
 
     # special case when no options are provided
     if [[ "$#" -eq 0 ]]; then
-        echo "  replicas: 1" >>"$rabbitmq_manifest_file"
+        echo "  {}" >>"$rabbitmq_manifest_file"
     fi
 
     while [[ "$#" -ne 0 ]]; do

--- a/charts/rabbitmq/expected-template-output
+++ b/charts/rabbitmq/expected-template-output
@@ -22,7 +22,6 @@ metadata:
 spec:
   image: rabbitmq:3.8.1
   imagePullSecret: foo
-
   replicas: 3
   service:
     type: LoadBalancer

--- a/charts/rabbitmq/templates/rabbitmq.yaml
+++ b/charts/rabbitmq/templates/rabbitmq.yaml
@@ -30,7 +30,9 @@ spec:
   imagePullSecret: {{ .Values.imagePullSecret }}
   {{- end }}
 
+  {{- if .Values.replicas }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
 
   {{- if .Values.service }}
   service:

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -3773,8 +3773,6 @@ spec:
                       type: string
                   type: object
                 type: array
-            required:
-            - replicas
             type: object
           status:
             description: Status presents the observed state of RabbitmqCluster


### PR DESCRIPTION
Before this PR, when `replicas` is not specified, the following error occurs:
```
error: error validating "cr-example.yaml": error validating data: ValidationError(RabbitmqCluster.spec): missing required field "replicas" in com.rabbitmq.v1beta1.RabbitmqCluster.spec; if you choose to ignore these errors, turn validation off with --validate=false
```
After this PR, the error does not occur and the default specified in https://github.com/rabbitmq/cluster-operator/blob/df0c63074f1f865487222bb1e494c03befd7cab7/api/v1beta1/rabbitmqcluster_types.go#L42 gets used.