### PR TITLE
Add automation to bump kubectl rabbitmq in krew index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Release
+on:
+  push:
+    tags:
+    - '*.*.*'
+
+jobs:
+  kubectl_rabbitmq:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update new version in krew-index
+      uses: rajatjindal/krew-release-bot@v0.0.38
+      with:
+        krew_template_file: hack/rabbitmq.yaml

--- a/hack/rabbitmq.yaml
+++ b/hack/rabbitmq.yaml
@@ -1,0 +1,29 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: rabbitmq
+spec:
+  homepage: https://github.com/rabbitmq/cluster-operator
+  shortDescription: Manage RabbitMQ clusters
+  version: v{{ .TagName }}
+  description: |
+    A plugin providing utilities to operate RabbitMQ clusters deployed
+    by the RabbitMQ cluster operator.
+  caveats: |
+    This plugin requires the RabbitMQ cluster operator to be installed.
+    To install the RabbitMQ cluster operator run `kubectl rabbitmq install-cluster-operator`.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values:
+        - darwin
+        - linux
+    {{addURIAndSha "https://github.com/rabbitmq/cluster-operator/archive/{{ .TagName }}.tar.gz" .TagName }}
+    bin: kubectl-rabbitmq
+    files:
+    - from: cluster-operator-*/bin/kubectl-rabbitmq
+      to: .
+    - from: cluster-operator-*/LICENSE.txt
+      to: .


### PR DESCRIPTION
Since https://github.com/kubernetes-sigs/krew-index/pull/895 is merged, we can now add automation to bump the kubectl rabbitmq plugin on every operator release.

The `hack/rabbitmq.yaml` template is output by https://rajatjindal.com/tools/krew-release-bot-helper/.

Relates #440.