### PR TITLE
Example: mTLS between RabbitMQ nodes

### DIFF
--- a/docs/examples/mtls-inter-node/README.md
+++ b/docs/examples/mtls-inter-node/README.md
@@ -21,3 +21,13 @@ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/relea
 # deploy the example
 ./setup.sh
 ```
+
+To validate that RabbitMQ nodes connect over TLS you can run the following checks:
+
+```shell
+# check that the distribution port has TLS enabled (this command should return `Verification: OK`)
+kubectl exec -it mtls-inter-node-server-0 -- bash -c 'openssl s_client -connect ${HOSTNAME}${K8S_HOSTNAME_SUFFIX}:25672 -state -cert /etc/rabbitmq/certs/tls.crt  -key /etc/rabbitmq/certs/tls.key -CAfile /etc/rabbitmq/certs/ca.crt 2>&1 | grep Verification'
+
+# check that distribution uses TLS (this command should return `{ok,[["inet_tls"]]}`)
+kubectl exec -it mtls-inter-node-server-0 -- rabbitmqctl eval 'init:get_argument(proto_dist).'
+```

--- a/docs/examples/mtls-inter-node/README.md
+++ b/docs/examples/mtls-inter-node/README.md
@@ -1,7 +1,7 @@
 # mtls-inter-node Example
 
 This example shows how to [secure the Erlang Distribution with TLS](https://www.rabbitmq.com/clustering-ssl.html) so that RabbitMQ cluster nodes communicate over secure channels.
-In future, RabbitMQ Cluster Operator may make it easier to configure but it is already possible to achieve that with `envConfig` and `override` properties.
+In the future, the RabbitMQ Cluster Operator may make this easier to configure but it is already possible with the [`envConfig`](https://www.rabbitmq.com/kubernetes/operator/using-operator.html#env-config) and [`override`](https://www.rabbitmq.com/kubernetes/operator/using-operator.html#override) properties.
 
 The most important parts of this example are:
 

--- a/docs/examples/mtls-inter-node/README.md
+++ b/docs/examples/mtls-inter-node/README.md
@@ -8,7 +8,7 @@ The most important parts of this example are:
 * `rabbitmq.yaml` - `RabbitmqCluster` definition with all the necessary configuration
 * `inter_node_tls.config` - Erlang Distribution configuration file that will be mounted as a volume
 
-The other files serve as an example for setting up certificates with Cert Manager.
+The other files serve as an example for setting up certificates with [Cert Manager](https://cert-manager.io/docs/).
 
 * `rabbitmq-ca.yaml` - defines an `Issuer` (CA)
 * `rabbitmq-certificate.yaml` - defines a certificate that will be provisioned by Cert Manager and then mounted as a volume

--- a/docs/examples/mtls-inter-node/README.md
+++ b/docs/examples/mtls-inter-node/README.md
@@ -1,6 +1,6 @@
 # mtls-inter-node Example
 
-This example shows how to secure Erlang Distribution with TLS so that RabbitMQ cluster nodes communicate over secure channels.
+This example shows how to [secure the Erlang Distribution with TLS](https://www.rabbitmq.com/clustering-ssl.html) so that RabbitMQ cluster nodes communicate over secure channels.
 In future, RabbitMQ Cluster Operator may make it easier to configure but it is already possible to achieve that with `envConfig` and `override` properties.
 
 The most important parts of this example are:

--- a/docs/examples/mtls-inter-node/README.md
+++ b/docs/examples/mtls-inter-node/README.md
@@ -1,0 +1,23 @@
+# mtls-inter-node Example
+
+This example shows how to secure Erlang Distribution with TLS so that RabbitMQ cluster nodes communicate over secure channels.
+In future, RabbitMQ Cluster Operator may make it easier to configure but it is already possible to achieve that with `envConfig` and `override` properties.
+
+The most important parts of this example are:
+
+* `rabbitmq.yaml` - `RabbitmqCluster` definition with all the necessary configuration
+* `inter_node_tls.config` - Erlang Distribution configuration file that will be mounted as a volume
+
+The other files serve as an example for setting up certificates with Cert Manager.
+
+* `rabbitmq-ca.yaml` - defines an `Issuer` (CA)
+* `rabbitmq-certificate.yaml` - defines a certificate that will be provisioned by Cert Manager and then mounted as a volume
+
+`setup.sh` should perform all the necessary steps but may need to be adjusted to work on your system.
+
+```shell
+# install Cert Manager
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.4/cert-manager.yaml
+# deploy the example
+./setup.sh
+```

--- a/docs/examples/mtls-inter-node/inter_node_tls.config
+++ b/docs/examples/mtls-inter-node/inter_node_tls.config
@@ -1,0 +1,24 @@
+[
+  {server, [
+    {cacertfile, "/etc/rabbitmq/certs/ca.crt"},
+    {certfile,   "/etc/rabbitmq/certs/tls.crt"},
+    {keyfile,    "/etc/rabbitmq/certs/tls.key"},
+    {secure_renegotiate, true},
+    {fail_if_no_peer_cert, true},
+    {verify, verify_peer},
+    {customize_hostname_check, [
+      {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
+    ]}
+  ]},
+  {client, [
+    {cacertfile, "/etc/rabbitmq/certs/ca.crt"},
+    {certfile,   "/etc/rabbitmq/certs/tls.crt"},
+    {keyfile,    "/etc/rabbitmq/certs/tls.key"},
+    {secure_renegotiate, true},
+    {fail_if_no_peer_cert, true},
+    {verify, verify_peer},
+    {customize_hostname_check, [
+      {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
+    ]}
+  ]}
+].

--- a/docs/examples/mtls-inter-node/rabbitmq-ca.yaml
+++ b/docs/examples/mtls-inter-node/rabbitmq-ca.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: rabbitmq-ca
+spec:
+  ca:
+    secretName: rabbitmq-ca

--- a/docs/examples/mtls-inter-node/rabbitmq-certificate.yaml
+++ b/docs/examples/mtls-inter-node/rabbitmq-certificate.yaml
@@ -1,0 +1,28 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mtls-inter-node-nodes-tls
+spec:
+  secretName: mtls-inter-node-nodes-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  subject:
+    organizations:
+    - RabbitMQ
+  commonName: mtls-inter-node
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+  - mtls-inter-node-server-0.mtls-inter-node-nodes.default
+  - mtls-inter-node-server-1.mtls-inter-node-nodes.default
+  - mtls-inter-node-server-2.mtls-inter-node-nodes.default
+  issuerRef:
+    name: rabbitmq-ca
+    kind: Issuer
+    group: cert-manager.io

--- a/docs/examples/mtls-inter-node/rabbitmq.yaml
+++ b/docs/examples/mtls-inter-node/rabbitmq.yaml
@@ -1,0 +1,42 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: mtls-inter-node
+spec:
+  rabbitmq:
+    envConfig: |
+      ERL_SSL_PATH="/usr/local/lib/erlang/lib/ssl-10.1/ebin"
+      SERVER_ADDITIONAL_ERL_ARGS="-pa /usr/local/lib/erlang/lib/ssl-10.1/ebin -proto_dist inet_tls -ssl_dist_optfile /etc/rabbitmq/inter-node-tls.config"
+      RABBITMQ_CTL_ERL_ARGS="-pa /usr/local/lib/erlang/lib/ssl-10.1/ebin -proto_dist inet_tls -ssl_dist_optfile /etc/rabbitmq/inter-node-tls.config"
+  replicas: 3
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              volumeMounts:
+              - mountPath: /etc/rabbitmq/certs
+                name: mtls-inter-node-nodes-tls
+              - mountPath: /etc/rabbitmq/inter-node-tls.config
+                name: inter-node-config
+                subPath: inter_node_tls.config
+            volumes:
+            - configMap:
+                defaultMode: 420
+                name: mtls-inter-node-tls-config
+              name: inter-node-config
+            - name: mtls-inter-node-nodes-tls
+              secret:
+                secretName: mtls-inter-node-nodes-tls
+                items:
+                - key: ca.crt
+                  mode: 416
+                  path: ca.crt
+                - key: tls.crt
+                  mode: 416
+                  path: tls.crt
+                - key: tls.key
+                  mode: 416
+                  path: tls.key

--- a/docs/examples/mtls-inter-node/rabbitmq.yaml
+++ b/docs/examples/mtls-inter-node/rabbitmq.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   rabbitmq:
     envConfig: |
-      ERL_SSL_PATH="/usr/local/lib/erlang/lib/ssl-10.1/ebin"
       SERVER_ADDITIONAL_ERL_ARGS="-pa /usr/local/lib/erlang/lib/ssl-10.1/ebin -proto_dist inet_tls -ssl_dist_optfile /etc/rabbitmq/inter-node-tls.config"
       RABBITMQ_CTL_ERL_ARGS="-pa /usr/local/lib/erlang/lib/ssl-10.1/ebin -proto_dist inet_tls -ssl_dist_optfile /etc/rabbitmq/inter-node-tls.config"
   replicas: 3

--- a/docs/examples/mtls-inter-node/setup.sh
+++ b/docs/examples/mtls-inter-node/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+OPENSSL=${OPENSSL:-openssl}
+
+# Generate CA certificate and key
+#
+# These commands do not work with LibreSSL which is shipped with MacOS. Please use openssl
+#
+if $OPENSSL version | grep -q LibreSSL; then
+  echo "Please do not use LibreSSL. Set OPENSSL variable to actual OpenSSL binary."
+  exit 1
+fi
+
+$OPENSSL genrsa -out rabbitmq-ca-key.pem 2048
+$OPENSSL req -x509 -new -nodes -key rabbitmq-ca-key.pem -subj "/CN=mtls-inter-node" -days 3650 -reqexts v3_req -extensions v3_ca -out rabbitmq-ca.pem
+
+# Create a CA secret
+kubectl create secret tls rabbitmq-ca --cert=rabbitmq-ca.pem --key=rabbitmq-ca-key.pem  
+
+# Create an Issuer (Cert Manager CA)
+kubectl apply -f rabbitmq-ca.yaml
+
+# Create a certificate for the cluster
+kubectl apply -f rabbitmq-certificate.yaml
+
+# Create a configuration file for Erlang Distribution
+kubectl create configmap mtls-inter-node-tls-config --from-file=inter_node_tls.config
+
+# Deploy a RabbitMQ cluster
+kubectl apply -f rabbitmq.yaml


### PR DESCRIPTION
This example shows how to configure mTLS between RabbitMQ nodes. It uses Cert Manager but could be used without it (secret would have to be created manually). 