### PR TITLE
Fix release GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
   kubectl_rabbitmq:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@main
     - name: Update new version in krew-index
       uses: rajatjindal/krew-release-bot@v0.0.38
       with:


### PR DESCRIPTION
GitHub action https://github.com/rabbitmq/cluster-operator/runs/1380561796?check_suite_focus=true failed with message:
`level=fatal msg="open /github/workspace/hack/rabbitmq.yaml: no such file or directory"`