### PR TITLE
Format expected config file with ini pkg

### DIFF
--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -382,6 +382,6 @@ func iniString(input string) string {
 	var output bytes.Buffer
 	cfg, _ := ini.Load([]byte(input))
 	_, err := cfg.WriteTo(&output)
-	Expect(err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	return output.String()
 }


### PR DESCRIPTION
This way the tests are not sensitive to whitespace differences since they compare actual config
file with the expected value after formatting using the same method as the actual code

To test, you can add/remove some spaces in `expectedRabbitmqConf` and the tests should still pass.