### PR TITLE
Remove crd patch hack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,6 @@ manifests: install-tools ## Generate manifests e.g. CRD, RBAC etc.
 	controller-gen $(CRD_OPTIONS) rbac:roleName=operator-role paths="./api/...;./controllers/..." output:crd:artifacts:config=config/crd/bases
 	./hack/remove-override-descriptions.sh
 	./hack/add-notice-to-yaml.sh config/rbac/role.yaml
-# this is temporary workaround due to issue https://github.com/kubernetes/kubernetes/issues/91395
-# the hack ensures that "protocal" is a required value where this field is listed as x-kubernetes-list-map-keys
-# without the hack, our crd doesn't install on k8s 1.18 because of the issue above
-	./hack/patch-crd.sh
 	./hack/add-notice-to-yaml.sh config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
 
 # Run go fmt against code

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -10,7 +10,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: rabbitmqclusters.rabbitmq.com
 spec:
@@ -713,6 +713,7 @@ spec:
                                   format: int32
                                   type: integer
                                 protocol:
+                                  default: TCP
                                   type: string
                                 targetPort:
                                   anyOf:
@@ -1364,6 +1365,7 @@ spec:
                                               name:
                                                 type: string
                                               protocol:
+                                                default: TCP
                                                 type: string
                                             required:
                                             - containerPort
@@ -1925,6 +1927,7 @@ spec:
                                               name:
                                                 type: string
                                               protocol:
+                                                default: TCP
                                                 type: string
                                             required:
                                             - containerPort
@@ -2485,6 +2488,7 @@ spec:
                                               name:
                                                 type: string
                                               protocol:
+                                                default: TCP
                                                 type: string
                                             required:
                                             - containerPort

--- a/hack/crd-patch.json
+++ b/hack/crd-patch.json
@@ -1,5 +1,0 @@
-[
-    { "op": "replace", "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/override/properties/statefulSet/properties/spec/properties/template/properties/spec/properties/containers/items/properties/ports/items/required", "value": [ "containerPort", "protocol"]},
-        { "op": "replace", "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/override/properties/service/properties/spec/properties/ports/items/required", "value": [ "port", "protocol"]},
-    { "op": "replace", "path": "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/override/properties/statefulSet/properties/spec/properties/template/properties/spec/properties/initContainers/items/properties/ports/items/required", "value": [ "containerPort", "protocol"]},
-]

--- a/hack/patch-crd.sh
+++ b/hack/patch-crd.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-kubectl patch -f config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml -p "$(cat hack/crd-patch.json)" --type json --local  -o yaml > /tmp/rabbitmq.com_rabbitmqclusters.yaml
-mv /tmp/rabbitmq.com_rabbitmqclusters.yaml config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- new controller-gen now adds default value 'TCP' to ports the hack is no longer needed

## Additional Context

## Local Testing

Have tried new CRD against 1.18 k8s version and it works.
