### PR TITLE
Use RabbitMQ management image variant

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -43,7 +43,7 @@ type RabbitmqClusterSpec struct {
 	// +kubebuilder:default:=1
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster.
-	// +kubebuilder:default:="rabbitmq:3.8.9"
+	// +kubebuilder:default:="rabbitmq:3.8.9-management"
 	Image string `json:"image,omitempty"`
 	// List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -474,7 +474,7 @@ func generateRabbitmqClusterObject(clusterName string) *RabbitmqCluster {
 		},
 		Spec: RabbitmqClusterSpec{
 			Replicas:                      pointer.Int32Ptr(1),
-			Image:                         "rabbitmq:3.8.9",
+			Image:                         "rabbitmq:3.8.9-management",
 			TerminationGracePeriodSeconds: pointer.Int64Ptr(604800),
 			Service: RabbitmqClusterServiceSpec{
 				Type: "ClusterIP",

--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -33,7 +33,7 @@ usage() {
     echo "    kubectl rabbitmq delete INSTANCE ..."
     echo
     echo "  Create a RabbitMQ custom resource - INSTANCE name required, all other flags optional"
-    echo "    kubectl rabbitmq create INSTANCE --replicas 1 --service ClusterIP --image rabbitmq:3.8.9 --image-pull-secret mysecret"
+    echo "    kubectl rabbitmq create INSTANCE --replicas 1 --service ClusterIP --image rabbitmq:3.8.9-management --image-pull-secret mysecret"
     echo "      --tls-secret secret-name --storage-class mystorageclass"
     echo
     echo "  Get a RabbitMQ custom resource and dependant objects"

--- a/charts/rabbitmq/example-configurations.yaml
+++ b/charts/rabbitmq/example-configurations.yaml
@@ -17,7 +17,7 @@ annotations:
 
 replicas: 3
 
-image: "rabbitmq:3.8.1"
+image: "rabbitmq:3.8.9-management"
 
 imagePullSecret: foo
 

--- a/charts/rabbitmq/expected-template-output
+++ b/charts/rabbitmq/expected-template-output
@@ -20,7 +20,7 @@ metadata:
     annotation2: bar
 
 spec:
-  image: rabbitmq:3.8.1
+  image: rabbitmq:3.8.9-management
   imagePullSecret: foo
   replicas: 3
   service:

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -643,7 +643,7 @@ spec:
                     type: object
                 type: object
               image:
-                default: rabbitmq:3.8.9
+                default: rabbitmq:3.8.9-management
                 description: Image is the name of the RabbitMQ docker image to use
                   for RabbitMQ nodes in the RabbitmqCluster.
                 type: string


### PR DESCRIPTION
This closes #441

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Changed the default RabbitMQ image to use tag `3.8.9-management`

## Additional Context

The non-management image variant disables metrics collection by the management agent, resulting in very little information
shown in the management UI. We want to always enable the management UI as it is a common entry point to RabbitMQ
administration. It's also not straightforward to re-enable the metric collection in the non-management variant.

## Local Testing

- Made changes to unit tests. Those are passing.
- No changes to integration or system tests. Those are also green.

