### PR TITLE
Apply same code format for all resources

### DIFF
--- a/internal/resource/client_service.go
+++ b/internal/resource/client_service.go
@@ -23,16 +23,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+type ClientServiceBuilder struct {
+	Instance *rabbitmqv1beta1.RabbitmqCluster
+	Scheme   *runtime.Scheme
+}
+
 func (builder *RabbitmqResourceBuilder) ClientService() *ClientServiceBuilder {
 	return &ClientServiceBuilder{
 		Instance: builder.Instance,
 		Scheme:   builder.Scheme,
 	}
-}
-
-type ClientServiceBuilder struct {
-	Instance *rabbitmqv1beta1.RabbitmqCluster
-	Scheme   *runtime.Scheme
 }
 
 func (builder *ClientServiceBuilder) Build() (runtime.Object, error) {

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -52,6 +52,15 @@ func (builder *RabbitmqResourceBuilder) ServerConfigMap() *ServerConfigMapBuilde
 	}
 }
 
+func (builder *ServerConfigMapBuilder) Build() (runtime.Object, error) {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      builder.Instance.ChildResourceName(ServerConfigMapName),
+			Namespace: builder.Instance.Namespace,
+		},
+	}, nil
+}
+
 func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 	configMap := object.(*corev1.ConfigMap)
 	configMap.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)
@@ -113,15 +122,6 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 	}
 
 	return nil
-}
-
-func (builder *ServerConfigMapBuilder) Build() (runtime.Object, error) {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      builder.Instance.ChildResourceName(ServerConfigMapName),
-			Namespace: builder.Instance.Namespace,
-		},
-	}, nil
 }
 
 func updateProperty(configMapData map[string]string, key string, value string) {

--- a/internal/resource/rabbitmq_plugins.go
+++ b/internal/resource/rabbitmq_plugins.go
@@ -2,8 +2,9 @@ package resource
 
 import (
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/metadata"
@@ -20,14 +21,49 @@ var requiredPlugins = []string{
 
 const PluginsConfigName = "plugins-conf"
 
-type RabbitmqPlugins struct {
-	requiredPlugins   []string
-	additionalPlugins []string
-}
-
 type RabbitmqPluginsConfigMapBuilder struct {
 	Instance *rabbitmqv1beta1.RabbitmqCluster
 	Scheme   *runtime.Scheme
+}
+
+func (builder *RabbitmqResourceBuilder) RabbitmqPluginsConfigMap() *RabbitmqPluginsConfigMapBuilder {
+	return &RabbitmqPluginsConfigMapBuilder{
+		Instance: builder.Instance,
+		Scheme:   builder.Scheme,
+	}
+}
+
+func (builder *RabbitmqPluginsConfigMapBuilder) Build() (runtime.Object, error) {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      builder.Instance.ChildResourceName(PluginsConfigName),
+			Namespace: builder.Instance.Namespace,
+		},
+		Data: map[string]string{
+			"enabled_plugins": desiredPluginsAsString([]rabbitmqv1beta1.Plugin{}),
+		},
+	}, nil
+}
+
+func (builder *RabbitmqPluginsConfigMapBuilder) Update(object runtime.Object) error {
+	configMap := object.(*corev1.ConfigMap)
+	configMap.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)
+	configMap.Annotations = metadata.ReconcileAndFilterAnnotations(configMap.GetAnnotations(), builder.Instance.Annotations)
+
+	if configMap.Data == nil {
+		configMap.Data = make(map[string]string)
+	}
+	configMap.Data["enabled_plugins"] = desiredPluginsAsString(builder.Instance.Spec.Rabbitmq.AdditionalPlugins)
+
+	if err := controllerutil.SetControllerReference(builder.Instance, configMap, builder.Scheme); err != nil {
+		return fmt.Errorf("failed setting controller reference: %v", err)
+	}
+	return nil
+}
+
+type RabbitmqPlugins struct {
+	requiredPlugins   []string
+	additionalPlugins []string
 }
 
 func NewRabbitmqPlugins(plugins []rabbitmqv1beta1.Plugin) RabbitmqPlugins {
@@ -58,41 +94,6 @@ func (r *RabbitmqPlugins) DesiredPlugins() []string {
 
 func (r *RabbitmqPlugins) AsString(sep string) string {
 	return strings.Join(r.DesiredPlugins(), sep)
-}
-
-func (builder *RabbitmqResourceBuilder) RabbitmqPluginsConfigMap() *RabbitmqPluginsConfigMapBuilder {
-	return &RabbitmqPluginsConfigMapBuilder{
-		Instance: builder.Instance,
-		Scheme:   builder.Scheme,
-	}
-}
-
-func (builder *RabbitmqPluginsConfigMapBuilder) Update(object runtime.Object) error {
-	configMap := object.(*corev1.ConfigMap)
-	configMap.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)
-	configMap.Annotations = metadata.ReconcileAndFilterAnnotations(configMap.GetAnnotations(), builder.Instance.Annotations)
-
-	if configMap.Data == nil {
-		configMap.Data = make(map[string]string)
-	}
-	configMap.Data["enabled_plugins"] = desiredPluginsAsString(builder.Instance.Spec.Rabbitmq.AdditionalPlugins)
-
-	if err := controllerutil.SetControllerReference(builder.Instance, configMap, builder.Scheme); err != nil {
-		return fmt.Errorf("failed setting controller reference: %v", err)
-	}
-	return nil
-}
-
-func (builder *RabbitmqPluginsConfigMapBuilder) Build() (runtime.Object, error) {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      builder.Instance.ChildResourceName(PluginsConfigName),
-			Namespace: builder.Instance.Namespace,
-		},
-		Data: map[string]string{
-			"enabled_plugins": desiredPluginsAsString([]rabbitmqv1beta1.Plugin{}),
-		},
-	}, nil
 }
 
 func desiredPluginsAsString(additionalPlugins []rabbitmqv1beta1.Plugin) string {

--- a/internal/resource/rabbitmq_resource_builder.go
+++ b/internal/resource/rabbitmq_resource_builder.go
@@ -20,8 +20,8 @@ type RabbitmqResourceBuilder struct {
 }
 
 type ResourceBuilder interface {
-	Update(runtime.Object) error
 	Build() (runtime.Object, error)
+	Update(runtime.Object) error
 }
 
 func (builder *RabbitmqResourceBuilder) ResourceBuilders() ([]ResourceBuilder, error) {

--- a/internal/resource/role.go
+++ b/internal/resource/role.go
@@ -11,6 +11,7 @@ package resource
 
 import (
 	"fmt"
+
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/metadata"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -35,6 +36,15 @@ func (builder *RabbitmqResourceBuilder) Role() *RoleBuilder {
 	}
 }
 
+func (builder *RoleBuilder) Build() (runtime.Object, error) {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: builder.Instance.Namespace,
+			Name:      builder.Instance.ChildResourceName(roleName),
+		},
+	}, nil
+}
+
 func (builder *RoleBuilder) Update(object runtime.Object) error {
 	role := object.(*rbacv1.Role)
 	role.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)
@@ -55,15 +65,5 @@ func (builder *RoleBuilder) Update(object runtime.Object) error {
 	if err := controllerutil.SetControllerReference(builder.Instance, role, builder.Scheme); err != nil {
 		return fmt.Errorf("failed setting controller reference: %v", err)
 	}
-
 	return nil
-}
-
-func (builder *RoleBuilder) Build() (runtime.Object, error) {
-	return &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: builder.Instance.Namespace,
-			Name:      builder.Instance.ChildResourceName(roleName),
-		},
-	}, nil
 }

--- a/internal/resource/service_account.go
+++ b/internal/resource/service_account.go
@@ -11,6 +11,7 @@ package resource
 
 import (
 	"fmt"
+
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/metadata"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,15 @@ func (builder *RabbitmqResourceBuilder) ServiceAccount() *ServiceAccountBuilder 
 	}
 }
 
+func (builder *ServiceAccountBuilder) Build() (runtime.Object, error) {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: builder.Instance.Namespace,
+			Name:      builder.Instance.ChildResourceName(serviceAccountName),
+		},
+	}, nil
+}
+
 func (builder *ServiceAccountBuilder) Update(object runtime.Object) error {
 	serviceAccount := object.(*corev1.ServiceAccount)
 	serviceAccount.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)
@@ -44,13 +54,4 @@ func (builder *ServiceAccountBuilder) Update(object runtime.Object) error {
 		return fmt.Errorf("failed setting controller reference: %v", err)
 	}
 	return nil
-}
-
-func (builder *ServiceAccountBuilder) Build() (runtime.Object, error) {
-	return &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: builder.Instance.Namespace,
-			Name:      builder.Instance.ChildResourceName(serviceAccountName),
-		},
-	}, nil
 }


### PR DESCRIPTION
This is a simple copy and paste (no change of functionality) such that all resources have the same
code format in the form of:

```
type Builder struct {...}
NewBuilder() *Builder
Build()
Update()
private methods
```

to easier navigate the resources.