### PR TITLE
Rename cluster-links to cluster-rpc in headless service.

### DIFF
--- a/internal/resource/headless_service.go
+++ b/internal/resource/headless_service.go
@@ -60,7 +60,7 @@ func (builder *HeadlessServiceBuilder) Update(object runtime.Object) error {
 			{
 				Protocol: corev1.ProtocolTCP,
 				Port:     25672,
-				Name:     "cluster-links", // aka distribution port
+				Name:     "cluster-rpc", // aka distribution port
 			},
 		},
 		PublishNotReadyAddresses: true,

--- a/internal/resource/headless_service_test.go
+++ b/internal/resource/headless_service_test.go
@@ -188,7 +188,7 @@ var _ = Describe("HeadlessService", func() {
 					{
 						Protocol: corev1.ProtocolTCP,
 						Port:     25672,
-						Name:     "cluster-links",
+						Name:     "cluster-rpc",
 					},
 				},
 				PublishNotReadyAddresses: true,


### PR DESCRIPTION
This closes #420 

Have run unit and integration tests. System tests should run via github actions.
