### PR TITLE
Make persistence test testing persistence

### DIFF
--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -491,11 +491,6 @@ func rabbitmqNodePort(ctx context.Context, clientSet *kubernetes.Clientset, clus
 	return ""
 }
 
-func waitForTLSUpdate(cluster *rabbitmqv1beta1.RabbitmqCluster) {
-	waitForRabbitmqNotRunningWithOffset(cluster, 2)
-	waitForRabbitmqRunning(cluster)
-}
-
 func waitForRabbitmqUpdate(cluster *rabbitmqv1beta1.RabbitmqCluster) {
 	waitForRabbitmqNotRunningWithOffset(cluster, 2)
 	waitForRabbitmqRunningWithOffset(cluster, 2)


### PR DESCRIPTION
Before this PR, the persistence test wasn't testing persistence.

This PR fixes a regression introduced in https://github.com/rabbitmq/cluster-operator/commit/ca9e12fdbe0492bf6ca7de6405ef644cca5c02be.