### PR TITLE
Use a tcp readiness probe instead of cli command

### DIFF
--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
 )
@@ -941,8 +942,9 @@ var _ = Describe("StatefulSet", func() {
 			Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 
 			container := extractContainer(statefulSet.Spec.Template.Spec.Containers, "rabbitmq")
-			actualProbeCommand := container.ReadinessProbe.Handler.Exec.Command
-			Expect(actualProbeCommand).To(Equal([]string{"/bin/sh", "-c", "rabbitmq-diagnostics check_port_connectivity"}))
+			TCPProbe := container.ReadinessProbe.TCPSocket
+			Expect(TCPProbe.Port.Type).To(Equal(intstr.String))
+			Expect(TCPProbe.Port.StrVal).To(Equal("amqp"))
 		})
 
 		It("templates the correct InitContainer", func() {


### PR DESCRIPTION
This closes #409

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- define a tcp readiness probe
- rabbitmq-diagnostics check_port_connectivity as readiness probe causes context deadline exceeded errors, and pods
could be stuck at terminating for deletion
- reduce PeriodSeconds in readinessProbe to 10 seconds since a tcp probe should be less expansive than running a diagnostics command

## Additional Context

See issue: #409 for more details

## Local Testing

Have run unit, integration, and system tests