### PR TITLE
Add 'kubectl rabbitmq version' sub command

### DIFF
--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -66,9 +66,36 @@ USAGE:
 
   Print this help
     kubectl rabbitmq help
+
+  Print kubectl-rabbitmq plugin version
+    kubectl rabbitmq version
 END
 )
   echo "$usage"
+}
+
+version() {
+  # Since we require to install this plugin via krew, we get the version from krew instead of hardcoding a version to this file.
+  failure_msg="version cannot be determined because plugin was not installed via krew"
+  if ! command -v kubectl-krew &> /dev/null
+  then
+      echo "$failure_msg"
+      exit 1
+  fi
+
+  # We can't use `krew info` because it provides versions about available - not installed - plugins.
+  # `krew list` provides versions of installed plugins.
+  # We can't redirect stdout of `krew list` because this will suppress the version number (see `kubectl krew list --help`)
+  # Therefore, we have to get the version number from the `krew list` logs.
+  version_line=$(kubectl krew -v 4 list 2>&1 | grep 'rabbitmq: version=' || true)
+  if [[ -z "$version_line" ]];
+  then
+      echo "$failure_msg"
+      exit 1
+  fi
+
+  version="${version_line##*rabbitmq: version=}"
+  echo "kubectl-rabbitmq $version"
 }
 
 get_instance_details() {
@@ -304,6 +331,9 @@ main() {
         ;;
     "-h")
         usage
+        ;;
+    "version")
+        version
         ;;
     *)
         usage

--- a/bin/kubectl-rabbitmq.bats
+++ b/bin/kubectl-rabbitmq.bats
@@ -16,6 +16,20 @@ eventually() {
   return 1
 }
 
+@test "version outputs version" {
+  run kubectl rabbitmq version
+
+  if ! command -v kubectl-krew &> /dev/null
+  then
+    [ "$status" -eq 1 ]
+    [ "${lines[0]}" = "version cannot be determined because plugin was not installed via krew" ]
+  else
+    [ "$status" -eq 0 ]
+    version_regex='kubectl-rabbitmq v([0-9]+)\.([0-9]+)\.([0-9]+)$'
+    [[ "${lines[0]}" =~ $version_regex ]]
+  fi
+}
+
 @test "install-cluster-operator with too many args fails" {
   run kubectl rabbitmq install-cluster-operator too-many-args
 


### PR DESCRIPTION
Relates #440.

Since we require the kubectl rabbitmq plugin to be installed via krew, the easiest way to output the plugin version is to ask krew. As explained in the commit message `kubectl krew info rabbitmq` will output the available - not installed - version. In contrast, `kubectl krew list` outputs the installed version.

As explained in `kubectl krew list --help`:

> Remarks:
>  Redirecting the output of this command to a program or file will only print the names of the plugins installed

Therefore, we parse the rabbitmq plugin version from the `krew list` logs by increasing the verbosity to `4`.

If the rabbitmq plugin is not installed via krew, the command will output an appropriate error message.

I wrote the tests such that they don't require `krew` to be installed. If krew isn't installed, we simply test for the error message.

**Caveats:**
If the rabbitmq plugin is installed via krew, but the script is not invoked via krew (e.g. `cluster-operator/bin/kubectl-rabbitmq` takes precedence over `/usr/local/bin/kubectl-krew` in PATH), the rabbitmq plugin version of krew will still be output. I think that's a minor issue for us developers, but not for end users.

**Alternative approach:**
Have some version variable hard coded in the bash script. Include a task in our Concourse release job which bumps that version and commits right before tagging. This approach seems to be more brittle because that task needs to commit directly to the `main` branch which introduces other difficulties (as have have experienced from our BOSH release pipelines).