### PR TITLE
Correct mTLS example

### DIFF
--- a/docs/examples/mtls/README.md
+++ b/docs/examples/mtls/README.md
@@ -20,7 +20,7 @@ Assuming the CA's certificate is accessible as `ca.pem`, you can create this Sec
 kubectl create secret generic ca-secret --from-file=ca.crt=ca.pem
 ```
 
-These Secrets can also be created by [Cert Manager](https://cert-manager.io/).
+The Secret must be stored with key 'ca.crt'. These Secrets can also be created by [Cert Manager](https://cert-manager.io/).
 
 Once the secrets exist, you can deploy this example as follows:
 

--- a/docs/examples/mtls/rabbitmq.yaml
+++ b/docs/examples/mtls/rabbitmq.yaml
@@ -7,4 +7,3 @@ spec:
   tls:
     secretName: tls-secret
     caSecretName: ca-secret
-    caCertName: ca.crt


### PR DESCRIPTION
- caCertName is now hardcoded as ca.crt

This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
