### PR TITLE
Change spec.imagePullSecrets to spec.imagePullSecrets

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -44,8 +44,8 @@ type RabbitmqClusterSpec struct {
 	// Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster.
 	// +kubebuilder:default:="rabbitmq:3.8.9"
 	Image string `json:"image,omitempty"`
-	// Name of the Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
-	ImagePullSecret string `json:"imagePullSecret,omitempty"`
+	// List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	// +kubebuilder:default:={type: "ClusterIP"}
 	Service RabbitmqClusterServiceSpec `json:"service,omitempty"`
 	// +kubebuilder:default:={storage: "10Gi"}

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -179,9 +179,9 @@ var _ = Describe("RabbitmqCluster", func() {
 							Namespace: "default",
 						},
 						Spec: RabbitmqClusterSpec{
-							Replicas:        &three,
-							Image:           "rabbitmq-image-from-cr",
-							ImagePullSecret: "my-super-secret",
+							Replicas:         &three,
+							Image:            "rabbitmq-image-from-cr",
+							ImagePullSecrets: []corev1.LocalObjectReference{{Name: "my-super-secret"}},
 							Service: RabbitmqClusterServiceSpec{
 								Type: "NodePort",
 								Annotations: map[string]string{

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -369,6 +369,11 @@ func (in *RabbitmqClusterSpec) DeepCopyInto(out *RabbitmqClusterSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ImagePullSecrets != nil {
+		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
+		*out = make([]v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
+	}
 	in.Service.DeepCopyInto(&out.Service)
 	in.Persistence.DeepCopyInto(&out.Persistence)
 	if in.Resources != nil {

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -647,11 +647,20 @@ spec:
                 description: Image is the name of the RabbitMQ docker image to use
                   for RabbitMQ nodes in the RabbitmqCluster.
                 type: string
-              imagePullSecret:
-                description: Name of the Secret resource containing access credentials
+              imagePullSecrets:
+                description: List of Secret resource containing access credentials
                   to the registry for the RabbitMQ image. Required if the docker registry
                   is private.
-                type: string
+                items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                type: array
               override:
                 properties:
                   clientService:

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -428,8 +428,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 					},
 				},
 				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-					Replicas:        &one,
-					ImagePullSecret: "rabbit-two-secret",
+					Replicas: &one,
 				},
 			}
 
@@ -459,8 +458,8 @@ var _ = Describe("RabbitmqClusterController", func() {
 					Namespace: defaultNamespace,
 				},
 				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-					Replicas:        &one,
-					ImagePullSecret: "rabbit-two-secret",
+					Replicas:         &one,
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "rabbit-two-secret"}},
 				},
 			}
 
@@ -502,9 +501,8 @@ var _ = Describe("RabbitmqClusterController", func() {
 					Namespace: defaultNamespace,
 				},
 				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-					Replicas:        &one,
-					Affinity:        affinity,
-					ImagePullSecret: "rabbit-two-secret",
+					Replicas: &one,
+					Affinity: affinity,
 				},
 			}
 			Expect(client.Create(ctx, cluster)).To(Succeed())
@@ -534,8 +532,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 					Namespace: defaultNamespace,
 				},
 				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-					Replicas:        &one,
-					ImagePullSecret: "rabbit-service-secret",
+					Replicas: &one,
 				},
 			}
 			cluster.Spec.Service.Type = "LoadBalancer"
@@ -561,8 +558,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 					Namespace: defaultNamespace,
 				},
 				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-					Replicas:        &one,
-					ImagePullSecret: "rabbit-resource-secret",
+					Replicas: &one,
 				},
 			}
 			cluster.Spec.Resources = &corev1.ResourceRequirements{
@@ -605,8 +601,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 					Namespace: defaultNamespace,
 				},
 				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-					Replicas:        &one,
-					ImagePullSecret: "rabbit-resource-secret",
+					Replicas: &one,
 				},
 			}
 			storageClassName := "my-storage-class"
@@ -636,8 +631,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 					Namespace: defaultNamespace,
 				},
 				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-					Replicas:        &one,
-					ImagePullSecret: "rabbit-two-secret",
+					Replicas: &one,
 				},
 			}
 			clientServiceName = cluster.ChildResourceName("client")
@@ -716,7 +710,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 
 		It("the rabbitmq ImagePullSecret is updated", func() {
 			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
-				r.Spec.ImagePullSecret = "my-new-secret"
+				r.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "my-new-secret"}}
 			})).To(Succeed())
 
 			Eventually(func() []corev1.LocalObjectReference {
@@ -917,8 +911,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 					Namespace: defaultNamespace,
 				},
 				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-					Replicas:        &one,
-					ImagePullSecret: "rabbit-two-secret",
+					Replicas: &one,
 				},
 			}
 			clientServiceName = cluster.ChildResourceName("client")

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -245,12 +245,6 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 	cpuRequest := k8sresource.MustParse(initContainerCPU)
 	memoryRequest := k8sresource.MustParse(initContainerMemory)
 
-	//Image Pull Secret
-	var imagePullSecrets []corev1.LocalObjectReference
-	if builder.Instance.Spec.ImagePullSecret != "" {
-		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{Name: builder.Instance.Spec.ImagePullSecret})
-	}
-
 	automountServiceAccountToken := true
 	rabbitmqGID := int64(999)
 	rabbitmqUID := int64(999)
@@ -506,7 +500,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 				RunAsGroup: &rabbitmqGID,
 				RunAsUser:  &rabbitmqUID,
 			},
-			ImagePullSecrets:              imagePullSecrets,
+			ImagePullSecrets:              builder.Instance.Spec.ImagePullSecrets,
 			TerminationGracePeriodSeconds: &terminationGracePeriod,
 			ServiceAccountName:            builder.Instance.ChildResourceName(serviceAccountName),
 			AutomountServiceAccountToken:  &automountServiceAccountToken,

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -675,12 +675,12 @@ var _ = Describe("StatefulSet", func() {
 			})
 		})
 
-		It("updates the image pull secret; sets it back to default after deleting the configuration", func() {
-			stsBuilder.Instance.Spec.ImagePullSecret = "my-shiny-new-secret"
+		It("updates the imagePullSecrets list; sets it back to empty list after deleting the configuration", func() {
+			stsBuilder.Instance.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "my-shiny-new-secret"}}
 			Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 			Expect(statefulSet.Spec.Template.Spec.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "my-shiny-new-secret"}))
 
-			stsBuilder.Instance.Spec.ImagePullSecret = ""
+			stsBuilder.Instance.Spec.ImagePullSecrets = nil
 			Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 			Expect(statefulSet.Spec.Template.Spec.ImagePullSecrets).To(BeEmpty())
 		})
@@ -1065,9 +1065,9 @@ var _ = Describe("StatefulSet", func() {
 		})
 
 		When("configures private image", func() {
-			It("uses the instance ImagePullSecret and image reference when provided", func() {
+			It("uses the instance ImagePullSecrets and image reference when provided", func() {
 				instance.Spec.Image = "my-private-repo/rabbitmq:latest"
-				instance.Spec.ImagePullSecret = "my-great-secret"
+				instance.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "my-great-secret"}}
 				builder = &resource.RabbitmqResourceBuilder{
 					Instance: &instance,
 					Scheme:   scheme,
@@ -1410,9 +1410,9 @@ func generateRabbitmqCluster() rabbitmqv1beta1.RabbitmqCluster {
 			Namespace: "foo-namespace",
 		},
 		Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-			Replicas:        &one,
-			Image:           "rabbitmq-image-from-cr",
-			ImagePullSecret: "my-super-secret",
+			Replicas:         &one,
+			Image:            "rabbitmq-image-from-cr",
+			ImagePullSecrets: []corev1.LocalObjectReference{{Name: "my-super-secret"}},
 			Service: rabbitmqv1beta1.RabbitmqClusterServiceSpec{
 				Type:        "this-is-a-service",
 				Annotations: map[string]string{},


### PR DESCRIPTION
- directly use the k8s type LocalObjectReference to be alignedwith pod template

This closes #343 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- imagePullSecret to imagePullSecrets
- directly use the k8s type LocalObjectReference to be aligned with pod template
- docs changes are already in rabbitmq-website live because I accidentally pushed the commit without forking: https://github.com/rabbitmq/rabbitmq-website/commit/9e589eef59ec746c32cb9b7d116517c86bfb74a0  😅

Previously:

```yaml
spec:
  image: <SOME PRIVATE IMAGE>
  imagePullSecret: mygreatsecret

```

with this change

```yaml
spec:
  image: <SOME PRIVATE IMAGE>
  imagePullSecrets:
  - name: mygreatsecret

```

## Additional Context

## Local Testing

Have run unit, integration, and system tests
