### PR TITLE
Run `make manifests`

### DIFF
--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -10,7 +10,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: rabbitmqclusters.rabbitmq.com
 spec:
@@ -713,6 +713,7 @@ spec:
                                   format: int32
                                   type: integer
                                 protocol:
+                                  default: TCP
                                   type: string
                                 targetPort:
                                   anyOf:
@@ -1364,6 +1365,7 @@ spec:
                                               name:
                                                 type: string
                                               protocol:
+                                                default: TCP
                                                 type: string
                                             required:
                                             - containerPort
@@ -1925,6 +1927,7 @@ spec:
                                               name:
                                                 type: string
                                               protocol:
+                                                default: TCP
                                                 type: string
                                             required:
                                             - containerPort
@@ -2485,6 +2488,7 @@ spec:
                                               name:
                                                 type: string
                                               protocol:
+                                                default: TCP
                                                 type: string
                                             required:
                                             - containerPort


### PR DESCRIPTION
after bumping sigs.k8s.io/controller-tools from v0.4.0 to v0.4.1.