### PR TITLE
Stop triggering pod restarts for CR labels/annotations updates

### DIFF
--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -534,34 +534,13 @@ var _ = Describe("RabbitmqClusterController", func() {
 				}, 3).Should(HaveKeyWithValue(annotationKey, annotationValue))
 			})
 
-			It("updates annotations for config maps", func() {
-				Eventually(func() map[string]string {
-					roleBinding, err := clientSet.CoreV1().ConfigMaps(cluster.Namespace).Get(ctx, cluster.ChildResourceName("server-conf"), metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-					return roleBinding.Annotations
-				}, 3).Should(HaveKeyWithValue(annotationKey, annotationValue))
-
+			It("updates annotations for plugins config map", func() {
 				Eventually(func() map[string]string {
 					roleBinding, err := clientSet.CoreV1().ConfigMaps(cluster.Namespace).Get(ctx, cluster.ChildResourceName("plugins-conf"), metav1.GetOptions{})
 					Expect(err).NotTo(HaveOccurred())
 					return roleBinding.Annotations
 				}, 3).Should(HaveKeyWithValue(annotationKey, annotationValue))
 			})
-
-			It("updates annotations for config maps", func() {
-				Eventually(func() map[string]string {
-					roleBinding, err := clientSet.CoreV1().ConfigMaps(cluster.Namespace).Get(ctx, cluster.ChildResourceName("server-conf"), metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-					return roleBinding.Annotations
-				}, 3).Should(HaveKeyWithValue(annotationKey, annotationValue))
-
-				Eventually(func() map[string]string {
-					roleBinding, err := clientSet.CoreV1().ConfigMaps(cluster.Namespace).Get(ctx, cluster.ChildResourceName("plugins-conf"), metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-					return roleBinding.Annotations
-				}, 3).Should(HaveKeyWithValue(annotationKey, annotationValue))
-			})
-
 		})
 
 		It("service type is updated", func() {

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -533,14 +533,6 @@ var _ = Describe("RabbitmqClusterController", func() {
 					return roleBinding.Annotations
 				}, 3).Should(HaveKeyWithValue(annotationKey, annotationValue))
 			})
-
-			It("updates annotations for plugins config map", func() {
-				Eventually(func() map[string]string {
-					roleBinding, err := clientSet.CoreV1().ConfigMaps(cluster.Namespace).Get(ctx, cluster.ChildResourceName("plugins-conf"), metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-					return roleBinding.Annotations
-				}, 3).Should(HaveKeyWithValue(annotationKey, annotationValue))
-			})
 		})
 
 		It("service type is updated", func() {

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -55,16 +55,16 @@ func (builder *RabbitmqResourceBuilder) ServerConfigMap() *ServerConfigMapBuilde
 func (builder *ServerConfigMapBuilder) Build() (runtime.Object, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      builder.Instance.ChildResourceName(ServerConfigMapName),
-			Namespace: builder.Instance.Namespace,
+			Name:        builder.Instance.ChildResourceName(ServerConfigMapName),
+			Namespace:   builder.Instance.Namespace,
+			Labels:      metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels),
+			Annotations: metadata.ReconcileAndFilterAnnotations(nil, builder.Instance.Annotations),
 		},
 	}, nil
 }
 
 func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 	configMap := object.(*corev1.ConfigMap)
-	configMap.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)
-	configMap.Annotations = metadata.ReconcileAndFilterAnnotations(configMap.GetAnnotations(), builder.Instance.Annotations)
 
 	ini.PrettySection = false // Remove trailing new line because rabbitmq.conf has only a default section.
 	cfg, err := ini.Load([]byte(defaultRabbitmqConf))

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -66,11 +66,6 @@ var _ = Describe("GenerateServerConfigMap", func() {
 		var configMap *corev1.ConfigMap
 
 		BeforeEach(func() {
-			instance = rabbitmqv1beta1.RabbitmqCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "rabbit-example",
-				},
-			}
 			instance.Labels = map[string]string{
 				"app.kubernetes.io/foo": "bar",
 				"foo":                   "bar",
@@ -98,8 +93,8 @@ var _ = Describe("GenerateServerConfigMap", func() {
 		})
 
 		It("adds labels from the instance and default labels", func() {
-			Expect(len(configMap.Labels)).To(Equal(6))
 			Expect(configMap.Labels).To(SatisfyAll(
+				HaveLen(6),
 				HaveKeyWithValue("foo", "bar"),
 				HaveKeyWithValue("rabbitmq", "is-great"),
 				HaveKeyWithValue("foo/app.kubernetes.io", "edgecase"),
@@ -111,8 +106,8 @@ var _ = Describe("GenerateServerConfigMap", func() {
 		})
 
 		It("adds annotations from the instance", func() {
-			Expect(len(configMap.Annotations)).To(Equal(1))
 			Expect(configMap.Annotations).To(SatisfyAll(
+				HaveLen(1),
 				HaveKeyWithValue("my-annotation", "i-like-this"),
 				Not(HaveKey("kubernetes.io/name")),
 				Not(HaveKey("kubectl.kubernetes.io/name")),
@@ -342,8 +337,8 @@ ssl_options.verify     = verify_peer
 				"new-label": "test",
 			}
 			Expect(configMapBuilder.Update(configMap)).To(Succeed())
-			Expect(len(configMap.Labels)).To(Equal(3))
 			Expect(configMap.Labels).To(SatisfyAll(
+				HaveLen(3),
 				HaveKeyWithValue("app.kubernetes.io/name", instance.Name),
 				HaveKeyWithValue("app.kubernetes.io/component", "rabbitmq"),
 				HaveKeyWithValue("app.kubernetes.io/part-of", "rabbitmq"),
@@ -352,7 +347,7 @@ ssl_options.verify     = verify_peer
 		})
 
 		// this is to ensure that pods are not restarted when instance annotations are updated
-		It("does not update labels on the config map", func() {
+		It("does not update annotations on the config map", func() {
 			instance.Annotations = map[string]string{
 				"new-annotation": "test",
 			}

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -66,6 +66,27 @@ var _ = Describe("GenerateServerConfigMap", func() {
 		var configMap *corev1.ConfigMap
 
 		BeforeEach(func() {
+			instance = rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rabbit-example",
+				},
+			}
+			instance.Labels = map[string]string{
+				"app.kubernetes.io/foo": "bar",
+				"foo":                   "bar",
+				"rabbitmq":              "is-great",
+				"foo/app.kubernetes.io": "edgecase",
+			}
+			instance.Annotations = map[string]string{
+				"my-annotation":               "i-like-this",
+				"kubernetes.io/name":          "i-do-not-like-this",
+				"kubectl.kubernetes.io/name":  "i-do-not-like-this",
+				"k8s.io/name":                 "i-do-not-like-this",
+				"kubernetes.io/other":         "i-do-not-like-this",
+				"kubectl.kubernetes.io/other": "i-do-not-like-this",
+				"k8s.io/other":                "i-do-not-like-this",
+			}
+
 			obj, err := configMapBuilder.Build()
 			configMap = obj.(*corev1.ConfigMap)
 			Expect(err).NotTo(HaveOccurred())
@@ -74,6 +95,32 @@ var _ = Describe("GenerateServerConfigMap", func() {
 		It("generates a ConfigMap with the correct name and namespace", func() {
 			Expect(configMap.Name).To(Equal(builder.Instance.ChildResourceName("server-conf")))
 			Expect(configMap.Namespace).To(Equal(builder.Instance.Namespace))
+		})
+
+		It("adds labels from the instance and default labels", func() {
+			Expect(len(configMap.Labels)).To(Equal(6))
+			Expect(configMap.Labels).To(SatisfyAll(
+				HaveKeyWithValue("foo", "bar"),
+				HaveKeyWithValue("rabbitmq", "is-great"),
+				HaveKeyWithValue("foo/app.kubernetes.io", "edgecase"),
+				HaveKeyWithValue("app.kubernetes.io/name", instance.Name),
+				HaveKeyWithValue("app.kubernetes.io/component", "rabbitmq"),
+				HaveKeyWithValue("app.kubernetes.io/part-of", "rabbitmq"),
+				Not(HaveKey("app.kubernetes.io/foo")),
+			))
+		})
+
+		It("adds annotations from the instance", func() {
+			Expect(len(configMap.Annotations)).To(Equal(1))
+			Expect(configMap.Annotations).To(SatisfyAll(
+				HaveKeyWithValue("my-annotation", "i-like-this"),
+				Not(HaveKey("kubernetes.io/name")),
+				Not(HaveKey("kubectl.kubernetes.io/name")),
+				Not(HaveKey("k8s.io/name")),
+				Not(HaveKey("kubernetes.io/other")),
+				Not(HaveKey("kubectl.kubernetes.io/other")),
+				Not(HaveKey("k8s.io/other")),
+			))
 		})
 	})
 
@@ -284,94 +331,33 @@ ssl_options.verify     = verify_peer
 			})
 		})
 
-		Context("labels", func() {
-			BeforeEach(func() {
-				instance = rabbitmqv1beta1.RabbitmqCluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "rabbit-labelled",
-					},
-				}
-				instance.Labels = map[string]string{
-					"app.kubernetes.io/foo": "bar",
-					"foo":                   "bar",
-					"rabbitmq":              "is-great",
-					"foo/app.kubernetes.io": "edgecase",
-				}
-
-				configMap = &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							"app.kubernetes.io/name":      instance.Name,
-							"app.kubernetes.io/part-of":   "rabbitmq",
-							"this-was-the-previous-label": "should-be-deleted",
-						},
-					},
-				}
-				err := configMapBuilder.Update(configMap)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("adds labels from the CR", func() {
-				testLabels(configMap.Labels)
-			})
-
-			It("restores the default labels", func() {
-				labels := configMap.Labels
-				Expect(labels["app.kubernetes.io/name"]).To(Equal(instance.Name))
-				Expect(labels["app.kubernetes.io/component"]).To(Equal("rabbitmq"))
-				Expect(labels["app.kubernetes.io/part-of"]).To(Equal("rabbitmq"))
-			})
-
-			It("deletes the labels that are removed from the CR", func() {
-				Expect(configMap.Labels).NotTo(HaveKey("this-was-the-previous-label"))
-			})
+		// this is to ensure that pods are not restarted when instance labels are updated
+		It("does not update labels on the config map", func() {
+			configMap.Labels = map[string]string{
+				"app.kubernetes.io/name":      instance.Name,
+				"app.kubernetes.io/component": "rabbitmq",
+				"app.kubernetes.io/part-of":   "rabbitmq",
+			}
+			instance.Labels = map[string]string{
+				"new-label": "test",
+			}
+			Expect(configMapBuilder.Update(configMap)).To(Succeed())
+			Expect(len(configMap.Labels)).To(Equal(3))
+			Expect(configMap.Labels).To(SatisfyAll(
+				HaveKeyWithValue("app.kubernetes.io/name", instance.Name),
+				HaveKeyWithValue("app.kubernetes.io/component", "rabbitmq"),
+				HaveKeyWithValue("app.kubernetes.io/part-of", "rabbitmq"),
+				Not(HaveKey("new-label")),
+			))
 		})
 
-		Context("instance annotations", func() {
-			BeforeEach(func() {
-				instance = rabbitmqv1beta1.RabbitmqCluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "rabbit-labelled",
-					},
-				}
-				instance.Annotations = map[string]string{
-					"my-annotation":               "i-like-this",
-					"kubernetes.io/name":          "i-do-not-like-this",
-					"kubectl.kubernetes.io/name":  "i-do-not-like-this",
-					"k8s.io/name":                 "i-do-not-like-this",
-					"kubernetes.io/other":         "i-do-not-like-this",
-					"kubectl.kubernetes.io/other": "i-do-not-like-this",
-					"k8s.io/other":                "i-do-not-like-this",
-				}
-
-				configMap = &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							"my-annotation":                 "i-will-not-stay",
-							"old-annotation":                "old-value",
-							"im-here-to-stay.kubernetes.io": "for-a-while",
-							"kubernetes.io/name":            "should-stay",
-							"kubectl.kubernetes.io/name":    "should-stay",
-							"k8s.io/name":                   "should-stay",
-						},
-					},
-				}
-				err := configMapBuilder.Update(configMap)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("updates config map annotations", func() {
-				expectedAnnotations := map[string]string{
-					"my-annotation":                 "i-like-this",
-					"old-annotation":                "old-value",
-					"im-here-to-stay.kubernetes.io": "for-a-while",
-					"kubernetes.io/name":            "should-stay",
-					"kubectl.kubernetes.io/name":    "should-stay",
-					"k8s.io/name":                   "should-stay",
-				}
-
-				Expect(configMap.Annotations).To(Equal(expectedAnnotations))
-			})
+		// this is to ensure that pods are not restarted when instance annotations are updated
+		It("does not update labels on the config map", func() {
+			instance.Annotations = map[string]string{
+				"new-annotation": "test",
+			}
+			Expect(configMapBuilder.Update(configMap)).To(Succeed())
+			Expect(configMap.Annotations).To(BeEmpty())
 		})
 	})
 })

--- a/internal/resource/rabbitmq_plugins.go
+++ b/internal/resource/rabbitmq_plugins.go
@@ -36,8 +36,10 @@ func (builder *RabbitmqResourceBuilder) RabbitmqPluginsConfigMap() *RabbitmqPlug
 func (builder *RabbitmqPluginsConfigMapBuilder) Build() (runtime.Object, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      builder.Instance.ChildResourceName(PluginsConfigName),
-			Namespace: builder.Instance.Namespace,
+			Name:        builder.Instance.ChildResourceName(PluginsConfigName),
+			Namespace:   builder.Instance.Namespace,
+			Labels:      metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels),
+			Annotations: metadata.ReconcileAndFilterAnnotations(nil, builder.Instance.Annotations),
 		},
 		Data: map[string]string{
 			"enabled_plugins": desiredPluginsAsString([]rabbitmqv1beta1.Plugin{}),
@@ -47,8 +49,6 @@ func (builder *RabbitmqPluginsConfigMapBuilder) Build() (runtime.Object, error) 
 
 func (builder *RabbitmqPluginsConfigMapBuilder) Update(object runtime.Object) error {
 	configMap := object.(*corev1.ConfigMap)
-	configMap.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)
-	configMap.Annotations = metadata.ReconcileAndFilterAnnotations(configMap.GetAnnotations(), builder.Instance.Annotations)
 
 	if configMap.Data == nil {
 		configMap.Data = make(map[string]string)

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -401,11 +401,21 @@ var _ = Describe("StatefulSet", func() {
 				testLabels(statefulSet.Labels)
 			})
 
-			It("has the labels from the instance on the pod", func() {
+			It("adds default labels to pods but does not populate labels from the instance onto pods", func() {
 				stsBuilder := builder.StatefulSet()
 				Expect(stsBuilder.Update(statefulSet)).To(Succeed())
-				podTemplate := statefulSet.Spec.Template
-				testLabels(podTemplate.Labels)
+
+				labels := statefulSet.Spec.Template.ObjectMeta.Labels
+				Expect(len(labels)).To(Equal(3))
+				Expect(labels).To(SatisfyAll(
+					HaveKeyWithValue("app.kubernetes.io/name", instance.Name),
+					HaveKeyWithValue("app.kubernetes.io/component", "rabbitmq"),
+					HaveKeyWithValue("app.kubernetes.io/part-of", "rabbitmq"),
+					Not(HaveKey("foo")),
+					Not(HaveKey("rabbitmq")),
+					Not(HaveKey("foo/app.kubernetes.io")),
+					Not(HaveKey("app.kubernetes.io/foo")),
+				))
 			})
 
 			It("adds the correct labels on the statefulset", func() {
@@ -437,16 +447,6 @@ var _ = Describe("StatefulSet", func() {
 				By("deleting the labels that are removed from the CR")
 				Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 				Expect(statefulSet.Labels).NotTo(HaveKey("this-was-the-previous-label"))
-			})
-
-			It("adds the correct labels on the rabbitmq pods", func() {
-				stsBuilder := builder.StatefulSet()
-				Expect(stsBuilder.Update(statefulSet)).To(Succeed())
-
-				labels := statefulSet.Spec.Template.ObjectMeta.Labels
-				Expect(labels["app.kubernetes.io/name"]).To(Equal(instance.Name))
-				Expect(labels["app.kubernetes.io/component"]).To(Equal("rabbitmq"))
-				Expect(labels["app.kubernetes.io/part-of"]).To(Equal("rabbitmq"))
 			})
 		})
 
@@ -483,8 +483,6 @@ var _ = Describe("StatefulSet", func() {
 						"prometheus.io/scrape":           "true",
 						"prometheus.io/port":             "15692",
 						"this-was-the-previous-pod-anno": "should-be-preserved",
-						"app.kubernetes.io/part-of":      "rabbitmq-pod",
-						"app.k8s.io/something":           "something-amazing-on-pod",
 					}
 
 					existingPvcTemplateAnnotations = map[string]string{
@@ -501,7 +499,7 @@ var _ = Describe("StatefulSet", func() {
 					statefulSet.Spec.VolumeClaimTemplates[0].Annotations = existingPvcTemplateAnnotations
 				})
 
-				It("updates annotations", func() {
+				It("updates sts annotations", func() {
 					stsBuilder.Instance.Annotations = map[string]string{
 						"kubernetes.io/name":          "i-do-not-like-this",
 						"kubectl.kubernetes.io/name":  "i-do-not-like-this",
@@ -523,28 +521,24 @@ var _ = Describe("StatefulSet", func() {
 					Expect(statefulSet.Annotations).To(Equal(expectedAnnotations))
 				})
 
-				It("update annotations from the instance to the pod", func() {
+				It("adds default annotations but does not populate annotations from the instance to the pod", func() {
 					stsBuilder.Instance.Annotations = map[string]string{
-						"kubernetes.io/name":          "i-do-not-like-this",
-						"kubectl.kubernetes.io/name":  "i-do-not-like-this",
-						"k8s.io/name":                 "i-do-not-like-this",
-						"kubernetes.io/other":         "i-do-not-like-this",
-						"kubectl.kubernetes.io/other": "i-do-not-like-this",
-						"k8s.io/other":                "i-do-not-like-this",
-						"my-annotation":               "i-like-this",
+						"my-annotation": "my-annotation",
+						"k8s.io/other":  "i-do-not-like-this",
 					}
 
 					Expect(stsBuilder.Update(statefulSet)).To(Succeed())
-					expectedAnnotations := map[string]string{
-						"prometheus.io/scrape":           "true",
-						"prometheus.io/port":             "15692",
-						"my-annotation":                  "i-like-this",
-						"app.kubernetes.io/part-of":      "rabbitmq-pod",
-						"this-was-the-previous-pod-anno": "should-be-preserved",
-						"app.k8s.io/something":           "something-amazing-on-pod",
-					}
-
-					Expect(statefulSet.Spec.Template.Annotations).To(Equal(expectedAnnotations))
+					annotations := statefulSet.Spec.Template.Annotations
+					Expect(len(annotations)).To(Equal(3))
+					Expect(annotations).To(SatisfyAll(
+						HaveKeyWithValue("prometheus.io/scrape", "true"),
+						HaveKeyWithValue("prometheus.io/port", "15692"),
+						HaveKeyWithValue("this-was-the-previous-pod-anno", "should-be-preserved"),
+						Not(HaveKey("app.kubernetes.io/part-of")),
+						Not(HaveKey("app.k8s.io/something")),
+						Not(HaveKey("my-annotation")),
+						Not(HaveKey("k8s.io/other")),
+					))
 				})
 
 				It("does not update annotations from the instance to the pvc template", func() {

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -405,9 +405,8 @@ var _ = Describe("StatefulSet", func() {
 				stsBuilder := builder.StatefulSet()
 				Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 
-				labels := statefulSet.Spec.Template.ObjectMeta.Labels
-				Expect(len(labels)).To(Equal(3))
-				Expect(labels).To(SatisfyAll(
+				Expect(statefulSet.Spec.Template.ObjectMeta.Labels).To(SatisfyAll(
+					HaveLen(3),
 					HaveKeyWithValue("app.kubernetes.io/name", instance.Name),
 					HaveKeyWithValue("app.kubernetes.io/component", "rabbitmq"),
 					HaveKeyWithValue("app.kubernetes.io/part-of", "rabbitmq"),
@@ -528,9 +527,8 @@ var _ = Describe("StatefulSet", func() {
 					}
 
 					Expect(stsBuilder.Update(statefulSet)).To(Succeed())
-					annotations := statefulSet.Spec.Template.Annotations
-					Expect(len(annotations)).To(Equal(3))
-					Expect(annotations).To(SatisfyAll(
+					Expect(statefulSet.Spec.Template.Annotations).To(SatisfyAll(
+						HaveLen(3),
 						HaveKeyWithValue("prometheus.io/scrape", "true"),
 						HaveKeyWithValue("prometheus.io/port", "15692"),
 						HaveKeyWithValue("this-was-the-previous-pod-anno", "should-be-preserved"),


### PR DESCRIPTION
This closes #442 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
-  Stop populate CR labels/annotations to pods. Instance labels and annotations are still populated and updated for statefulSet.
- Stop updating label/annotation on server conf configMap, because updates to server-conf configMap triggers pod restart. Instance labels and annotations are still applied at creation.
Stop updating label/annotation on plugins configmap, because updates to the plugins configMap triggers unnecessary `rabbitmq-plugins set`.

## Additional Context

## Local Testing

Have run unit, integration, and system tests.