### PR TITLE
Update minimum Kubernetes version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.8.9` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.16` or newer.
+The operator deploys RabbitMQ `3.8.9` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.17` or newer.
 
 ## Versioning
 


### PR DESCRIPTION
Kubernetes 1.16 is out of support and we test in 1.17+