### PR TITLE
Add rabbit memory limit

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -314,6 +314,10 @@ func (cluster *RabbitmqCluster) MutualTLSEnabled() bool {
 	return cluster.TLSEnabled() && cluster.Spec.TLS.CaSecretName != ""
 }
 
+func (cluster *RabbitmqCluster) MemoryLimitProvided() bool {
+	return cluster.Spec.Resources != nil && cluster.Spec.Resources.Limits != nil && !cluster.Spec.Resources.Limits.Memory().IsZero()
+}
+
 func (cluster *RabbitmqCluster) SingleTLSSecret() bool {
 	return cluster.MutualTLSEnabled() && cluster.Spec.TLS.CaSecretName == cluster.Spec.TLS.SecretName
 }

--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -314,7 +314,7 @@ func (cluster *RabbitmqCluster) MutualTLSEnabled() bool {
 	return cluster.TLSEnabled() && cluster.Spec.TLS.CaSecretName != ""
 }
 
-func (cluster *RabbitmqCluster) MemoryLimitProvided() bool {
+func (cluster *RabbitmqCluster) MemoryLimited() bool {
 	return cluster.Spec.Resources != nil && cluster.Spec.Resources.Limits != nil && !cluster.Spec.Resources.Limits.Memory().IsZero()
 }
 

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -113,6 +113,16 @@ var _ = Describe("RabbitmqCluster", func() {
 			Expect(created.MutualTLSEnabled()).To(BeTrue())
 		})
 
+		It("can be queried if memory limits are provided", func() {
+			created := generateRabbitmqClusterObject("rabbit-mem-limit")
+			Expect(created.MemoryLimitProvided()).To(BeTrue())
+
+			created.Spec.Resources = &corev1.ResourceRequirements{
+				Limits: map[corev1.ResourceName]resource.Quantity{},
+			}
+			Expect(created.MemoryLimitProvided()).To(BeFalse())
+		})
+
 		It("is validated", func() {
 			By("checking the replica count", func() {
 				nOne := int32(-1)

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -115,12 +115,12 @@ var _ = Describe("RabbitmqCluster", func() {
 
 		It("can be queried if memory limits are provided", func() {
 			created := generateRabbitmqClusterObject("rabbit-mem-limit")
-			Expect(created.MemoryLimitProvided()).To(BeTrue())
+			Expect(created.MemoryLimited()).To(BeTrue())
 
 			created.Spec.Resources = &corev1.ResourceRequirements{
 				Limits: map[corev1.ResourceName]resource.Quantity{},
 			}
-			Expect(created.MemoryLimitProvided()).To(BeFalse())
+			Expect(created.MemoryLimited()).To(BeFalse())
 		})
 
 		It("is validated", func() {

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -144,10 +144,41 @@ func updateProperty(configMapData map[string]string, key string, value string) {
 }
 
 func formatMemory(k8sMemory string) (string, error) {
-	if strings.HasSuffix(k8sMemory, "Ki") || strings.HasSuffix(k8sMemory, "Mi") ||
-		strings.HasSuffix(k8sMemory, "Gi") || strings.HasSuffix(k8sMemory, "Ti") ||
-		strings.HasSuffix(k8sMemory, "Pi") || strings.HasSuffix(k8sMemory, "Ei") {
+	if strings.HasSuffix(k8sMemory, "Mi") || strings.HasSuffix(k8sMemory, "Gi") || strings.HasSuffix(k8sMemory, "M") || strings.HasSuffix(k8sMemory, "G") {
 		return k8sMemory + "B", nil
+	}
+	if strings.HasSuffix(k8sMemory, "K") || strings.HasSuffix(k8sMemory, "Ki") {
+		return strings.ToLower(k8sMemory) + "B", nil
+	}
+	if strings.HasSuffix(k8sMemory, "Ti") {
+		tb, err := strconv.Atoi(strings.TrimSuffix(k8sMemory, "Ti"))
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%dGiB", tb*1024), nil
+	}
+	if strings.HasSuffix(k8sMemory, "Pi") {
+		pb, err := strconv.Atoi(strings.TrimSuffix(k8sMemory, "Pi"))
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%dGiB", pb*1048576), nil
+	}
+	if strings.HasSuffix(k8sMemory, "Ei") {
+		eb, err := strconv.Atoi(strings.TrimSuffix(k8sMemory, "Ei"))
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%dGiB", eb*1073741824), nil
+	}
+	if strings.HasSuffix(k8sMemory, "T") {
+		return strings.TrimSuffix(k8sMemory, "T")+"000GB", nil
+	}
+	if strings.HasSuffix(k8sMemory, "P") {
+		return strings.TrimSuffix(k8sMemory, "P")+"000000GB", nil
+	}
+	if strings.HasSuffix(k8sMemory, "E") {
+		return strings.TrimSuffix(k8sMemory, "E")+"000000000GB", nil
 	}
 	if strings.Contains(k8sMemory, "e") {
 		splitMemory := strings.Split(k8sMemory, "e")

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -88,7 +88,7 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 		}
 	}
 
-	if builder.Instance.MemoryLimitProvided() {
+	if builder.Instance.MemoryLimited() {
 		if _, err := defaultSection.NewKey("total_memory_available_override_value", fmt.Sprintf("%d", removeHeadroom(builder.Instance.Spec.Resources.Limits.Memory().Value()))); err != nil {
 			return err
 		}
@@ -137,6 +137,8 @@ func updateProperty(configMapData map[string]string, key string, value string) {
 	}
 }
 
+// The Erlang VM needs headroom above Rabbit to avoid being OOM killed
+// We set the headroom to be the smaller amount of 20% memory or 2GiB
 func removeHeadroom(memLimit int64) int64 {
 	const GiB int64 = 1073741824
 	if memLimit/5 > 2*GiB {

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -172,13 +172,13 @@ func formatMemory(k8sMemory string) (string, error) {
 		return fmt.Sprintf("%dGiB", eb*1073741824), nil
 	}
 	if strings.HasSuffix(k8sMemory, "T") {
-		return strings.TrimSuffix(k8sMemory, "T")+"000GB", nil
+		return strings.TrimSuffix(k8sMemory, "T") + "000GB", nil
 	}
 	if strings.HasSuffix(k8sMemory, "P") {
-		return strings.TrimSuffix(k8sMemory, "P")+"000000GB", nil
+		return strings.TrimSuffix(k8sMemory, "P") + "000000GB", nil
 	}
 	if strings.HasSuffix(k8sMemory, "E") {
-		return strings.TrimSuffix(k8sMemory, "E")+"000000000GB", nil
+		return strings.TrimSuffix(k8sMemory, "E") + "000000000GB", nil
 	}
 	if strings.Contains(k8sMemory, "e") {
 		splitMemory := strings.Split(k8sMemory, "e")


### PR DESCRIPTION
This closes #392

**Note to reviewers:** the commits should be squashed before merging

## Summary Of Changes
Sets `total_memory_available_override_value` in rabbitmq.conf if there is a memory resource limit.