### PR TITLE
Remove redundant and wrong assertion

### DIFF
--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -716,7 +716,6 @@ var _ = Describe("RabbitmqClusterController", func() {
 			Eventually(func() []corev1.LocalObjectReference {
 				stsName := cluster.ChildResourceName("server")
 				sts, _ := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
-				Expect(len(sts.Spec.Template.Spec.ImagePullSecrets)).To(Equal(1))
 				return sts.Spec.Template.Spec.ImagePullSecrets
 			}, 3).Should(ConsistOf(corev1.LocalObjectReference{Name: "my-new-secret"}))
 		})

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -622,7 +622,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 	Context("Custom Resource updates", func() {
 		var (
 			clientServiceName string
-			statefulSetName   string
+			stsName           string
 		)
 		BeforeEach(func() {
 			cluster = &rabbitmqv1beta1.RabbitmqCluster{
@@ -635,7 +635,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 				},
 			}
 			clientServiceName = cluster.ChildResourceName("client")
-			statefulSetName = cluster.ChildResourceName("server")
+			stsName = cluster.ChildResourceName("server")
 
 			Expect(client.Create(ctx, cluster)).To(Succeed())
 			waitForClusterCreation(ctx, cluster, client)
@@ -680,7 +680,6 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})).To(Succeed())
 
 			Eventually(func() corev1.ResourceList {
-				stsName := cluster.ChildResourceName("server")
 				sts, err := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				resourceRequirements = sts.Spec.Template.Spec.Containers[0].Resources
@@ -702,7 +701,6 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})).To(Succeed())
 
 			Eventually(func() string {
-				stsName := cluster.ChildResourceName("server")
 				sts, _ := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
 				return sts.Spec.Template.Spec.Containers[0].Image
 			}, 3).Should(Equal("rabbitmq:3.8.0"))
@@ -714,7 +712,6 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})).To(Succeed())
 
 			Eventually(func() []corev1.LocalObjectReference {
-				stsName := cluster.ChildResourceName("server")
 				sts, _ := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
 				return sts.Spec.Template.Spec.ImagePullSecrets
 			}, 3).Should(ConsistOf(corev1.LocalObjectReference{Name: "my-new-secret"}))
@@ -733,7 +730,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 			}, 3).Should(HaveKeyWithValue("foo", "bar"))
 			var sts *appsv1.StatefulSet
 			Eventually(func() map[string]string {
-				sts, _ = clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, statefulSetName, metav1.GetOptions{})
+				sts, _ = clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
 				return sts.Labels
 			}, 3).Should(HaveKeyWithValue("foo", "bar"))
 		})
@@ -765,7 +762,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 
 			It("updates annotations for stateful set", func() {
 				Eventually(func() map[string]string {
-					sts, err := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, statefulSetName, metav1.GetOptions{})
+					sts, err := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
 					Expect(err).NotTo(HaveOccurred())
 					return sts.Annotations
 				}, 3).Should(HaveKeyWithValue(annotationKey, annotationValue))
@@ -875,7 +872,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})).To(Succeed())
 
 			Eventually(func() *corev1.Affinity {
-				sts, _ := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, statefulSetName, metav1.GetOptions{})
+				sts, _ := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
 				return sts.Spec.Template.Spec.Affinity
 			}, 3).Should(Equal(affinity))
 
@@ -890,7 +887,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 				r.Spec.Affinity = affinity
 			})).To(Succeed())
 			Eventually(func() *corev1.Affinity {
-				sts, _ := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, statefulSetName, metav1.GetOptions{})
+				sts, _ := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
 				return sts.Spec.Template.Spec.Affinity
 			}, 3).Should(BeNil())
 		})


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

-  the expect assertion on length of imagePullSecrets is in an eventually but not as the returned result, which means that the 3 seconds timeout does not apply and when failed at the first iteration the assertion will just fail. While waiting for the statefulSet to update, this could be very flaky on a bad day
- the assertion itself is also redundant, as "ConsistOf" is an exact matcher so the length is asserted already.
- consistent naming for variable `stsName`

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
