### PR TITLE
Remove duplicated name prefix

### DIFF
--- a/config/default/base/kustomization.yaml
+++ b/config/default/base/kustomization.yaml
@@ -9,7 +9,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 namespace: rabbitmq-system
-namePrefix: rabbitmq-cluster-
 resources:
 - ../../manager
 # [CERTMANAGER] Uncomment next line to enable cert-manager


### PR DESCRIPTION

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Removed name prefix in the base kustomization file because the name prefix is already present in the manager kustomization.
Adding the name prefix here is producing double prefixed name for the Operator deployment e.g. rabbitmq-cluster-rabbitmq-cluster-operator.

