### PR TITLE
Enable all feature flags for new clusters

### DIFF
--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -14,14 +14,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
+
 	"github.com/rabbitmq/cluster-operator/internal/resource"
 	"github.com/rabbitmq/cluster-operator/internal/status"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	"reflect"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -182,7 +183,7 @@ func (r *RabbitmqClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 			return ctrl.Result{}, err
 		}
 
-		if err = r.annotateConfigMapIfUpdated(ctx, builder, operationResult, rabbitmqCluster); err != nil {
+		if err = r.annotateIfNeeded(ctx, builder, operationResult, rabbitmqCluster); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/rabbitmq/cluster-operator/internal/resource"
 	"github.com/rabbitmq/cluster-operator/internal/status"
@@ -211,7 +212,7 @@ func (r *RabbitmqClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 
 	// By this point the StatefulSet may have finished deploying. Run any
 	// post-deploy steps if so, or requeue until the deployment is finished.
-	requeueAfter, err = r.runPostDeployStepsIfNeeded(ctx, rabbitmqCluster)
+	requeueAfter, err = r.runRabbitmqCLICommandsIfAnnotated(ctx, rabbitmqCluster)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -338,4 +339,20 @@ func validateAndGetOwner(owner *metav1.OwnerReference) []string {
 		return nil
 	}
 	return []string{owner.Name}
+}
+
+func (r *RabbitmqClusterReconciler) markForQueueRebalance(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) error {
+	if rmq.ObjectMeta.Annotations == nil {
+		rmq.ObjectMeta.Annotations = make(map[string]string)
+	}
+
+	if len(rmq.ObjectMeta.Annotations[queueRebalanceAnnotation]) > 0 {
+		return nil
+	}
+
+	rmq.ObjectMeta.Annotations[queueRebalanceAnnotation] = time.Now().Format(time.RFC3339)
+	if err := r.Update(ctx, rmq); err != nil {
+		return err
+	}
+	return nil
 }

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -1188,12 +1188,11 @@ func createSecret(ctx context.Context, secretName string, namespace string, data
 func waitForClusterCreation(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster, client runtimeClient.Client) {
 	EventuallyWithOffset(1, func() string {
 		rabbitmqClusterCreated := rabbitmqv1beta1.RabbitmqCluster{}
-		err := client.Get(
+		if err := client.Get(
 			ctx,
 			types.NamespacedName{Name: rabbitmqCluster.Name, Namespace: rabbitmqCluster.Namespace},
 			&rabbitmqClusterCreated,
-		)
-		if err != nil {
+		); err != nil {
 			return fmt.Sprintf("%v+", err)
 		}
 

--- a/controllers/reconcile_cli_test.go
+++ b/controllers/reconcile_cli_test.go
@@ -14,7 +14,7 @@ import (
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 )
 
-var _ = Describe("Reconcile post deploy", func() {
+var _ = Describe("Reconcile CLI", func() {
 	var (
 		cluster          *rabbitmqv1beta1.RabbitmqCluster
 		annotations      map[string]string

--- a/controllers/reconcile_post_deploy_test.go
+++ b/controllers/reconcile_post_deploy_test.go
@@ -1,9 +1,10 @@
 package controllers_test
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +14,7 @@ import (
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 )
 
-var _ = Describe("Reconcile queue Rebalance", func() {
+var _ = Describe("Reconcile post deploy", func() {
 	var (
 		cluster          *rabbitmqv1beta1.RabbitmqCluster
 		annotations      map[string]string
@@ -27,6 +28,41 @@ var _ = Describe("Reconcile queue Rebalance", func() {
 	AfterEach(func() {
 		Expect(client.Delete(ctx, cluster)).To(Succeed())
 		waitForClusterDeletion(ctx, cluster, client)
+	})
+
+	When("cluster is created", func() {
+		var sts *appsv1.StatefulSet
+		BeforeEach(func() {
+			cluster = &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rabbitmq-feature-flags",
+					Namespace: defaultNamespace,
+				},
+			}
+			Expect(client.Create(ctx, cluster)).To(Succeed())
+			waitForClusterCreation(ctx, cluster, client)
+		})
+
+		It("enables all feature flags", func() {
+			By("annotating that StatefulSet got created", func() {
+				sts = statefulSet(ctx, cluster)
+				value := sts.ObjectMeta.Annotations["rabbitmq.com/createdAt"]
+				_, err := time.Parse(time.RFC3339, value)
+				Expect(err).NotTo(HaveOccurred(), "annotation rabbitmq.com/createdAt was not a valid RFC3339 timestamp")
+			})
+
+			By("enabling all feature flags once all Pods are up, and removing the annotation", func() {
+				sts.Status.Replicas = 1
+				sts.Status.ReadyReplicas = 1
+				Expect(client.Status().Update(ctx, sts)).To(Succeed())
+				Eventually(func() map[string]string {
+					Expect(client.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.ChildResourceName("server")}, sts)).To(Succeed())
+					return sts.ObjectMeta.Annotations
+				}, 5).ShouldNot(HaveKey("rabbitmq.com/createdAt"))
+				Expect(fakeExecutor.ExecutedCommands()).To(ContainElement(command{"bash", "-c",
+					"set -eo pipefail; rabbitmqctl -s list_feature_flags name state stability | (grep 'disabled\\sstable$' || true) | cut -f 1 | xargs -r -n1 rabbitmqctl enable_feature_flag"}))
+			})
+		})
 	})
 
 	When("the cluster is configured to run post-deploy steps", func() {
@@ -54,22 +90,19 @@ var _ = Describe("Reconcile queue Rebalance", func() {
 				sts.Status.UpdatedReplicas = 1
 				sts.Status.UpdateRevision = "some-new-revision"
 
-				statusWriter := client.Status()
-				err := statusWriter.Update(ctx, sts)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(client.Status().Update(ctx, sts)).To(Succeed())
 			})
 
 			It("triggers the controller to run rabbitmq-queues rebalance all", func() {
 				By("setting an annotation on the CR", func() {
 					Eventually(func() map[string]string {
 						rmq := &rabbitmqv1beta1.RabbitmqCluster{}
-						err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
-						Expect(err).To(BeNil())
+						Expect(client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)).To(Succeed())
 						annotations = rmq.ObjectMeta.Annotations
 						return annotations
 					}, 5).Should(HaveKey("rabbitmq.com/queueRebalanceNeededAt"))
 					_, err := time.Parse(time.RFC3339, annotations["rabbitmq.com/queueRebalanceNeededAt"])
-					Expect(err).NotTo(HaveOccurred(), "Annotation rabbitmq.com/queueRebalanceNeededAt was not a valid RFC3339 timestamp")
+					Expect(err).NotTo(HaveOccurred(), "annotation rabbitmq.com/queueRebalanceNeededAt was not a valid RFC3339 timestamp")
 				})
 
 				By("not removing the annotation when all replicas are updated but not yet ready", func() {
@@ -78,9 +111,7 @@ var _ = Describe("Reconcile queue Rebalance", func() {
 					sts.Status.UpdatedReplicas = 3
 					sts.Status.UpdateRevision = "some-new-revision"
 					sts.Status.ReadyReplicas = 2
-					statusWriter := client.Status()
-					err := statusWriter.Update(ctx, sts)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(client.Status().Update(ctx, sts)).To(Succeed())
 					Eventually(func() map[string]string {
 						rmq := &rabbitmqv1beta1.RabbitmqCluster{}
 						err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
@@ -89,15 +120,13 @@ var _ = Describe("Reconcile queue Rebalance", func() {
 						return annotations
 					}, 5).Should(HaveKey("rabbitmq.com/queueRebalanceNeededAt"))
 					Expect(fakeExecutor.ExecutedCommands()).NotTo(ContainElement(command{"sh", "-c", "rabbitmq-queues rebalance all"}))
-					_, err = time.Parse(time.RFC3339, annotations["rabbitmq.com/queueRebalanceNeededAt"])
+					_, err := time.Parse(time.RFC3339, annotations["rabbitmq.com/queueRebalanceNeededAt"])
 					Expect(err).NotTo(HaveOccurred(), "Annotation rabbitmq.com/queueRebalanceNeededAt was not a valid RFC3339 timestamp")
 				})
 
 				By("removing the annotation once all Pods are up, and triggering the queue rebalance", func() {
 					sts.Status.ReadyReplicas = 3
-					statusWriter := client.Status()
-					err := statusWriter.Update(ctx, sts)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(client.Status().Update(ctx, sts)).To(Succeed())
 					Eventually(func() map[string]string {
 						rmq := &rabbitmqv1beta1.RabbitmqCluster{}
 						err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
@@ -136,9 +165,7 @@ var _ = Describe("Reconcile queue Rebalance", func() {
 				sts.Status.UpdatedReplicas = 1
 				sts.Status.UpdateRevision = "some-new-revision"
 
-				statusWriter := client.Status()
-				err := statusWriter.Update(ctx, sts)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(client.Status().Update(ctx, sts)).To(Succeed())
 			})
 
 			It("does not trigger the controller to run rabbitmq-queues rebalance all", func() {
@@ -157,9 +184,7 @@ var _ = Describe("Reconcile queue Rebalance", func() {
 					sts.Status.UpdatedReplicas = 3
 					sts.Status.UpdateRevision = "some-new-revision"
 					sts.Status.ReadyReplicas = 3
-					statusWriter := client.Status()
-					err := statusWriter.Update(ctx, sts)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(client.Status().Update(ctx, sts)).To(Succeed())
 					Consistently(func() map[string]string {
 						rmq := &rabbitmqv1beta1.RabbitmqCluster{}
 						err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
@@ -168,9 +193,7 @@ var _ = Describe("Reconcile queue Rebalance", func() {
 					}, 5).ShouldNot(HaveKey("rabbitmq.com/queueRebalanceNeededAt"))
 					Expect(fakeExecutor.ExecutedCommands()).NotTo(ContainElement(command{"sh", "-c", "rabbitmq-queues rebalance all"}))
 				})
-
 			})
-
 		})
 	})
 
@@ -201,9 +224,7 @@ var _ = Describe("Reconcile queue Rebalance", func() {
 				sts.Status.UpdateRevision = "some-new-revision"
 				sts.Status.ReadyReplicas = 0
 
-				statusWriter := client.Status()
-				err := statusWriter.Update(ctx, sts)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(client.Status().Update(ctx, sts)).To(Succeed())
 			})
 
 			It("does not trigger the controller to run rabbitmq-queues rebalance all", func() {
@@ -222,9 +243,7 @@ var _ = Describe("Reconcile queue Rebalance", func() {
 					sts.Status.UpdatedReplicas = 1
 					sts.Status.UpdateRevision = "some-new-revision"
 					sts.Status.ReadyReplicas = 1
-					statusWriter := client.Status()
-					err := statusWriter.Update(ctx, sts)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(client.Status().Update(ctx, sts)).To(Succeed())
 					Consistently(func() map[string]string {
 						rmq := &rabbitmqv1beta1.RabbitmqCluster{}
 						err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
@@ -233,9 +252,7 @@ var _ = Describe("Reconcile queue Rebalance", func() {
 					}, 5).ShouldNot(HaveKey("rabbitmq.com/queueRebalanceNeededAt"))
 					Expect(fakeExecutor.ExecutedCommands()).NotTo(ContainElement(command{"sh", "-c", "rabbitmq-queues rebalance all"}))
 				})
-
 			})
-
 		})
 	})
 })

--- a/controllers/reconcile_rabbitmq_configurations.go
+++ b/controllers/reconcile_rabbitmq_configurations.go
@@ -128,14 +128,10 @@ func (r *RabbitmqClusterReconciler) restartStatefulSetIfNeeded(ctx context.Conte
 }
 
 func pluginsConfigUpdatedRecently(cfg *corev1.ConfigMap) (bool, error) {
-	if cfg == nil {
-		return false, nil
-	}
 	pluginsUpdatedAt, ok := cfg.Annotations[pluginsUpdateAnnotation]
 	if !ok {
 		return false, nil // plugins configMap was not updated
 	}
-
 	annotationTime, err := time.Parse(time.RFC3339, pluginsUpdatedAt)
 	if err != nil {
 		return false, err

--- a/controllers/reconcile_rabbitmq_configurations.go
+++ b/controllers/reconcile_rabbitmq_configurations.go
@@ -3,90 +3,80 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
+
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientretry "k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"time"
 )
 
 const (
 	pluginsUpdateAnnotation = "rabbitmq.com/pluginsUpdatedAt"
 	serverConfAnnotation    = "rabbitmq.com/serverConfUpdatedAt"
 	stsRestartAnnotation    = "rabbitmq.com/lastRestartAt"
+	stsCreateAnnotation     = "rabbitmq.com/createdAt"
 )
 
-// There are 2 paths how plugins are set:
-// 1. When StatefulSet is (re)started, the up-to-date plugins list (ConfigMap copied by the init container) is read by RabbitMQ nodes during node start up.
-// 2. When the plugins ConfigMap is changed, 'rabbitmq-plugins set' updates the plugins on every node (without the need to re-start the nodes).
-// This method implements the 2nd path.
-func (r *RabbitmqClusterReconciler) runSetPluginsCommand(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster, configMap *corev1.ConfigMap) error {
-	plugins := resource.NewRabbitmqPlugins(rmq.Spec.Rabbitmq.AdditionalPlugins)
-	for i := int32(0); i < *rmq.Spec.Replicas; i++ {
-		podName := fmt.Sprintf("%s-%d", rmq.ChildResourceName("server"), i)
-		rabbitCommand := fmt.Sprintf("rabbitmq-plugins set %s", plugins.AsString(" "))
-		stdout, stderr, err := r.exec(rmq.Namespace, podName, "rabbitmq", "sh", "-c", rabbitCommand)
-		if err != nil {
-			r.Log.Error(err, "failed to set plugins",
-				"namespace", rmq.Namespace,
-				"name", rmq.Name,
-				"pod", podName,
-				"command", rabbitCommand,
-				"stdout", stdout,
-				"stderr", stderr)
-			return err
-		}
-	}
-	r.Log.Info("successfully set plugins on RabbitmqCluster",
-		"namespace", rmq.Namespace,
-		"name", rmq.Name)
+// Annotates an object depending on object type and operationResult.
+// These annotations are temporary markers used in later reconcile loops to perform some action (such as restarting the StatefulSet or executing RabbitMQ CLI commands)
+func (r *RabbitmqClusterReconciler) annotateIfNeeded(ctx context.Context, builder resource.ResourceBuilder, operationResult controllerutil.OperationResult, rmq *rabbitmqv1beta1.RabbitmqCluster) error {
+	var (
+		obj           runtime.Object
+		objName       string
+		annotationKey string
+	)
 
-	delete(configMap.Annotations, pluginsUpdateAnnotation)
-	if err := r.Update(ctx, configMap); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Annotates the plugins ConfigMap or the server-conf ConfigMap
-// annotations later used to indicate whether to call 'rabbitmq-plugins set' or to restart the sts
-func (r *RabbitmqClusterReconciler) annotateConfigMapIfUpdated(ctx context.Context, builder resource.ResourceBuilder, operationResult controllerutil.OperationResult, rmq *rabbitmqv1beta1.RabbitmqCluster) error {
-	if operationResult != controllerutil.OperationResultUpdated {
-		return nil
-	}
-
-	var configMap, annotationKey string
 	switch builder.(type) {
+
 	case *resource.RabbitmqPluginsConfigMapBuilder:
-		configMap = rmq.ChildResourceName(resource.PluginsConfigName)
+		if operationResult != controllerutil.OperationResultUpdated {
+			return nil
+		}
+		obj = &corev1.ConfigMap{}
+		objName = rmq.ChildResourceName(resource.PluginsConfigName)
 		annotationKey = pluginsUpdateAnnotation
+
 	case *resource.ServerConfigMapBuilder:
-		configMap = rmq.ChildResourceName(resource.ServerConfigMapName)
+		if operationResult != controllerutil.OperationResultUpdated {
+			return nil
+		}
+		obj = &corev1.ConfigMap{}
+		objName = rmq.ChildResourceName(resource.ServerConfigMapName)
 		annotationKey = serverConfAnnotation
+
+	case *resource.StatefulSetBuilder:
+		if operationResult != controllerutil.OperationResultCreated {
+			return nil
+		}
+		obj = &appsv1.StatefulSet{}
+		objName = rmq.ChildResourceName("server")
+		annotationKey = stsCreateAnnotation
+
 	default:
 		return nil
 	}
 
-	if err := r.annotateConfigMap(ctx, rmq.Namespace, configMap, annotationKey, time.Now().Format(time.RFC3339)); err != nil {
-		msg := fmt.Sprintf("Failed to annotate ConfigMap %s of Namespace %s; %s may be outdated", configMap, rmq.Namespace, rmq.Name)
-		r.Log.Error(err, msg)
+	if err := r.updateAnnotation(ctx, obj, rmq.Namespace, objName, annotationKey, time.Now().Format(time.RFC3339)); err != nil {
+		msg := "failed to annotate " + objName
+		r.Log.Error(err, msg, "namespace", rmq.Namespace)
 		r.Recorder.Event(rmq, corev1.EventTypeWarning, "FailedUpdate", msg)
 		return err
 	}
 
-	r.Log.Info("successfully annotated", "ConfigMap", configMap, "Namespace", rmq.Namespace)
+	r.Log.Info("successfully annotated", "namespace", rmq.Namespace, "name", objName)
 	return nil
 }
 
-// Adds an arbitrary annotation to the sts PodTemplate to trigger a sts restart
-// it compares annotation "rabbitmq.com/serverConfUpdatedAt" from server-conf configMap and annotation "rabbitmq.com/lastRestartAt" from sts
-// to determine whether to restart sts
+// Adds an arbitrary annotation to the sts PodTemplate to trigger a sts restart.
+// It compares annotation "rabbitmq.com/serverConfUpdatedAt" from server-conf configMap and annotation "rabbitmq.com/lastRestartAt" from sts
+// to determine whether to restart sts.
 func (r *RabbitmqClusterReconciler) restartStatefulSetIfNeeded(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) (time.Duration, error) {
 	serverConf, err := r.configMap(ctx, rmq, rmq.ChildResourceName(resource.ServerConfigMapName))
 	if err != nil {
@@ -135,23 +125,6 @@ func (r *RabbitmqClusterReconciler) restartStatefulSetIfNeeded(ctx context.Conte
 	r.Recorder.Event(rmq, corev1.EventTypeNormal, "SuccessfulUpdate", msg)
 
 	return 0, nil
-}
-
-func (r *RabbitmqClusterReconciler) annotateConfigMap(ctx context.Context, namespace, name, key, value string) error {
-	if retryOnConflictErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
-		configMap := corev1.ConfigMap{}
-		if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &configMap); err != nil {
-			return client.IgnoreNotFound(err)
-		}
-		if configMap.Annotations == nil {
-			configMap.Annotations = make(map[string]string)
-		}
-		configMap.Annotations[key] = value
-		return r.Update(ctx, &configMap)
-	}); retryOnConflictErr != nil {
-		return retryOnConflictErr
-	}
-	return nil
 }
 
 func pluginsConfigUpdatedRecently(cfg *corev1.ConfigMap) (bool, error) {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -12,17 +12,16 @@ package controllers_test
 
 import (
 	"context"
-	"k8s.io/client-go/util/retry"
 	"path/filepath"
 	"sync"
 	"testing"
+
+	"k8s.io/client-go/util/retry"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/controllers"
-
-	// "github.com/rabbitmq/cluster-operator/internal/config"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -101,8 +100,7 @@ var _ = AfterSuite(func() {
 	close(stopMgr)
 	mgrStopped.Wait()
 	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	Expect(testEnv.Stop()).To(Succeed())
 })
 
 func startManager(scheme *runtime.Scheme) {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -2,14 +2,59 @@ package controllers
 
 import (
 	"context"
+
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 )
 
 func (r *RabbitmqClusterReconciler) exec(namespace, podName, containerName string, command ...string) (string, string, error) {
 	return r.PodExecutor.Exec(r.Clientset, r.ClusterConfig, namespace, podName, containerName, command...)
+}
+
+func (r *RabbitmqClusterReconciler) deleteAnnotation(ctx context.Context, obj runtime.Object, annotation string) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	annotations := accessor.GetAnnotations()
+	if annotations == nil {
+		return nil
+	}
+	delete(annotations, annotation)
+	accessor.SetAnnotations(annotations)
+	return r.Update(ctx, obj)
+}
+
+func (r *RabbitmqClusterReconciler) updateAnnotation(ctx context.Context, obj runtime.Object, namespace, objName, key, value string) error {
+	return retry.OnError(
+		retry.DefaultRetry,
+		errorIsConflictOrNotFound, // StatefulSet needs time to be found after it got created
+		func() error {
+			if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: objName}, obj); err != nil {
+				return err
+			}
+			accessor, err := meta.Accessor(obj)
+			if err != nil {
+				return err
+			}
+			annotations := accessor.GetAnnotations()
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations[key] = value
+			accessor.SetAnnotations(annotations)
+			return r.Update(ctx, obj)
+		})
+}
+
+func errorIsConflictOrNotFound(err error) bool {
+	return errors.IsConflict(err) || errors.IsNotFound(err)
 }
 
 func (r *RabbitmqClusterReconciler) statefulSet(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) (*appsv1.StatefulSet, error) {

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"k8s.io/utils/pointer"
 	"log"
 	"net/http"
 	"os"
@@ -54,6 +53,11 @@ import (
 )
 
 const podCreationTimeout = 600 * time.Second
+
+type featureFlag struct {
+	Name  string
+	State string
+}
 
 func MustHaveEnv(name string) string {
 	value := os.Getenv(name)
@@ -376,14 +380,13 @@ func getUsernameAndPassword(ctx context.Context, clientset *kubernetes.Clientset
 	return string(username), string(password), nil
 }
 
-func generateRabbitmqCluster(namespace, instanceName string) *rabbitmqv1beta1.RabbitmqCluster {
+func newRabbitmqCluster(namespace, instanceName string) *rabbitmqv1beta1.RabbitmqCluster {
 	return &rabbitmqv1beta1.RabbitmqCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instanceName,
 			Namespace: namespace,
 		},
 		Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-			Replicas: pointer.Int32Ptr(1),
 			Service: rabbitmqv1beta1.RabbitmqClusterServiceSpec{
 				Type: "NodePort",
 			},


### PR DESCRIPTION
Closes #414 

**Notes:**
* The controller identifies a new RabbitMQ cluster by the operation result `created` of the StatefulSet.
* A new annotation `rabbitmq.com/createdAt` is added onto the created StatefulSet.
* Once all pods are ready, CLI command `rabbitmqctl enable_feature_flag` is used on the first pod of the StatefulSet to enable all stable and previously disabled feature flags. (In future, we could add feature flag methods to https://github.com/michaelklishin/rabbit-hole/ to not exec into the pod anymore.)