### PR TITLE
Ensure MY_POD_NAME and MY_POD_NAMESPACE envVar defined first

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -235,7 +235,7 @@ func patchPodSpec(podSpec, podSpecOverride *corev1.PodSpec) (corev1.PodSpec, err
 	}
 
 	// handle the rabbitmq container envVar list as a special case if it's overwritten
-	// we need to ensure that MY_POD_NAME and MY_POD_NAMESPACE are defined first so other envVars values can reference them
+	// we need to ensure that MY_POD_NAME, MY_POD_NAMESPACE and K8S_SERVICE_NAME are defined first so other envVars values can reference them
 	if rmqContainer := containerRabbitmq(podSpecOverride.Containers); rmqContainer.Env != nil {
 		sortEnvVar(patchedPodSpec.Containers[0].Env)
 	}
@@ -243,7 +243,7 @@ func patchPodSpec(podSpec, podSpecOverride *corev1.PodSpec) (corev1.PodSpec, err
 	return patchedPodSpec, nil
 }
 
-// sortEnvVar ensures that 'MY_POD_NAME' and 'My_POD_NAMESPACE' envVars is defined first in the list
+// sortEnvVar ensures that 'MY_POD_NAME', 'MY_POD_NAMESPACE' and 'K8S_SERVICE_NAME' envVars are defined first in the list
 // this is to enable other envVars to reference them as variables successfully
 func sortEnvVar(envVar []corev1.EnvVar) {
 	for i, e := range envVar {
@@ -253,6 +253,10 @@ func sortEnvVar(envVar []corev1.EnvVar) {
 		}
 		if e.Name == "MY_POD_NAMESPACE" {
 			envVar[1], envVar[i] = envVar[i], envVar[1]
+			continue
+		}
+		if e.Name == "K8S_SERVICE_NAME" {
+			envVar[2], envVar[i] = envVar[i], envVar[2]
 		}
 	}
 }

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1422,7 +1422,7 @@ var _ = Describe("StatefulSet", func() {
 					))
 				})
 				Context("Container EnvVar", func() {
-					It("Overrides the envVar list while making sure that 'My_POD_NAME' and 'MY_POD_NAMESPACE' are always defined first", func() {
+					It("Overrides the envVar list while making sure that 'MY_POD_NAME', 'MY_POD_NAMESPACE' and 'K8S_SERVICE_NAME' are always defined first", func() {
 						instance.Spec.Override.StatefulSet = &rabbitmqv1beta1.StatefulSet{
 							Spec: &rabbitmqv1beta1.StatefulSetSpec{
 								Template: &rabbitmqv1beta1.PodTemplateSpec{
@@ -1476,6 +1476,11 @@ var _ = Describe("StatefulSet", func() {
 										APIVersion: "v1",
 									},
 								},
+							}))
+						Expect(extractContainer(statefulSet.Spec.Template.Spec.Containers, "rabbitmq").Env[2]).To(Equal(
+							corev1.EnvVar{
+								Name:  "K8S_SERVICE_NAME",
+								Value: "foo-rabbitmq-headless",
 							}))
 						Expect(extractContainer(statefulSet.Spec.Template.Spec.Containers, "rabbitmq").Env).To(ConsistOf(
 							corev1.EnvVar{


### PR DESCRIPTION
This closes #433 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- handle the rabbitmq container envVar list as a special case if it's overwritten by override
- we need to ensure that MY_POD_NAME and MY_POD_NAMESPACE are defined first so other envVars values can reference them

## Additional Context

## Local Testing

Added additional test about templating at unit. Have run unit and integration tests
