### PR TITLE
Make system tests less flaky

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,50 +21,23 @@ jobs:
       working-directory: charts/rabbitmq
       run: ./test.sh
 
-  system_test_latest:
-    name: system tests on K8s latest
+  system_tests:
+    name: system tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s: [v1.17.11, v1.18.8, v1.19.1]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: System tests
+      env:
+        K8S_VERSION: ${{ matrix.k8s }}
       run: |
         curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
         export GOPATH=$HOME/go
         export PATH=$PATH:$GOPATH/bin
         make install-tools
-        kind create cluster
-        DOCKER_REGISTRY_SERVER=local-server OPERATOR_IMAGE=local-operator make deploy-kind
-        make system-tests
-
-  system_tests_1_18:
-    name: system tests on K8s v1.18
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-    - name: System tests
-      run: |
-        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
-        export GOPATH=$HOME/go
-        export PATH=$PATH:$GOPATH/bin
-        make install-tools
-        kind create cluster --image kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
-        DOCKER_REGISTRY_SERVER=local-server OPERATOR_IMAGE=local-operator make deploy-kind
-        make system-tests
-
-  system_tests_1_17:
-    name: system tests on K8s v1.17
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-    - name: System tests
-      run: |
-        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
-        export GOPATH=$HOME/go
-        export PATH=$PATH:$GOPATH/bin
-        make install-tools
-        kind create cluster --image kindest/node:v1.17.11@sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555
+        kind create cluster --image kindest/node:"$K8S_VERSION"
         DOCKER_REGISTRY_SERVER=local-server OPERATOR_IMAGE=local-operator make deploy-kind
         make system-tests

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -127,7 +127,7 @@ var _ = Describe("Operator", func() {
 					Expect(err).ToNot(HaveOccurred())
 					return configMap.Annotations
 				}
-				Eventually(getConfigMapAnnotations, 10, 0.5).Should(
+				Eventually(getConfigMapAnnotations, 30, 1).Should(
 					HaveKey("rabbitmq.com/pluginsUpdatedAt"), "plugins ConfigMap should have been annotated")
 				Eventually(getConfigMapAnnotations, 60, 1).Should(
 					Not(HaveKey("rabbitmq.com/pluginsUpdatedAt")), "plugins ConfigMap annotation should have been removed")

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -87,16 +87,17 @@ var _ = Describe("Operator", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(output)).To(Equal("'True'"))
 
-				output, err = kubectl(
-					"-n",
-					cluster.Namespace,
-					"get",
-					"rabbitmqclusters",
-					cluster.Name,
-					"-ojsonpath='{.status.conditions[?(@.type==\"ClusterAvailable\")].status}'",
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(output)).To(Equal("'True'"))
+				Eventually(func() (string, error) {
+					output, err := kubectl(
+						"-n",
+						cluster.Namespace,
+						"get",
+						"rabbitmqclusters",
+						cluster.Name,
+						"-ojsonpath='{.status.conditions[?(@.type==\"ClusterAvailable\")].status}'",
+					)
+					return string(output), err
+				}, 30, 2).Should(Equal("'True'"))
 			})
 		})
 	})

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -548,20 +548,15 @@ func assertTLSError(cluster *rabbitmqv1beta1.RabbitmqCluster) {
 }
 
 func assertHttpReady(hostname, port string) {
-	EventuallyWithOffset(1, func() int {
+	EventuallyWithOffset(1, func() (*http.Response, error) {
 		client := &http.Client{Timeout: 10 * time.Second}
-		url := fmt.Sprintf("http://%s:%s", hostname, port)
+		rabbitURL := fmt.Sprintf("http://%s:%s", hostname, port)
 
-		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req, err := http.NewRequest(http.MethodGet, rabbitURL, nil)
+		Expect(err).ToNot(HaveOccurred())
 
-		resp, err := client.Do(req)
-		if err != nil {
-			return 0
-		}
-		defer resp.Body.Close()
-
-		return resp.StatusCode
-	}, podCreationTimeout, 5).Should(Equal(http.StatusOK))
+		return client.Do(req)
+	}, podCreationTimeout, 5).Should(HaveHTTPStatus(http.StatusOK))
 }
 
 func createTLSSecret(secretName, secretNamespace, hostname string) string {


### PR DESCRIPTION
When system tests are run on GitHub actions, we observed that some of them are very flaky.

This PR increases some timeouts because kind on GitHub-hosted runners can be much slower than GKE where our Concourse system tests run.

I tested this PR on a fork.

Closes #395 