### PR TITLE
Configuration updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ list:    ## list Makefile targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 unit-tests: install-tools generate fmt vet manifests ## Run unit tests
-	ginkgo -r api/ internal/
+	ginkgo -r --randomizeAllSpecs api/ internal/
 
 integration-tests: install-tools generate fmt vet manifests ## Run integration tests
 	ginkgo -r controllers/

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -346,7 +346,7 @@ func (r *RabbitmqClusterReconciler) runPostDeployStepsIfNeeded(ctx context.Conte
 	}
 
 	// Retrieve the plugins config map, if it exists.
-	pluginsConfig, err := r.configMap(ctx, rmq, rmq.ChildResourceName(resource.PluginsConfig))
+	pluginsConfig, err := r.configMap(ctx, rmq, rmq.ChildResourceName(resource.PluginsConfigName))
 	if client.IgnoreNotFound(err) != nil {
 		return 0, err
 	}
@@ -431,7 +431,7 @@ func (r *RabbitmqClusterReconciler) runSetPluginsCommand(ctx context.Context, rm
 // it compares annotation "rabbitmq.com/serverConfUpdatedAt" from server-conf configMap and annotation "rabbitmq.com/lastRestartAt" from sts
 // to determine whether to restart sts
 func (r *RabbitmqClusterReconciler) restartStatefulSetIfNeeded(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) (time.Duration, error) {
-	serverConf, err := r.configMap(ctx, rmq, rmq.ChildResourceName(resource.ServerConfigMap))
+	serverConf, err := r.configMap(ctx, rmq, rmq.ChildResourceName(resource.ServerConfigMapName))
 	if err != nil {
 		// requeue request after 10s if unable to find server-conf configmap, else return the error
 		return 10 * time.Second, client.IgnoreNotFound(err)
@@ -506,10 +506,10 @@ func (r *RabbitmqClusterReconciler) annotateConfigMapIfUpdated(ctx context.Conte
 	var configMap, annotationKey string
 	switch builder.(type) {
 	case *resource.RabbitmqPluginsConfigMapBuilder:
-		configMap = rmq.ChildResourceName(resource.PluginsConfig)
+		configMap = rmq.ChildResourceName(resource.PluginsConfigName)
 		annotationKey = pluginsUpdateAnnotation
 	case *resource.ServerConfigMapBuilder:
-		configMap = rmq.ChildResourceName(resource.ServerConfigMap)
+		configMap = rmq.ChildResourceName(resource.ServerConfigMapName)
 		annotationKey = serverConfAnnotation
 	default:
 		return nil

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -60,6 +60,8 @@ const (
 	deletionFinalizer        = "deletion.finalizers.rabbitmqclusters.rabbitmq.com"
 	pluginsUpdateAnnotation  = "rabbitmq.com/pluginsUpdatedAt"
 	queueRebalanceAnnotation = "rabbitmq.com/queueRebalanceNeededAt"
+	serverConfAnnotation     = "rabbitmq.com/serverConfUpdatedAt"
+	stsRestartAnnotation     = "rabbitmq.com/lastRestartAt"
 )
 
 // RabbitmqClusterReconciler reconciles a RabbitmqCluster object
@@ -194,10 +196,17 @@ func (r *RabbitmqClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 			return ctrl.Result{}, err
 		}
 
-		r.annotatePluginsConfigMapIfUpdated(ctx, builder, operationResult, rabbitmqCluster)
-		if restarted := r.restartStatefulSetIfNeeded(ctx, builder, operationResult, rabbitmqCluster); restarted {
-			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
+		if err = r.annotateConfigMapIfUpdated(ctx, builder, operationResult, rabbitmqCluster); err != nil {
+			return ctrl.Result{}, err
 		}
+	}
+
+	requeueAfter, err := r.restartStatefulSetIfNeeded(ctx, rabbitmqCluster)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if requeueAfter > 0 {
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
 	// Set ReconcileSuccess to true here because all CRUD operations to Kube API related
@@ -215,7 +224,7 @@ func (r *RabbitmqClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 
 	// By this point the StatefulSet may have finished deploying. Run any
 	// post-deploy steps if so, or requeue until the deployment is finished.
-	requeueAfter, err := r.runPostDeployStepsIfNeeded(ctx, rabbitmqCluster)
+	requeueAfter, err = r.runPostDeployStepsIfNeeded(ctx, rabbitmqCluster)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -337,7 +346,7 @@ func (r *RabbitmqClusterReconciler) runPostDeployStepsIfNeeded(ctx context.Conte
 	}
 
 	// Retrieve the plugins config map, if it exists.
-	pluginsConfig, err := r.pluginsConfigMap(ctx, rmq)
+	pluginsConfig, err := r.configMap(ctx, rmq, rmq.ChildResourceName(resource.PluginsConfig))
 	if client.IgnoreNotFound(err) != nil {
 		return 0, err
 	}
@@ -418,16 +427,32 @@ func (r *RabbitmqClusterReconciler) runSetPluginsCommand(ctx context.Context, rm
 	return nil
 }
 
-// Adds an arbitrary annotation (rabbitmq.com/lastRestartAt) to the StatefulSet PodTemplate to trigger a StatefulSet restart
-// if builder requires StatefulSet to be updated.
-func (r *RabbitmqClusterReconciler) restartStatefulSetIfNeeded(
-	ctx context.Context,
-	builder resource.ResourceBuilder,
-	operationResult controllerutil.OperationResult,
-	rmq *rabbitmqv1beta1.RabbitmqCluster) (restarted bool) {
+// Adds an arbitrary annotation to the sts PodTemplate to trigger a sts restart
+// it compares annotation "rabbitmq.com/serverConfUpdatedAt" from server-conf configMap and annotation "rabbitmq.com/lastRestartAt" from sts
+// to determine whether to restart sts
+func (r *RabbitmqClusterReconciler) restartStatefulSetIfNeeded(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) (time.Duration, error) {
+	serverConf, err := r.configMap(ctx, rmq, rmq.ChildResourceName(resource.ServerConfigMap))
+	if err != nil {
+		// requeue request after 10s if unable to find server-conf configmap, else return the error
+		return 10 * time.Second, client.IgnoreNotFound(err)
+	}
 
-	if !(builder.UpdateRequiresStsRestart() && operationResult == controllerutil.OperationResultUpdated) {
-		return false
+	serverConfigUpdatedAt, ok := serverConf.Annotations[serverConfAnnotation]
+	if !ok {
+		// server-conf configmap hasn't been updated; no need to restart sts
+		return 0, nil
+	}
+
+	sts, err := r.statefulSet(ctx, rmq)
+	if err != nil {
+		// requeue request after 10s if unable to find sts, else return the error
+		return 10 * time.Second, client.IgnoreNotFound(err)
+	}
+
+	stsRestartedAt, ok := sts.Spec.Template.ObjectMeta.Annotations[stsRestartAnnotation]
+	if ok && stsRestartedAt > serverConfigUpdatedAt {
+		// sts was updated after the last server-conf configmap update; no need to restart sts
+		return 0, nil
 	}
 
 	if err := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
@@ -438,19 +463,21 @@ func (r *RabbitmqClusterReconciler) restartStatefulSetIfNeeded(
 		if sts.Spec.Template.ObjectMeta.Annotations == nil {
 			sts.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 		}
-		sts.Spec.Template.ObjectMeta.Annotations["rabbitmq.com/lastRestartAt"] = time.Now().Format(time.RFC3339)
+		sts.Spec.Template.ObjectMeta.Annotations[stsRestartAnnotation] = time.Now().Format(time.RFC3339)
 		return r.Update(ctx, sts)
 	}); err != nil {
 		msg := fmt.Sprintf("failed to restart StatefulSet %s of Namespace %s; rabbitmq.conf configuration may be outdated", rmq.ChildResourceName("server"), rmq.Namespace)
 		r.Log.Error(err, msg)
 		r.Recorder.Event(rmq, corev1.EventTypeWarning, "FailedUpdate", msg)
-		return false
+		// failed to restart sts; return error to requeue request
+		return 0, err
 	}
 
 	msg := fmt.Sprintf("restarted StatefulSet %s of Namespace %s", rmq.ChildResourceName("server"), rmq.Namespace)
 	r.Log.Info(msg)
 	r.Recorder.Event(rmq, corev1.EventTypeNormal, "SuccessfulUpdate", msg)
-	return true
+
+	return 0, nil
 }
 
 func (r *RabbitmqClusterReconciler) statefulSet(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) (*appsv1.StatefulSet, error) {
@@ -461,43 +488,59 @@ func (r *RabbitmqClusterReconciler) statefulSet(ctx context.Context, rmq *rabbit
 	return sts, nil
 }
 
-func (r *RabbitmqClusterReconciler) pluginsConfigMap(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) (*corev1.ConfigMap, error) {
+func (r *RabbitmqClusterReconciler) configMap(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster, name string) (*corev1.ConfigMap, error) {
 	configMap := &corev1.ConfigMap{}
-	if err := r.Get(ctx, types.NamespacedName{Namespace: rmq.Namespace, Name: rmq.ChildResourceName(resource.PluginsConfig)}, configMap); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Namespace: rmq.Namespace, Name: name}, configMap); err != nil {
 		return nil, err
 	}
 	return configMap, nil
 }
 
-// Annotates the plugins ConfigMap if it was updated such that 'rabbitmq-plugins set' will be called on the RabbitMQ nodes at a later point in time
-func (r *RabbitmqClusterReconciler) annotatePluginsConfigMapIfUpdated(
-	ctx context.Context,
-	builder resource.ResourceBuilder,
-	operationResult controllerutil.OperationResult,
-	rmq *rabbitmqv1beta1.RabbitmqCluster) {
-
-	if _, ok := builder.(*resource.RabbitmqPluginsConfigMapBuilder); !ok {
-		return
-	}
+// Annotates the plugins ConfigMap or the server-conf ConfigMap
+// annotations later used to indicate whether to call 'rabbitmq-plugins set' or to restart the sts
+func (r *RabbitmqClusterReconciler) annotateConfigMapIfUpdated(ctx context.Context, builder resource.ResourceBuilder, operationResult controllerutil.OperationResult, rmq *rabbitmqv1beta1.RabbitmqCluster) error {
 	if operationResult != controllerutil.OperationResultUpdated {
-		return
+		return nil
 	}
 
+	var configMap, annotationKey string
+	switch builder.(type) {
+	case *resource.RabbitmqPluginsConfigMapBuilder:
+		configMap = rmq.ChildResourceName(resource.PluginsConfig)
+		annotationKey = pluginsUpdateAnnotation
+	case *resource.ServerConfigMapBuilder:
+		configMap = rmq.ChildResourceName(resource.ServerConfigMap)
+		annotationKey = serverConfAnnotation
+	default:
+		return nil
+	}
+
+	if err := r.annotateConfigMap(ctx, rmq.Namespace, configMap, annotationKey, time.Now().Format(time.RFC3339)); err != nil {
+		msg := fmt.Sprintf("Failed to annotate ConfigMap %s of Namespace %s; %s may be outdated", configMap, rmq.Namespace, rmq.Name)
+		r.Log.Error(err, msg)
+		r.Recorder.Event(rmq, corev1.EventTypeWarning, "FailedUpdate", msg)
+		return err
+	}
+
+	r.Log.Info("successfully annotated", "ConfigMap", configMap, "Namespace", rmq.Namespace)
+	return nil
+}
+
+func (r *RabbitmqClusterReconciler) annotateConfigMap(ctx context.Context, namespace, name, key, value string) error {
 	if retryOnConflictErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 		configMap := corev1.ConfigMap{}
-		if err := r.Get(ctx, types.NamespacedName{Namespace: rmq.Namespace, Name: rmq.ChildResourceName(resource.PluginsConfig)}, &configMap); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &configMap); err != nil {
 			return client.IgnoreNotFound(err)
 		}
 		if configMap.Annotations == nil {
 			configMap.Annotations = make(map[string]string)
 		}
-		configMap.Annotations[pluginsUpdateAnnotation] = time.Now().Format(time.RFC3339)
+		configMap.Annotations[key] = value
 		return r.Update(ctx, &configMap)
 	}); retryOnConflictErr != nil {
-		msg := fmt.Sprintf("Failed to annotate ConfigMap %s of Namespace %s; enabled_plugins may be outdated", rmq.ChildResourceName(resource.PluginsConfig), rmq.Namespace)
-		r.Log.Error(retryOnConflictErr, msg)
-		r.Recorder.Event(rmq, corev1.EventTypeWarning, "FailedUpdate", msg)
+		return retryOnConflictErr
 	}
+	return nil
 }
 
 func (r *RabbitmqClusterReconciler) exec(namespace, podName, containerName string, command ...string) (string, string, error) {

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -1572,7 +1572,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})
 		})
 
-		When("the cluster is only 1 node large", func() {
+		When("the cluster is a single node cluster", func() {
 			BeforeEach(func() {
 				cluster = &rabbitmqv1beta1.RabbitmqCluster{
 					ObjectMeta: metav1.ObjectMeta{

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"
@@ -1639,86 +1640,75 @@ var _ = Describe("RabbitmqClusterController", func() {
 
 	})
 
-	Context("Server configurations updates", func() {
-		AfterEach(func() {
-			Expect(client.Delete(ctx, cluster)).To(Succeed())
-			waitForClusterDeletion(ctx, cluster, client)
-		})
+	DescribeTable("Server configurations updates",
+		func(testCase string) {
+			// create rabbitmqcluster
+			cluster = &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rabbitmq-" + testCase,
+					Namespace: defaultNamespace,
+				},
+				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
+					Replicas: &one,
+				},
+			}
+			Expect(client.Create(ctx, cluster)).To(Succeed())
+			waitForClusterCreation(ctx, cluster, client)
 
-		assertRabbitmqServerUpdates := func(testCase string) {
-			It("updates the rabbitmq server", func() {
-				// create rabbitmqcluster
-				cluster = &rabbitmqv1beta1.RabbitmqCluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "rabbitmq-" + testCase,
-						Namespace: defaultNamespace,
-					},
-					Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-						Replicas: &one,
-					},
+			// ensure that configMap and statefulSet does not have annotations set when configurations haven't changed
+			configMap, err := clientSet.CoreV1().ConfigMaps(cluster.Namespace).Get(ctx, cluster.ChildResourceName("server-conf"), metav1.GetOptions{})
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(configMap.Annotations).ShouldNot(HaveKey("rabbitmq.com/serverConfUpdatedAt"))
+
+			sts, err := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, cluster.ChildResourceName("server"), metav1.GetOptions{})
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(sts.Annotations).ShouldNot(HaveKey("rabbitmq.com/lastRestartAt"))
+
+			// update rabbitmq server configurations
+			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
+				if testCase == "additional-config" {
+					r.Spec.Rabbitmq.AdditionalConfig = "test_config=0"
 				}
-				Expect(client.Create(ctx, cluster)).To(Succeed())
-				waitForClusterCreation(ctx, cluster, client)
+				if testCase == "advanced-config" {
+					r.Spec.Rabbitmq.AdvancedConfig = "sample-advanced-config."
+				}
+				if testCase == "env-config" {
+					r.Spec.Rabbitmq.EnvConfig = "some-env-variable"
+				}
+			})).To(Succeed())
 
-				// ensure that configMap and statefulSet does not have annotations set when configurations haven't changed
+			By("annotating the server-conf ConfigMap")
+			// ensure annotations from the server-conf ConfigMap
+			var annotations map[string]string
+			Eventually(func() map[string]string {
 				configMap, err := clientSet.CoreV1().ConfigMaps(cluster.Namespace).Get(ctx, cluster.ChildResourceName("server-conf"), metav1.GetOptions{})
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(configMap.Annotations).ShouldNot(HaveKey("rabbitmq.com/serverConfUpdatedAt"))
+				annotations = configMap.Annotations
+				return annotations
+			}, 5).Should(HaveKey("rabbitmq.com/serverConfUpdatedAt"))
+			_, err = time.Parse(time.RFC3339, annotations["rabbitmq.com/serverConfUpdatedAt"])
+			Expect(err).NotTo(HaveOccurred(), "Annotation rabbitmq.com/serverConfUpdatedAt was not a valid RFC3339 timestamp")
 
+			By("annotating the sts podTemplate")
+			// ensure statefulSet annotations
+			Eventually(func() map[string]string {
 				sts, err := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, cluster.ChildResourceName("server"), metav1.GetOptions{})
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(sts.Annotations).ShouldNot(HaveKey("rabbitmq.com/lastRestartAt"))
+				annotations = sts.Spec.Template.Annotations
+				return annotations
+			}, 5).Should(HaveKey("rabbitmq.com/lastRestartAt"))
+			_, err = time.Parse(time.RFC3339, annotations["rabbitmq.com/lastRestartAt"])
+			Expect(err).NotTo(HaveOccurred(), "Annotation rabbitmq.com/lastRestartAt was not a valid RFC3339 timestamp")
 
-				// update rabbitmq server configurations
-				Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
-					if testCase == "additional-config" {
-						r.Spec.Rabbitmq.AdditionalConfig = "test_config=0"
-					}
-					if testCase == "advanced-config" {
-						r.Spec.Rabbitmq.AdvancedConfig = "sample-advanced-config."
-					}
-					if testCase == "env-config" {
-						r.Spec.Rabbitmq.EnvConfig = "some-env-variable"
-					}
-				})).To(Succeed())
+			// delete rmq cluster
+			Expect(client.Delete(ctx, cluster)).To(Succeed())
+			waitForClusterDeletion(ctx, cluster, client)
+		},
 
-				By("annotating the server-conf ConfigMap")
-				// ensure annotations from the server-conf ConfigMap
-				var annotations map[string]string
-				Eventually(func() map[string]string {
-					configMap, err := clientSet.CoreV1().ConfigMaps(cluster.Namespace).Get(ctx, cluster.ChildResourceName("server-conf"), metav1.GetOptions{})
-					Expect(err).To(Not(HaveOccurred()))
-					annotations = configMap.Annotations
-					return annotations
-				}, 5).Should(HaveKey("rabbitmq.com/serverConfUpdatedAt"))
-				_, err = time.Parse(time.RFC3339, annotations["rabbitmq.com/serverConfUpdatedAt"])
-				Expect(err).NotTo(HaveOccurred(), "Annotation rabbitmq.com/serverConfUpdatedAt was not a valid RFC3339 timestamp")
-
-				By("annotating the sts podTemplate")
-				// ensure statefulSet annotations
-				Eventually(func() map[string]string {
-					sts, err := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, cluster.ChildResourceName("server"), metav1.GetOptions{})
-					Expect(err).To(Not(HaveOccurred()))
-					annotations = sts.Spec.Template.Annotations
-					return annotations
-				}, 5).Should(HaveKey("rabbitmq.com/lastRestartAt"))
-				_, err = time.Parse(time.RFC3339, annotations["rabbitmq.com/lastRestartAt"])
-				Expect(err).NotTo(HaveOccurred(), "Annotation rabbitmq.com/lastRestartAt was not a valid RFC3339 timestamp")
-			})
-		}
-
-		When("spec.rabbitmq.additionalConfig is updated", func() {
-			assertRabbitmqServerUpdates("additional-config")
-		})
-
-		When("spec.rabbitmq.advancedConfig is updated", func() {
-			assertRabbitmqServerUpdates("advanced-config")
-		})
-
-		When("spec.rabbitmq.envConfig is updated", func() {
-			assertRabbitmqServerUpdates("env-config")
-		})
-	})
+		Entry("spec.rabbitmq.additionalConfig is updated", "additional-config"),
+		Entry("spec.rabbitmq.advancedConfig is updated", "advanced-config"),
+		Entry("spec.rabbitmq.envConfig is updated", "env-config"),
+	)
 })
 
 func extractContainer(containers []corev1.Container, containerName string) corev1.Container {

--- a/internal/resource/client_service.go
+++ b/internal/resource/client_service.go
@@ -35,10 +35,6 @@ type ClientServiceBuilder struct {
 	Scheme   *runtime.Scheme
 }
 
-func (builder *ClientServiceBuilder) UpdateRequiresStsRestart() bool {
-	return false
-}
-
 func (builder *ClientServiceBuilder) Build() (runtime.Object, error) {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	ServerConfigMap     = "server-conf"
+	ServerConfigMapName = "server-conf"
 	defaultRabbitmqConf = `
 cluster_formation.peer_discovery_backend = rabbit_peer_discovery_k8s
 cluster_formation.k8s.host = kubernetes.default
@@ -112,7 +112,7 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 func (builder *ServerConfigMapBuilder) Build() (runtime.Object, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      builder.Instance.ChildResourceName(ServerConfigMap),
+			Name:      builder.Instance.ChildResourceName(ServerConfigMapName),
 			Namespace: builder.Instance.Namespace,
 		},
 	}, nil

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -52,10 +52,6 @@ func (builder *RabbitmqResourceBuilder) ServerConfigMap() *ServerConfigMapBuilde
 	}
 }
 
-func (builder *ServerConfigMapBuilder) UpdateRequiresStsRestart() bool {
-	return true // because rabbitmq.conf and advanced.config changes take effect only after a node restart
-}
-
 func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 	configMap := object.(*corev1.ConfigMap)
 	configMap.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	serverConfigMapName = "server-conf"
+	ServerConfigMap     = "server-conf"
 	defaultRabbitmqConf = `
 cluster_formation.peer_discovery_backend = rabbit_peer_discovery_k8s
 cluster_formation.k8s.host = kubernetes.default
@@ -116,7 +116,7 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 func (builder *ServerConfigMapBuilder) Build() (runtime.Object, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      builder.Instance.ChildResourceName(serverConfigMapName),
+			Name:      builder.Instance.ChildResourceName(ServerConfigMap),
 			Namespace: builder.Instance.Namespace,
 		},
 	}, nil

--- a/internal/resource/default_user_secret.go
+++ b/internal/resource/default_user_secret.go
@@ -81,10 +81,6 @@ func (builder *DefaultUserSecretBuilder) Update(object runtime.Object) error {
 	return nil
 }
 
-func (builder *DefaultUserSecretBuilder) UpdateRequiresStsRestart() bool {
-	return false
-}
-
 func generateDefaultUserConf(username, password string) ([]byte, error) {
 	ini.PrettySection = false // Remove trailing new line because default_user.conf has only a default section.
 	cfg, err := ini.Load([]byte{})

--- a/internal/resource/erlang_cookie.go
+++ b/internal/resource/erlang_cookie.go
@@ -38,10 +38,6 @@ func (builder *RabbitmqResourceBuilder) ErlangCookie() *ErlangCookieBuilder {
 	}
 }
 
-func (builder *ErlangCookieBuilder) UpdateRequiresStsRestart() bool {
-	return false
-}
-
 func (builder *ErlangCookieBuilder) Build() (runtime.Object, error) {
 	cookie, err := randomEncodedString(24)
 	if err != nil {

--- a/internal/resource/headless_service.go
+++ b/internal/resource/headless_service.go
@@ -35,10 +35,6 @@ func (builder *RabbitmqResourceBuilder) HeadlessService() *HeadlessServiceBuilde
 	}
 }
 
-func (builder *HeadlessServiceBuilder) UpdateRequiresStsRestart() bool {
-	return false
-}
-
 func (builder *HeadlessServiceBuilder) Build() (runtime.Object, error) {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/resource/rabbitmq_plugins.go
+++ b/internal/resource/rabbitmq_plugins.go
@@ -18,7 +18,7 @@ var requiredPlugins = []string{
 	"rabbitmq_management",
 }
 
-const PluginsConfig = "plugins-conf"
+const PluginsConfigName = "plugins-conf"
 
 type RabbitmqPlugins struct {
 	requiredPlugins   []string
@@ -86,7 +86,7 @@ func (builder *RabbitmqPluginsConfigMapBuilder) Update(object runtime.Object) er
 func (builder *RabbitmqPluginsConfigMapBuilder) Build() (runtime.Object, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      builder.Instance.ChildResourceName(PluginsConfig),
+			Name:      builder.Instance.ChildResourceName(PluginsConfigName),
 			Namespace: builder.Instance.Namespace,
 		},
 		Data: map[string]string{

--- a/internal/resource/rabbitmq_plugins.go
+++ b/internal/resource/rabbitmq_plugins.go
@@ -67,10 +67,6 @@ func (builder *RabbitmqResourceBuilder) RabbitmqPluginsConfigMap() *RabbitmqPlug
 	}
 }
 
-func (builder *RabbitmqPluginsConfigMapBuilder) UpdateRequiresStsRestart() bool {
-	return false
-}
-
 func (builder *RabbitmqPluginsConfigMapBuilder) Update(object runtime.Object) error {
 	configMap := object.(*corev1.ConfigMap)
 	configMap.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/rabbitmq_resource_builder.go
+++ b/internal/resource/rabbitmq_resource_builder.go
@@ -22,7 +22,6 @@ type RabbitmqResourceBuilder struct {
 type ResourceBuilder interface {
 	Update(runtime.Object) error
 	Build() (runtime.Object, error)
-	UpdateRequiresStsRestart() bool
 }
 
 func (builder *RabbitmqResourceBuilder) ResourceBuilders() ([]ResourceBuilder, error) {

--- a/internal/resource/role.go
+++ b/internal/resource/role.go
@@ -35,10 +35,6 @@ func (builder *RabbitmqResourceBuilder) Role() *RoleBuilder {
 	}
 }
 
-func (builder *RoleBuilder) UpdateRequiresStsRestart() bool {
-	return false
-}
-
 func (builder *RoleBuilder) Update(object runtime.Object) error {
 	role := object.(*rbacv1.Role)
 	role.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/role_binding.go
+++ b/internal/resource/role_binding.go
@@ -36,10 +36,6 @@ func (builder *RabbitmqResourceBuilder) RoleBinding() *RoleBindingBuilder {
 	}
 }
 
-func (builder *RoleBindingBuilder) UpdateRequiresStsRestart() bool {
-	return false
-}
-
 func (builder *RoleBindingBuilder) Update(object runtime.Object) error {
 	roleBinding := object.(*rbacv1.RoleBinding)
 	roleBinding.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/service_account.go
+++ b/internal/resource/service_account.go
@@ -35,10 +35,6 @@ func (builder *RabbitmqResourceBuilder) ServiceAccount() *ServiceAccountBuilder 
 	}
 }
 
-func (builder *ServiceAccountBuilder) UpdateRequiresStsRestart() bool {
-	return false
-}
-
 func (builder *ServiceAccountBuilder) Update(object runtime.Object) error {
 	serviceAccount := object.(*corev1.ServiceAccount)
 	serviceAccount.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -45,10 +45,6 @@ type StatefulSetBuilder struct {
 	Scheme   *runtime.Scheme
 }
 
-func (builder *StatefulSetBuilder) UpdateRequiresStsRestart() bool {
-	return false
-}
-
 func (builder *StatefulSetBuilder) Build() (runtime.Object, error) {
 	// PVC, ServiceName & Selector: can't be updated without deleting the statefulset
 	pvc, err := persistentVolumeClaim(builder.Instance, builder.Scheme)

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -259,7 +259,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: builder.Instance.ChildResourceName(ServerConfigMap),
+						Name: builder.Instance.ChildResourceName(ServerConfigMapName),
 					},
 				},
 			},
@@ -269,7 +269,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: builder.Instance.ChildResourceName(PluginsConfig),
+						Name: builder.Instance.ChildResourceName(PluginsConfigName),
 					},
 				},
 			},

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -263,7 +263,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: builder.Instance.ChildResourceName(serverConfigMapName),
+						Name: builder.Instance.ChildResourceName(ServerConfigMap),
 					},
 				},
 			},


### PR DESCRIPTION
This closes #225 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- adds a timestamped annotation to the server-conf configmap "rabbitmq.com/serverConfUpdatedAt" when the configMap is updated
- controller compares the timestamp of the server-conf configMap and the sts restart timestamp (if exists)
- if the sts restart timestamp is before the server conf timestamp, or if the server-conf has the timestamp, and the sts doesn't, the controller restarts the sts by annotating the podTemplate (how we trigger the sts restart is the same as before)
- randomized specs for unit tests.
- deleted unused method "UpdateRequiresStsRestart()" from all the resource builders; it was used previously in the controller for sts updates.
- added test cases in integration to ensure annotations are added for sts and server-conf configmap for all rabbitmq configurations updates.
- no new system tests since the use case is the same as before and already covered. 

## Additional Context

## Local Testing

Have run unit, integration, and system tests locally.
