### PR TITLE
Set topologySpreadConstraints by default

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -491,6 +491,19 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 			Labels:      labels,
 		},
 		Spec: corev1.PodSpec{
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+				{
+					MaxSkew: 1,
+					// "topology.kubernetes.io/zone" is a well-known label.
+					// It is automatically set by kubelet if the cloud provider provides the zone information.
+					// See: https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#topologykubernetesiozone
+					TopologyKey:       "topology.kubernetes.io/zone",
+					WhenUnsatisfiable: corev1.ScheduleAnyway,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: metadata.LabelSelector(builder.Instance.Name),
+					},
+				},
+			},
 			SecurityContext: &corev1.PodSecurityContext{
 				FSGroup:    &rabbitmqGID,
 				RunAsGroup: &rabbitmqGID,


### PR DESCRIPTION
This closes #398

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- "topology.kubernetes.io/zone" is a popular label set by kubelet on worker nodes
- "ScheduleAnyways" makes sure that this constraint is treated as a soft requirement, and pods still get scheduled without meeting the requirement
- using hostname as topologyKey is also a valid contraint. However, the official docs recommends not to set multiple contraints if possible to aviod conflicts

## Additional Context

## Local Testing

Added new test in unit tests to ensure on the templating level. Have run unit, integration, and system tests
