### PR TITLE
Set up `rabbitmqadmin` automatically

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -533,7 +533,11 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 							"&& chmod 600 /var/lib/rabbitmq/.erlang.cookie ; " +
 							"cp /tmp/rabbitmq-plugins/enabled_plugins /operator/enabled_plugins " +
 							"&& chown 999:999 /operator/enabled_plugins ; " +
-							"chgrp 999 /var/lib/rabbitmq/mnesia/",
+							"chgrp 999 /var/lib/rabbitmq/mnesia/ ; " +
+							"echo '[default]' > /var/lib/rabbitmq/.rabbitmqadmin.conf " +
+							"&& sed -e 's/default_user/username/' -e 's/default_pass/password/' /tmp/default_user.conf >> /var/lib/rabbitmq/.rabbitmqadmin.conf " +
+							"&& chown 999:999 /var/lib/rabbitmq/.rabbitmqadmin.conf " +
+							"&& chmod 600 /var/lib/rabbitmq/.rabbitmqadmin.conf",
 					},
 					Resources: corev1.ResourceRequirements{
 						Limits: map[corev1.ResourceName]k8sresource.Quantity{
@@ -565,6 +569,11 @@ func (builder *StatefulSetBuilder) podTemplateSpec(annotations, labels map[strin
 						{
 							Name:      "persistence",
 							MountPath: "/var/lib/rabbitmq/mnesia/",
+						},
+						{
+							Name:      "rabbitmq-confd",
+							MountPath: "/tmp/default_user.conf",
+							SubPath:   "default_user.conf",
 						},
 					},
 				},

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -986,7 +986,11 @@ var _ = Describe("StatefulSet", func() {
 						"&& chmod 600 /var/lib/rabbitmq/.erlang.cookie ; "+
 						"cp /tmp/rabbitmq-plugins/enabled_plugins /operator/enabled_plugins "+
 						"&& chown 999:999 /operator/enabled_plugins ; "+
-						"chgrp 999 /var/lib/rabbitmq/mnesia/",
+						"chgrp 999 /var/lib/rabbitmq/mnesia/ ; "+
+						"echo '[default]' > /var/lib/rabbitmq/.rabbitmqadmin.conf "+
+						"&& sed -e 's/default_user/username/' -e 's/default_pass/password/' /tmp/default_user.conf >> /var/lib/rabbitmq/.rabbitmqadmin.conf "+
+						"&& chown 999:999 /var/lib/rabbitmq/.rabbitmqadmin.conf "+
+						"&& chmod 600 /var/lib/rabbitmq/.rabbitmqadmin.conf",
 				),
 				"VolumeMounts": ConsistOf(
 					corev1.VolumeMount{
@@ -1008,6 +1012,11 @@ var _ = Describe("StatefulSet", func() {
 					corev1.VolumeMount{
 						Name:      "persistence",
 						MountPath: "/var/lib/rabbitmq/mnesia/",
+					},
+					corev1.VolumeMount{
+						Name:      "rabbitmq-confd",
+						MountPath: "/tmp/default_user.conf",
+						SubPath:   "default_user.conf",
 					},
 				),
 			}))


### PR DESCRIPTION
For images the contain `rabbitmqadmin` CLI, this PR configures that CLI so that it's ready to be used.

This closes rabbitmq/tanzu-cluster-operator#13
