### PR TITLE
Add spec.tls.disableNonTLSListeners property

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -241,6 +241,9 @@ type TLSSpec struct {
 	// The Secret must store this as ca.crt.
 	// Used for mTLS, and TLS for rabbitmq_web_stomp and rabbitmq_web_mqtt.
 	CaSecretName string `json:"caSecretName,omitempty"`
+	// When set to true, the RabbitmqCluster disables non-TLS listeners for RabbitMQ and for any enabled plugins in the following list: stomp, mqtt, web_stomp, web_mqtt.
+	// Only TLS-enabled clients will be able to connect.
+	DisableNonTLSListeners bool `json:"disableNonTLSListeners,omitempty"`
 }
 
 // kubebuilder validating tags 'Pattern' and 'MaxLength' must be specified on string type.
@@ -323,6 +326,10 @@ func (cluster *RabbitmqCluster) MemoryLimited() bool {
 
 func (cluster *RabbitmqCluster) SingleTLSSecret() bool {
 	return cluster.MutualTLSEnabled() && cluster.Spec.TLS.CaSecretName == cluster.Spec.TLS.SecretName
+}
+
+func (cluster *RabbitmqCluster) DisableNonTLSListeners() bool {
+	return cluster.Spec.TLS.DisableNonTLSListeners
 }
 
 func (cluster *RabbitmqCluster) AdditionalPluginEnabled(plugin Plugin) bool {

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -20,3506 +20,527 @@ spec:
     listKind: RabbitmqClusterList
     plural: rabbitmqclusters
     shortNames:
-    - rmq
+      - rmq
     singular: rabbitmqcluster
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.clusterStatus
-      name: Status
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: RabbitmqCluster is the Schema for the rabbitmqclusters API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec is the desired state of the RabbitmqCluster Custom Resource.
-            properties:
-              affinity:
-                description: Affinity is a group of affinity scheduling rules.
-                properties:
-                  nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node matches
-                          the corresponding matchExpressions; the node(s) with the
-                          highest sum are the most preferred.
-                        items:
-                          description: An empty preferred scheduling term matches
-                            all objects with implicit weight 0 (i.e. it's a no-op).
-                            A null preferred scheduling term matches no objects (i.e.
-                            is also a no-op).
-                          properties:
-                            preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - preference
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to an update), the system may or may not try to
-                          eventually evict the pod from its node.
-                        properties:
-                          nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
-                            items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            type: array
-                        required:
-                        - nodeSelectorTerms
-                        type: object
-                    type: object
-                  podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to a pod label update), the system may or may
-                          not try to eventually evict the pod from its node. When
-                          there are multiple elements, the lists of nodes corresponding
-                          to each podAffinityTerm are intersected, i.e. all terms
-                          must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
-                                type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                  podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the anti-affinity expressions specified
-                          by this field, but it may choose a node that violates one
-                          or more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the anti-affinity requirements specified by
-                          this field are not met at scheduling time, the pod will
-                          not be scheduled onto the node. If the anti-affinity requirements
-                          specified by this field cease to be met at some point during
-                          pod execution (e.g. due to a pod label update), the system
-                          may or may not try to eventually evict the pod from its
-                          node. When there are multiple elements, the lists of nodes
-                          corresponding to each podAffinityTerm are intersected, i.e.
-                          all terms must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
-                                type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              image:
-                default: rabbitmq:3.8.9-management
-                description: Image is the name of the RabbitMQ docker image to use
-                  for RabbitMQ nodes in the RabbitmqCluster.
-                type: string
-              imagePullSecrets:
-                description: List of Secret resource containing access credentials
-                  to the registry for the RabbitMQ image. Required if the docker registry
-                  is private.
-                items:
-                  description: LocalObjectReference contains enough information to
-                    let you locate the referenced object inside the same namespace.
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.clusterStatus
+          name: Status
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: RabbitmqCluster is the Schema for the rabbitmqclusters API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec is the desired state of the RabbitmqCluster Custom Resource.
+              properties:
+                affinity:
+                  description: Affinity is a group of affinity scheduling rules.
                   properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                type: array
-              override:
-                properties:
-                  service:
-                    properties:
-                      metadata:
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      spec:
-                        properties:
-                          clusterIP:
-                            type: string
-                          externalIPs:
-                            items:
-                              type: string
-                            type: array
-                          externalName:
-                            type: string
-                          externalTrafficPolicy:
-                            type: string
-                          healthCheckNodePort:
-                            format: int32
-                            type: integer
-                          ipFamily:
-                            type: string
-                          loadBalancerIP:
-                            type: string
-                          loadBalancerSourceRanges:
-                            items:
-                              type: string
-                            type: array
-                          ports:
-                            items:
-                              properties:
-                                appProtocol:
-                                  type: string
-                                name:
-                                  type: string
-                                nodePort:
-                                  format: int32
-                                  type: integer
-                                port:
-                                  format: int32
-                                  type: integer
-                                protocol:
-                                  default: TCP
-                                  type: string
-                                targetPort:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - port
-                              - protocol
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - port
-                            - protocol
-                            x-kubernetes-list-type: map
-                          publishNotReadyAddresses:
-                            type: boolean
-                          selector:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          sessionAffinity:
-                            type: string
-                          sessionAffinityConfig:
+                    nodeAffinity:
+                      description: Describes node affinity scheduling rules for the pod.
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                          items:
+                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                             properties:
-                              clientIP:
+                              preference:
+                                description: A node selector term, associated with the corresponding weight.
                                 properties:
-                                  timeoutSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                            type: object
-                          topologyKeys:
-                            items:
-                              type: string
-                            type: array
-                          type:
-                            type: string
-                        type: object
-                    type: object
-                  statefulSet:
-                    properties:
-                      metadata:
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      spec:
-                        properties:
-                          podManagementPolicy:
-                            type: string
-                          replicas:
-                            format: int32
-                            type: integer
-                          selector:
-                            properties:
-                              matchExpressions:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    operator:
-                                      type: string
-                                    values:
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          serviceName:
-                            type: string
-                          template:
-                            properties:
-                              metadata:
-                                properties:
-                                  annotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  labels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  name:
-                                    type: string
-                                  namespace:
-                                    type: string
-                                type: object
-                              spec:
-                                properties:
-                                  activeDeadlineSeconds:
-                                    format: int64
-                                    type: integer
-                                  affinity:
-                                    properties:
-                                      nodeAffinity:
-                                        properties:
-                                          preferredDuringSchedulingIgnoredDuringExecution:
-                                            items:
-                                              properties:
-                                                preference:
-                                                  properties:
-                                                    matchExpressions:
-                                                      items:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          operator:
-                                                            type: string
-                                                          values:
-                                                            items:
-                                                              type: string
-                                                            type: array
-                                                        required:
-                                                        - key
-                                                        - operator
-                                                        type: object
-                                                      type: array
-                                                    matchFields:
-                                                      items:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          operator:
-                                                            type: string
-                                                          values:
-                                                            items:
-                                                              type: string
-                                                            type: array
-                                                        required:
-                                                        - key
-                                                        - operator
-                                                        type: object
-                                                      type: array
-                                                  type: object
-                                                weight:
-                                                  format: int32
-                                                  type: integer
-                                              required:
-                                              - preference
-                                              - weight
-                                              type: object
-                                            type: array
-                                          requiredDuringSchedulingIgnoredDuringExecution:
-                                            properties:
-                                              nodeSelectorTerms:
-                                                items:
-                                                  properties:
-                                                    matchExpressions:
-                                                      items:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          operator:
-                                                            type: string
-                                                          values:
-                                                            items:
-                                                              type: string
-                                                            type: array
-                                                        required:
-                                                        - key
-                                                        - operator
-                                                        type: object
-                                                      type: array
-                                                    matchFields:
-                                                      items:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          operator:
-                                                            type: string
-                                                          values:
-                                                            items:
-                                                              type: string
-                                                            type: array
-                                                        required:
-                                                        - key
-                                                        - operator
-                                                        type: object
-                                                      type: array
-                                                  type: object
-                                                type: array
-                                            required:
-                                            - nodeSelectorTerms
-                                            type: object
-                                        type: object
-                                      podAffinity:
-                                        properties:
-                                          preferredDuringSchedulingIgnoredDuringExecution:
-                                            items:
-                                              properties:
-                                                podAffinityTerm:
-                                                  properties:
-                                                    labelSelector:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchLabels:
-                                                          additionalProperties:
-                                                            type: string
-                                                          type: object
-                                                      type: object
-                                                    namespaces:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    topologyKey:
-                                                      type: string
-                                                  required:
-                                                  - topologyKey
-                                                  type: object
-                                                weight:
-                                                  format: int32
-                                                  type: integer
-                                              required:
-                                              - podAffinityTerm
-                                              - weight
-                                              type: object
-                                            type: array
-                                          requiredDuringSchedulingIgnoredDuringExecution:
-                                            items:
-                                              properties:
-                                                labelSelector:
-                                                  properties:
-                                                    matchExpressions:
-                                                      items:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          operator:
-                                                            type: string
-                                                          values:
-                                                            items:
-                                                              type: string
-                                                            type: array
-                                                        required:
-                                                        - key
-                                                        - operator
-                                                        type: object
-                                                      type: array
-                                                    matchLabels:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
-                                                  type: object
-                                                namespaces:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                topologyKey:
-                                                  type: string
-                                              required:
-                                              - topologyKey
-                                              type: object
-                                            type: array
-                                        type: object
-                                      podAntiAffinity:
-                                        properties:
-                                          preferredDuringSchedulingIgnoredDuringExecution:
-                                            items:
-                                              properties:
-                                                podAffinityTerm:
-                                                  properties:
-                                                    labelSelector:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchLabels:
-                                                          additionalProperties:
-                                                            type: string
-                                                          type: object
-                                                      type: object
-                                                    namespaces:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    topologyKey:
-                                                      type: string
-                                                  required:
-                                                  - topologyKey
-                                                  type: object
-                                                weight:
-                                                  format: int32
-                                                  type: integer
-                                              required:
-                                              - podAffinityTerm
-                                              - weight
-                                              type: object
-                                            type: array
-                                          requiredDuringSchedulingIgnoredDuringExecution:
-                                            items:
-                                              properties:
-                                                labelSelector:
-                                                  properties:
-                                                    matchExpressions:
-                                                      items:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          operator:
-                                                            type: string
-                                                          values:
-                                                            items:
-                                                              type: string
-                                                            type: array
-                                                        required:
-                                                        - key
-                                                        - operator
-                                                        type: object
-                                                      type: array
-                                                    matchLabels:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
-                                                  type: object
-                                                namespaces:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                topologyKey:
-                                                  type: string
-                                              required:
-                                              - topologyKey
-                                              type: object
-                                            type: array
-                                        type: object
-                                    type: object
-                                  automountServiceAccountToken:
-                                    type: boolean
-                                  containers:
+                                  matchExpressions:
+                                    description: A list of node selector requirements by node's labels.
                                     items:
+                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                       properties:
-                                        args:
-                                          items:
-                                            type: string
-                                          type: array
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                        env:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                              valueFrom:
-                                                properties:
-                                                  configMapKeyRef:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    required:
-                                                    - key
-                                                    type: object
-                                                  fieldRef:
-                                                    properties:
-                                                      apiVersion:
-                                                        type: string
-                                                      fieldPath:
-                                                        type: string
-                                                    required:
-                                                    - fieldPath
-                                                    type: object
-                                                  resourceFieldRef:
-                                                    properties:
-                                                      containerName:
-                                                        type: string
-                                                      divisor:
-                                                        anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                        x-kubernetes-int-or-string: true
-                                                      resource:
-                                                        type: string
-                                                    required:
-                                                    - resource
-                                                    type: object
-                                                  secretKeyRef:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    required:
-                                                    - key
-                                                    type: object
-                                                type: object
-                                            required:
-                                            - name
-                                            type: object
-                                          type: array
-                                        envFrom:
-                                          items:
-                                            properties:
-                                              configMapRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  optional:
-                                                    type: boolean
-                                                type: object
-                                              prefix:
-                                                type: string
-                                              secretRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  optional:
-                                                    type: boolean
-                                                type: object
-                                            type: object
-                                          type: array
-                                        image:
-                                          type: string
-                                        imagePullPolicy:
-                                          type: string
-                                        lifecycle:
-                                          properties:
-                                            postStart:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                              type: object
-                                            preStop:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                              type: object
-                                          type: object
-                                        livenessProbe:
-                                          properties:
-                                            exec:
-                                              properties:
-                                                command:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            failureThreshold:
-                                              format: int32
-                                              type: integer
-                                            httpGet:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                httpHeaders:
-                                                  items:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      value:
-                                                        type: string
-                                                    required:
-                                                    - name
-                                                    - value
-                                                    type: object
-                                                  type: array
-                                                path:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                                scheme:
-                                                  type: string
-                                              required:
-                                              - port
-                                              type: object
-                                            initialDelaySeconds:
-                                              format: int32
-                                              type: integer
-                                            periodSeconds:
-                                              format: int32
-                                              type: integer
-                                            successThreshold:
-                                              format: int32
-                                              type: integer
-                                            tcpSocket:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                              required:
-                                              - port
-                                              type: object
-                                            timeoutSeconds:
-                                              format: int32
-                                              type: integer
-                                          type: object
-                                        name:
-                                          type: string
-                                        ports:
-                                          items:
-                                            properties:
-                                              containerPort:
-                                                format: int32
-                                                type: integer
-                                              hostIP:
-                                                type: string
-                                              hostPort:
-                                                format: int32
-                                                type: integer
-                                              name:
-                                                type: string
-                                              protocol:
-                                                default: TCP
-                                                type: string
-                                            required:
-                                            - containerPort
-                                            - protocol
-                                            type: object
-                                          type: array
-                                          x-kubernetes-list-map-keys:
-                                          - containerPort
-                                          - protocol
-                                          x-kubernetes-list-type: map
-                                        readinessProbe:
-                                          properties:
-                                            exec:
-                                              properties:
-                                                command:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            failureThreshold:
-                                              format: int32
-                                              type: integer
-                                            httpGet:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                httpHeaders:
-                                                  items:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      value:
-                                                        type: string
-                                                    required:
-                                                    - name
-                                                    - value
-                                                    type: object
-                                                  type: array
-                                                path:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                                scheme:
-                                                  type: string
-                                              required:
-                                              - port
-                                              type: object
-                                            initialDelaySeconds:
-                                              format: int32
-                                              type: integer
-                                            periodSeconds:
-                                              format: int32
-                                              type: integer
-                                            successThreshold:
-                                              format: int32
-                                              type: integer
-                                            tcpSocket:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                              required:
-                                              - port
-                                              type: object
-                                            timeoutSeconds:
-                                              format: int32
-                                              type: integer
-                                          type: object
-                                        resources:
-                                          properties:
-                                            limits:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                            requests:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                          type: object
-                                        securityContext:
-                                          properties:
-                                            allowPrivilegeEscalation:
-                                              type: boolean
-                                            capabilities:
-                                              properties:
-                                                add:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                drop:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            privileged:
-                                              type: boolean
-                                            procMount:
-                                              type: string
-                                            readOnlyRootFilesystem:
-                                              type: boolean
-                                            runAsGroup:
-                                              format: int64
-                                              type: integer
-                                            runAsNonRoot:
-                                              type: boolean
-                                            runAsUser:
-                                              format: int64
-                                              type: integer
-                                            seLinuxOptions:
-                                              properties:
-                                                level:
-                                                  type: string
-                                                role:
-                                                  type: string
-                                                type:
-                                                  type: string
-                                                user:
-                                                  type: string
-                                              type: object
-                                            windowsOptions:
-                                              properties:
-                                                gmsaCredentialSpec:
-                                                  type: string
-                                                gmsaCredentialSpecName:
-                                                  type: string
-                                                runAsUserName:
-                                                  type: string
-                                              type: object
-                                          type: object
-                                        startupProbe:
-                                          properties:
-                                            exec:
-                                              properties:
-                                                command:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            failureThreshold:
-                                              format: int32
-                                              type: integer
-                                            httpGet:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                httpHeaders:
-                                                  items:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      value:
-                                                        type: string
-                                                    required:
-                                                    - name
-                                                    - value
-                                                    type: object
-                                                  type: array
-                                                path:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                                scheme:
-                                                  type: string
-                                              required:
-                                              - port
-                                              type: object
-                                            initialDelaySeconds:
-                                              format: int32
-                                              type: integer
-                                            periodSeconds:
-                                              format: int32
-                                              type: integer
-                                            successThreshold:
-                                              format: int32
-                                              type: integer
-                                            tcpSocket:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                              required:
-                                              - port
-                                              type: object
-                                            timeoutSeconds:
-                                              format: int32
-                                              type: integer
-                                          type: object
-                                        stdin:
-                                          type: boolean
-                                        stdinOnce:
-                                          type: boolean
-                                        terminationMessagePath:
-                                          type: string
-                                        terminationMessagePolicy:
-                                          type: string
-                                        tty:
-                                          type: boolean
-                                        volumeDevices:
-                                          items:
-                                            properties:
-                                              devicePath:
-                                                type: string
-                                              name:
-                                                type: string
-                                            required:
-                                            - devicePath
-                                            - name
-                                            type: object
-                                          type: array
-                                        volumeMounts:
-                                          items:
-                                            properties:
-                                              mountPath:
-                                                type: string
-                                              mountPropagation:
-                                                type: string
-                                              name:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                              subPath:
-                                                type: string
-                                              subPathExpr:
-                                                type: string
-                                            required:
-                                            - mountPath
-                                            - name
-                                            type: object
-                                          type: array
-                                        workingDir:
-                                          type: string
-                                      required:
-                                      - name
-                                      type: object
-                                    type: array
-                                  dnsConfig:
-                                    properties:
-                                      nameservers:
-                                        items:
-                                          type: string
-                                        type: array
-                                      options:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      searches:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  dnsPolicy:
-                                    type: string
-                                  enableServiceLinks:
-                                    type: boolean
-                                  ephemeralContainers:
-                                    items:
-                                      properties:
-                                        args:
-                                          items:
-                                            type: string
-                                          type: array
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                        env:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                              valueFrom:
-                                                properties:
-                                                  configMapKeyRef:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    required:
-                                                    - key
-                                                    type: object
-                                                  fieldRef:
-                                                    properties:
-                                                      apiVersion:
-                                                        type: string
-                                                      fieldPath:
-                                                        type: string
-                                                    required:
-                                                    - fieldPath
-                                                    type: object
-                                                  resourceFieldRef:
-                                                    properties:
-                                                      containerName:
-                                                        type: string
-                                                      divisor:
-                                                        anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                        x-kubernetes-int-or-string: true
-                                                      resource:
-                                                        type: string
-                                                    required:
-                                                    - resource
-                                                    type: object
-                                                  secretKeyRef:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    required:
-                                                    - key
-                                                    type: object
-                                                type: object
-                                            required:
-                                            - name
-                                            type: object
-                                          type: array
-                                        envFrom:
-                                          items:
-                                            properties:
-                                              configMapRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  optional:
-                                                    type: boolean
-                                                type: object
-                                              prefix:
-                                                type: string
-                                              secretRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  optional:
-                                                    type: boolean
-                                                type: object
-                                            type: object
-                                          type: array
-                                        image:
-                                          type: string
-                                        imagePullPolicy:
-                                          type: string
-                                        lifecycle:
-                                          properties:
-                                            postStart:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                              type: object
-                                            preStop:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                              type: object
-                                          type: object
-                                        livenessProbe:
-                                          properties:
-                                            exec:
-                                              properties:
-                                                command:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            failureThreshold:
-                                              format: int32
-                                              type: integer
-                                            httpGet:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                httpHeaders:
-                                                  items:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      value:
-                                                        type: string
-                                                    required:
-                                                    - name
-                                                    - value
-                                                    type: object
-                                                  type: array
-                                                path:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                                scheme:
-                                                  type: string
-                                              required:
-                                              - port
-                                              type: object
-                                            initialDelaySeconds:
-                                              format: int32
-                                              type: integer
-                                            periodSeconds:
-                                              format: int32
-                                              type: integer
-                                            successThreshold:
-                                              format: int32
-                                              type: integer
-                                            tcpSocket:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                              required:
-                                              - port
-                                              type: object
-                                            timeoutSeconds:
-                                              format: int32
-                                              type: integer
-                                          type: object
-                                        name:
-                                          type: string
-                                        ports:
-                                          items:
-                                            properties:
-                                              containerPort:
-                                                format: int32
-                                                type: integer
-                                              hostIP:
-                                                type: string
-                                              hostPort:
-                                                format: int32
-                                                type: integer
-                                              name:
-                                                type: string
-                                              protocol:
-                                                default: TCP
-                                                type: string
-                                            required:
-                                            - containerPort
-                                            type: object
-                                          type: array
-                                        readinessProbe:
-                                          properties:
-                                            exec:
-                                              properties:
-                                                command:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            failureThreshold:
-                                              format: int32
-                                              type: integer
-                                            httpGet:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                httpHeaders:
-                                                  items:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      value:
-                                                        type: string
-                                                    required:
-                                                    - name
-                                                    - value
-                                                    type: object
-                                                  type: array
-                                                path:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                                scheme:
-                                                  type: string
-                                              required:
-                                              - port
-                                              type: object
-                                            initialDelaySeconds:
-                                              format: int32
-                                              type: integer
-                                            periodSeconds:
-                                              format: int32
-                                              type: integer
-                                            successThreshold:
-                                              format: int32
-                                              type: integer
-                                            tcpSocket:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                              required:
-                                              - port
-                                              type: object
-                                            timeoutSeconds:
-                                              format: int32
-                                              type: integer
-                                          type: object
-                                        resources:
-                                          properties:
-                                            limits:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                            requests:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                          type: object
-                                        securityContext:
-                                          properties:
-                                            allowPrivilegeEscalation:
-                                              type: boolean
-                                            capabilities:
-                                              properties:
-                                                add:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                drop:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            privileged:
-                                              type: boolean
-                                            procMount:
-                                              type: string
-                                            readOnlyRootFilesystem:
-                                              type: boolean
-                                            runAsGroup:
-                                              format: int64
-                                              type: integer
-                                            runAsNonRoot:
-                                              type: boolean
-                                            runAsUser:
-                                              format: int64
-                                              type: integer
-                                            seLinuxOptions:
-                                              properties:
-                                                level:
-                                                  type: string
-                                                role:
-                                                  type: string
-                                                type:
-                                                  type: string
-                                                user:
-                                                  type: string
-                                              type: object
-                                            windowsOptions:
-                                              properties:
-                                                gmsaCredentialSpec:
-                                                  type: string
-                                                gmsaCredentialSpecName:
-                                                  type: string
-                                                runAsUserName:
-                                                  type: string
-                                              type: object
-                                          type: object
-                                        startupProbe:
-                                          properties:
-                                            exec:
-                                              properties:
-                                                command:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            failureThreshold:
-                                              format: int32
-                                              type: integer
-                                            httpGet:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                httpHeaders:
-                                                  items:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      value:
-                                                        type: string
-                                                    required:
-                                                    - name
-                                                    - value
-                                                    type: object
-                                                  type: array
-                                                path:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                                scheme:
-                                                  type: string
-                                              required:
-                                              - port
-                                              type: object
-                                            initialDelaySeconds:
-                                              format: int32
-                                              type: integer
-                                            periodSeconds:
-                                              format: int32
-                                              type: integer
-                                            successThreshold:
-                                              format: int32
-                                              type: integer
-                                            tcpSocket:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                              required:
-                                              - port
-                                              type: object
-                                            timeoutSeconds:
-                                              format: int32
-                                              type: integer
-                                          type: object
-                                        stdin:
-                                          type: boolean
-                                        stdinOnce:
-                                          type: boolean
-                                        targetContainerName:
-                                          type: string
-                                        terminationMessagePath:
-                                          type: string
-                                        terminationMessagePolicy:
-                                          type: string
-                                        tty:
-                                          type: boolean
-                                        volumeDevices:
-                                          items:
-                                            properties:
-                                              devicePath:
-                                                type: string
-                                              name:
-                                                type: string
-                                            required:
-                                            - devicePath
-                                            - name
-                                            type: object
-                                          type: array
-                                        volumeMounts:
-                                          items:
-                                            properties:
-                                              mountPath:
-                                                type: string
-                                              mountPropagation:
-                                                type: string
-                                              name:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                              subPath:
-                                                type: string
-                                              subPathExpr:
-                                                type: string
-                                            required:
-                                            - mountPath
-                                            - name
-                                            type: object
-                                          type: array
-                                        workingDir:
-                                          type: string
-                                      required:
-                                      - name
-                                      type: object
-                                    type: array
-                                  hostAliases:
-                                    items:
-                                      properties:
-                                        hostnames:
-                                          items:
-                                            type: string
-                                          type: array
-                                        ip:
-                                          type: string
-                                      type: object
-                                    type: array
-                                  hostIPC:
-                                    type: boolean
-                                  hostNetwork:
-                                    type: boolean
-                                  hostPID:
-                                    type: boolean
-                                  hostname:
-                                    type: string
-                                  imagePullSecrets:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    type: array
-                                  initContainers:
-                                    items:
-                                      properties:
-                                        args:
-                                          items:
-                                            type: string
-                                          type: array
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                        env:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                              valueFrom:
-                                                properties:
-                                                  configMapKeyRef:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    required:
-                                                    - key
-                                                    type: object
-                                                  fieldRef:
-                                                    properties:
-                                                      apiVersion:
-                                                        type: string
-                                                      fieldPath:
-                                                        type: string
-                                                    required:
-                                                    - fieldPath
-                                                    type: object
-                                                  resourceFieldRef:
-                                                    properties:
-                                                      containerName:
-                                                        type: string
-                                                      divisor:
-                                                        anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                        x-kubernetes-int-or-string: true
-                                                      resource:
-                                                        type: string
-                                                    required:
-                                                    - resource
-                                                    type: object
-                                                  secretKeyRef:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    required:
-                                                    - key
-                                                    type: object
-                                                type: object
-                                            required:
-                                            - name
-                                            type: object
-                                          type: array
-                                        envFrom:
-                                          items:
-                                            properties:
-                                              configMapRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  optional:
-                                                    type: boolean
-                                                type: object
-                                              prefix:
-                                                type: string
-                                              secretRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  optional:
-                                                    type: boolean
-                                                type: object
-                                            type: object
-                                          type: array
-                                        image:
-                                          type: string
-                                        imagePullPolicy:
-                                          type: string
-                                        lifecycle:
-                                          properties:
-                                            postStart:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                              type: object
-                                            preStop:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                              type: object
-                                          type: object
-                                        livenessProbe:
-                                          properties:
-                                            exec:
-                                              properties:
-                                                command:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            failureThreshold:
-                                              format: int32
-                                              type: integer
-                                            httpGet:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                httpHeaders:
-                                                  items:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      value:
-                                                        type: string
-                                                    required:
-                                                    - name
-                                                    - value
-                                                    type: object
-                                                  type: array
-                                                path:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                                scheme:
-                                                  type: string
-                                              required:
-                                              - port
-                                              type: object
-                                            initialDelaySeconds:
-                                              format: int32
-                                              type: integer
-                                            periodSeconds:
-                                              format: int32
-                                              type: integer
-                                            successThreshold:
-                                              format: int32
-                                              type: integer
-                                            tcpSocket:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                              required:
-                                              - port
-                                              type: object
-                                            timeoutSeconds:
-                                              format: int32
-                                              type: integer
-                                          type: object
-                                        name:
-                                          type: string
-                                        ports:
-                                          items:
-                                            properties:
-                                              containerPort:
-                                                format: int32
-                                                type: integer
-                                              hostIP:
-                                                type: string
-                                              hostPort:
-                                                format: int32
-                                                type: integer
-                                              name:
-                                                type: string
-                                              protocol:
-                                                default: TCP
-                                                type: string
-                                            required:
-                                            - containerPort
-                                            - protocol
-                                            type: object
-                                          type: array
-                                          x-kubernetes-list-map-keys:
-                                          - containerPort
-                                          - protocol
-                                          x-kubernetes-list-type: map
-                                        readinessProbe:
-                                          properties:
-                                            exec:
-                                              properties:
-                                                command:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            failureThreshold:
-                                              format: int32
-                                              type: integer
-                                            httpGet:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                httpHeaders:
-                                                  items:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      value:
-                                                        type: string
-                                                    required:
-                                                    - name
-                                                    - value
-                                                    type: object
-                                                  type: array
-                                                path:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                                scheme:
-                                                  type: string
-                                              required:
-                                              - port
-                                              type: object
-                                            initialDelaySeconds:
-                                              format: int32
-                                              type: integer
-                                            periodSeconds:
-                                              format: int32
-                                              type: integer
-                                            successThreshold:
-                                              format: int32
-                                              type: integer
-                                            tcpSocket:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                              required:
-                                              - port
-                                              type: object
-                                            timeoutSeconds:
-                                              format: int32
-                                              type: integer
-                                          type: object
-                                        resources:
-                                          properties:
-                                            limits:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                            requests:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                          type: object
-                                        securityContext:
-                                          properties:
-                                            allowPrivilegeEscalation:
-                                              type: boolean
-                                            capabilities:
-                                              properties:
-                                                add:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                drop:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            privileged:
-                                              type: boolean
-                                            procMount:
-                                              type: string
-                                            readOnlyRootFilesystem:
-                                              type: boolean
-                                            runAsGroup:
-                                              format: int64
-                                              type: integer
-                                            runAsNonRoot:
-                                              type: boolean
-                                            runAsUser:
-                                              format: int64
-                                              type: integer
-                                            seLinuxOptions:
-                                              properties:
-                                                level:
-                                                  type: string
-                                                role:
-                                                  type: string
-                                                type:
-                                                  type: string
-                                                user:
-                                                  type: string
-                                              type: object
-                                            windowsOptions:
-                                              properties:
-                                                gmsaCredentialSpec:
-                                                  type: string
-                                                gmsaCredentialSpecName:
-                                                  type: string
-                                                runAsUserName:
-                                                  type: string
-                                              type: object
-                                          type: object
-                                        startupProbe:
-                                          properties:
-                                            exec:
-                                              properties:
-                                                command:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            failureThreshold:
-                                              format: int32
-                                              type: integer
-                                            httpGet:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                httpHeaders:
-                                                  items:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      value:
-                                                        type: string
-                                                    required:
-                                                    - name
-                                                    - value
-                                                    type: object
-                                                  type: array
-                                                path:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                                scheme:
-                                                  type: string
-                                              required:
-                                              - port
-                                              type: object
-                                            initialDelaySeconds:
-                                              format: int32
-                                              type: integer
-                                            periodSeconds:
-                                              format: int32
-                                              type: integer
-                                            successThreshold:
-                                              format: int32
-                                              type: integer
-                                            tcpSocket:
-                                              properties:
-                                                host:
-                                                  type: string
-                                                port:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                              required:
-                                              - port
-                                              type: object
-                                            timeoutSeconds:
-                                              format: int32
-                                              type: integer
-                                          type: object
-                                        stdin:
-                                          type: boolean
-                                        stdinOnce:
-                                          type: boolean
-                                        terminationMessagePath:
-                                          type: string
-                                        terminationMessagePolicy:
-                                          type: string
-                                        tty:
-                                          type: boolean
-                                        volumeDevices:
-                                          items:
-                                            properties:
-                                              devicePath:
-                                                type: string
-                                              name:
-                                                type: string
-                                            required:
-                                            - devicePath
-                                            - name
-                                            type: object
-                                          type: array
-                                        volumeMounts:
-                                          items:
-                                            properties:
-                                              mountPath:
-                                                type: string
-                                              mountPropagation:
-                                                type: string
-                                              name:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                              subPath:
-                                                type: string
-                                              subPathExpr:
-                                                type: string
-                                            required:
-                                            - mountPath
-                                            - name
-                                            type: object
-                                          type: array
-                                        workingDir:
-                                          type: string
-                                      required:
-                                      - name
-                                      type: object
-                                    type: array
-                                  nodeName:
-                                    type: string
-                                  nodeSelector:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  overhead:
-                                    additionalProperties:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    type: object
-                                  preemptionPolicy:
-                                    type: string
-                                  priority:
-                                    format: int32
-                                    type: integer
-                                  priorityClassName:
-                                    type: string
-                                  readinessGates:
-                                    items:
-                                      properties:
-                                        conditionType:
-                                          type: string
-                                      required:
-                                      - conditionType
-                                      type: object
-                                    type: array
-                                  restartPolicy:
-                                    type: string
-                                  runtimeClassName:
-                                    type: string
-                                  schedulerName:
-                                    type: string
-                                  securityContext:
-                                    properties:
-                                      fsGroup:
-                                        format: int64
-                                        type: integer
-                                      fsGroupChangePolicy:
-                                        type: string
-                                      runAsGroup:
-                                        format: int64
-                                        type: integer
-                                      runAsNonRoot:
-                                        type: boolean
-                                      runAsUser:
-                                        format: int64
-                                        type: integer
-                                      seLinuxOptions:
-                                        properties:
-                                          level:
-                                            type: string
-                                          role:
-                                            type: string
-                                          type:
-                                            type: string
-                                          user:
-                                            type: string
-                                        type: object
-                                      supplementalGroups:
-                                        items:
-                                          format: int64
-                                          type: integer
-                                        type: array
-                                      sysctls:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                          - name
-                                          - value
-                                          type: object
-                                        type: array
-                                      windowsOptions:
-                                        properties:
-                                          gmsaCredentialSpec:
-                                            type: string
-                                          gmsaCredentialSpecName:
-                                            type: string
-                                          runAsUserName:
-                                            type: string
-                                        type: object
-                                    type: object
-                                  serviceAccount:
-                                    type: string
-                                  serviceAccountName:
-                                    type: string
-                                  shareProcessNamespace:
-                                    type: boolean
-                                  subdomain:
-                                    type: string
-                                  terminationGracePeriodSeconds:
-                                    format: int64
-                                    type: integer
-                                  tolerations:
-                                    items:
-                                      properties:
-                                        effect:
-                                          type: string
                                         key:
+                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
+                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
-                                        tolerationSeconds:
-                                          format: int64
-                                          type: integer
-                                        value:
-                                          type: string
-                                      type: object
-                                    type: array
-                                  topologySpreadConstraints:
-                                    items:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        maxSkew:
-                                          format: int32
-                                          type: integer
-                                        topologyKey:
-                                          type: string
-                                        whenUnsatisfiable:
-                                          type: string
+                                        values:
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
                                       required:
-                                      - maxSkew
-                                      - topologyKey
-                                      - whenUnsatisfiable
+                                        - key
+                                        - operator
                                       type: object
                                     type: array
-                                    x-kubernetes-list-map-keys:
-                                    - topologyKey
-                                    - whenUnsatisfiable
-                                    x-kubernetes-list-type: map
-                                  volumes:
+                                  matchFields:
+                                    description: A list of node selector requirements by node's fields.
                                     items:
+                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                       properties:
-                                        awsElasticBlockStore:
-                                          properties:
-                                            fsType:
-                                              type: string
-                                            partition:
-                                              format: int32
-                                              type: integer
-                                            readOnly:
-                                              type: boolean
-                                            volumeID:
-                                              type: string
-                                          required:
-                                          - volumeID
-                                          type: object
-                                        azureDisk:
-                                          properties:
-                                            cachingMode:
-                                              type: string
-                                            diskName:
-                                              type: string
-                                            diskURI:
-                                              type: string
-                                            fsType:
-                                              type: string
-                                            kind:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                          required:
-                                          - diskName
-                                          - diskURI
-                                          type: object
-                                        azureFile:
-                                          properties:
-                                            readOnly:
-                                              type: boolean
-                                            secretName:
-                                              type: string
-                                            shareName:
-                                              type: string
-                                          required:
-                                          - secretName
-                                          - shareName
-                                          type: object
-                                        cephfs:
-                                          properties:
-                                            monitors:
-                                              items:
-                                                type: string
-                                              type: array
-                                            path:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                            secretFile:
-                                              type: string
-                                            secretRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                              type: object
-                                            user:
-                                              type: string
-                                          required:
-                                          - monitors
-                                          type: object
-                                        cinder:
-                                          properties:
-                                            fsType:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                            secretRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                              type: object
-                                            volumeID:
-                                              type: string
-                                          required:
-                                          - volumeID
-                                          type: object
-                                        configMap:
-                                          properties:
-                                            defaultMode:
-                                              format: int32
-                                              type: integer
-                                            items:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  mode:
-                                                    format: int32
-                                                    type: integer
-                                                  path:
-                                                    type: string
-                                                required:
-                                                - key
-                                                - path
-                                                type: object
-                                              type: array
-                                            name:
-                                              type: string
-                                            optional:
-                                              type: boolean
-                                          type: object
-                                        csi:
-                                          properties:
-                                            driver:
-                                              type: string
-                                            fsType:
-                                              type: string
-                                            nodePublishSecretRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                              type: object
-                                            readOnly:
-                                              type: boolean
-                                            volumeAttributes:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          required:
-                                          - driver
-                                          type: object
-                                        downwardAPI:
-                                          properties:
-                                            defaultMode:
-                                              format: int32
-                                              type: integer
-                                            items:
-                                              items:
-                                                properties:
-                                                  fieldRef:
-                                                    properties:
-                                                      apiVersion:
-                                                        type: string
-                                                      fieldPath:
-                                                        type: string
-                                                    required:
-                                                    - fieldPath
-                                                    type: object
-                                                  mode:
-                                                    format: int32
-                                                    type: integer
-                                                  path:
-                                                    type: string
-                                                  resourceFieldRef:
-                                                    properties:
-                                                      containerName:
-                                                        type: string
-                                                      divisor:
-                                                        anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                        x-kubernetes-int-or-string: true
-                                                      resource:
-                                                        type: string
-                                                    required:
-                                                    - resource
-                                                    type: object
-                                                required:
-                                                - path
-                                                type: object
-                                              type: array
-                                          type: object
-                                        emptyDir:
-                                          properties:
-                                            medium:
-                                              type: string
-                                            sizeLimit:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                          type: object
-                                        fc:
-                                          properties:
-                                            fsType:
-                                              type: string
-                                            lun:
-                                              format: int32
-                                              type: integer
-                                            readOnly:
-                                              type: boolean
-                                            targetWWNs:
-                                              items:
-                                                type: string
-                                              type: array
-                                            wwids:
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        flexVolume:
-                                          properties:
-                                            driver:
-                                              type: string
-                                            fsType:
-                                              type: string
-                                            options:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                            readOnly:
-                                              type: boolean
-                                            secretRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                              type: object
-                                          required:
-                                          - driver
-                                          type: object
-                                        flocker:
-                                          properties:
-                                            datasetName:
-                                              type: string
-                                            datasetUUID:
-                                              type: string
-                                          type: object
-                                        gcePersistentDisk:
-                                          properties:
-                                            fsType:
-                                              type: string
-                                            partition:
-                                              format: int32
-                                              type: integer
-                                            pdName:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                          required:
-                                          - pdName
-                                          type: object
-                                        gitRepo:
-                                          properties:
-                                            directory:
-                                              type: string
-                                            repository:
-                                              type: string
-                                            revision:
-                                              type: string
-                                          required:
-                                          - repository
-                                          type: object
-                                        glusterfs:
-                                          properties:
-                                            endpoints:
-                                              type: string
-                                            path:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                          required:
-                                          - endpoints
-                                          - path
-                                          type: object
-                                        hostPath:
-                                          properties:
-                                            path:
-                                              type: string
-                                            type:
-                                              type: string
-                                          required:
-                                          - path
-                                          type: object
-                                        iscsi:
-                                          properties:
-                                            chapAuthDiscovery:
-                                              type: boolean
-                                            chapAuthSession:
-                                              type: boolean
-                                            fsType:
-                                              type: string
-                                            initiatorName:
-                                              type: string
-                                            iqn:
-                                              type: string
-                                            iscsiInterface:
-                                              type: string
-                                            lun:
-                                              format: int32
-                                              type: integer
-                                            portals:
-                                              items:
-                                                type: string
-                                              type: array
-                                            readOnly:
-                                              type: boolean
-                                            secretRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                              type: object
-                                            targetPortal:
-                                              type: string
-                                          required:
-                                          - iqn
-                                          - lun
-                                          - targetPortal
-                                          type: object
-                                        name:
+                                        key:
+                                          description: The label key that the selector applies to.
                                           type: string
-                                        nfs:
-                                          properties:
-                                            path:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                            server:
-                                              type: string
-                                          required:
-                                          - path
-                                          - server
-                                          type: object
-                                        persistentVolumeClaim:
-                                          properties:
-                                            claimName:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                          required:
-                                          - claimName
-                                          type: object
-                                        photonPersistentDisk:
-                                          properties:
-                                            fsType:
-                                              type: string
-                                            pdID:
-                                              type: string
-                                          required:
-                                          - pdID
-                                          type: object
-                                        portworxVolume:
-                                          properties:
-                                            fsType:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                            volumeID:
-                                              type: string
-                                          required:
-                                          - volumeID
-                                          type: object
-                                        projected:
-                                          properties:
-                                            defaultMode:
-                                              format: int32
-                                              type: integer
-                                            sources:
-                                              items:
-                                                properties:
-                                                  configMap:
-                                                    properties:
-                                                      items:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            mode:
-                                                              format: int32
-                                                              type: integer
-                                                            path:
-                                                              type: string
-                                                          required:
-                                                          - key
-                                                          - path
-                                                          type: object
-                                                        type: array
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                  downwardAPI:
-                                                    properties:
-                                                      items:
-                                                        items:
-                                                          properties:
-                                                            fieldRef:
-                                                              properties:
-                                                                apiVersion:
-                                                                  type: string
-                                                                fieldPath:
-                                                                  type: string
-                                                              required:
-                                                              - fieldPath
-                                                              type: object
-                                                            mode:
-                                                              format: int32
-                                                              type: integer
-                                                            path:
-                                                              type: string
-                                                            resourceFieldRef:
-                                                              properties:
-                                                                containerName:
-                                                                  type: string
-                                                                divisor:
-                                                                  anyOf:
-                                                                  - type: integer
-                                                                  - type: string
-                                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                                  x-kubernetes-int-or-string: true
-                                                                resource:
-                                                                  type: string
-                                                              required:
-                                                              - resource
-                                                              type: object
-                                                          required:
-                                                          - path
-                                                          type: object
-                                                        type: array
-                                                    type: object
-                                                  secret:
-                                                    properties:
-                                                      items:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            mode:
-                                                              format: int32
-                                                              type: integer
-                                                            path:
-                                                              type: string
-                                                          required:
-                                                          - key
-                                                          - path
-                                                          type: object
-                                                        type: array
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                  serviceAccountToken:
-                                                    properties:
-                                                      audience:
-                                                        type: string
-                                                      expirationSeconds:
-                                                        format: int64
-                                                        type: integer
-                                                      path:
-                                                        type: string
-                                                    required:
-                                                    - path
-                                                    type: object
-                                                type: object
-                                              type: array
-                                          required:
-                                          - sources
-                                          type: object
-                                        quobyte:
-                                          properties:
-                                            group:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                            registry:
-                                              type: string
-                                            tenant:
-                                              type: string
-                                            user:
-                                              type: string
-                                            volume:
-                                              type: string
-                                          required:
-                                          - registry
-                                          - volume
-                                          type: object
-                                        rbd:
-                                          properties:
-                                            fsType:
-                                              type: string
-                                            image:
-                                              type: string
-                                            keyring:
-                                              type: string
-                                            monitors:
-                                              items:
-                                                type: string
-                                              type: array
-                                            pool:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                            secretRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                              type: object
-                                            user:
-                                              type: string
-                                          required:
-                                          - image
-                                          - monitors
-                                          type: object
-                                        scaleIO:
-                                          properties:
-                                            fsType:
-                                              type: string
-                                            gateway:
-                                              type: string
-                                            protectionDomain:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                            secretRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                              type: object
-                                            sslEnabled:
-                                              type: boolean
-                                            storageMode:
-                                              type: string
-                                            storagePool:
-                                              type: string
-                                            system:
-                                              type: string
-                                            volumeName:
-                                              type: string
-                                          required:
-                                          - gateway
-                                          - secretRef
-                                          - system
-                                          type: object
-                                        secret:
-                                          properties:
-                                            defaultMode:
-                                              format: int32
-                                              type: integer
-                                            items:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  mode:
-                                                    format: int32
-                                                    type: integer
-                                                  path:
-                                                    type: string
-                                                required:
-                                                - key
-                                                - path
-                                                type: object
-                                              type: array
-                                            optional:
-                                              type: boolean
-                                            secretName:
-                                              type: string
-                                          type: object
-                                        storageos:
-                                          properties:
-                                            fsType:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                            secretRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                              type: object
-                                            volumeName:
-                                              type: string
-                                            volumeNamespace:
-                                              type: string
-                                          type: object
-                                        vsphereVolume:
-                                          properties:
-                                            fsType:
-                                              type: string
-                                            storagePolicyID:
-                                              type: string
-                                            storagePolicyName:
-                                              type: string
-                                            volumePath:
-                                              type: string
-                                          required:
-                                          - volumePath
-                                          type: object
+                                        operator:
+                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
                                       required:
-                                      - name
+                                        - key
+                                        - operator
                                       type: object
                                     type: array
-                                required:
-                                - containers
                                 type: object
+                              weight:
+                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - preference
+                              - weight
                             type: object
-                          updateStrategy:
-                            properties:
-                              rollingUpdate:
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms. The terms are ORed.
+                              items:
+                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                 properties:
-                                  partition:
+                                  matchExpressions:
+                                    description: A list of node selector requirements by node's labels.
+                                    items:
+                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements by node's fields.
+                                    items:
+                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                            - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources, in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources, in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources, in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources, in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                image:
+                  default: rabbitmq:3.8.9-management
+                  description: Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster.
+                  type: string
+                imagePullSecrets:
+                  description: List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
+                  items:
+                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  type: array
+                override:
+                  properties:
+                    service:
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        spec:
+                          properties:
+                            clusterIP:
+                              type: string
+                            externalIPs:
+                              items:
+                                type: string
+                              type: array
+                            externalName:
+                              type: string
+                            externalTrafficPolicy:
+                              type: string
+                            healthCheckNodePort:
+                              format: int32
+                              type: integer
+                            ipFamily:
+                              type: string
+                            loadBalancerIP:
+                              type: string
+                            loadBalancerSourceRanges:
+                              items:
+                                type: string
+                              type: array
+                            ports:
+                              items:
+                                properties:
+                                  appProtocol:
+                                    type: string
+                                  name:
+                                    type: string
+                                  nodePort:
                                     format: int32
                                     type: integer
+                                  port:
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                  targetPort:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
                                 type: object
-                              type:
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - port
+                                - protocol
+                              x-kubernetes-list-type: map
+                            publishNotReadyAddresses:
+                              type: boolean
+                            selector:
+                              additionalProperties:
                                 type: string
-                            type: object
-                          volumeClaimTemplates:
-                            items:
+                              type: object
+                            sessionAffinity:
+                              type: string
+                            sessionAffinityConfig:
                               properties:
-                                apiVersion:
-                                  type: string
-                                kind:
-                                  type: string
+                                clientIP:
+                                  properties:
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                              type: object
+                            topologyKeys:
+                              items:
+                                type: string
+                              type: array
+                            type:
+                              type: string
+                          type: object
+                      type: object
+                    statefulSet:
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        spec:
+                          properties:
+                            podManagementPolicy:
+                              type: string
+                            replicas:
+                              format: int32
+                              type: integer
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            serviceName:
+                              type: string
+                            template:
+                              properties:
                                 metadata:
                                   properties:
                                     annotations:
@@ -3537,331 +558,3001 @@ spec:
                                   type: object
                                 spec:
                                   properties:
-                                    accessModes:
+                                    activeDeadlineSeconds:
+                                      format: int64
+                                      type: integer
+                                    affinity:
+                                      properties:
+                                        nodeAffinity:
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              items:
+                                                properties:
+                                                  preference:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                      matchFields:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  weight:
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                type: object
+                                              type: array
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  items:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                      matchFields:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  type: array
+                                              required:
+                                                - nodeSelectorTerms
+                                              type: object
+                                          type: object
+                                        podAffinity:
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              items:
+                                                properties:
+                                                  podAffinityTerm:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                      - topologyKey
+                                                    type: object
+                                                  weight:
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                type: object
+                                              type: array
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              items:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                  namespaces:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  topologyKey:
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              type: array
+                                          type: object
+                                        podAntiAffinity:
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              items:
+                                                properties:
+                                                  podAffinityTerm:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                      - topologyKey
+                                                    type: object
+                                                  weight:
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                type: object
+                                              type: array
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              items:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                  namespaces:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  topologyKey:
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              type: array
+                                          type: object
+                                      type: object
+                                    automountServiceAccountToken:
+                                      type: boolean
+                                    containers:
                                       items:
-                                        type: string
+                                        properties:
+                                          args:
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                          env:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                                valueFrom:
+                                                  properties:
+                                                    configMapKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      required:
+                                                        - fieldPath
+                                                      type: object
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      required:
+                                                        - resource
+                                                      type: object
+                                                    secretKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                  type: object
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                          envFrom:
+                                            items:
+                                              properties:
+                                                configMapRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                prefix:
+                                                  type: string
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                              type: object
+                                            type: array
+                                          image:
+                                            type: string
+                                          imagePullPolicy:
+                                            type: string
+                                          lifecycle:
+                                            properties:
+                                              postStart:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                            - name
+                                                            - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                      - port
+                                                    type: object
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                      - port
+                                                    type: object
+                                                type: object
+                                              preStop:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                            - name
+                                                            - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                      - port
+                                                    type: object
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                      - port
+                                                    type: object
+                                                type: object
+                                            type: object
+                                          livenessProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          name:
+                                            type: string
+                                          ports:
+                                            items:
+                                              properties:
+                                                containerPort:
+                                                  format: int32
+                                                  type: integer
+                                                hostIP:
+                                                  type: string
+                                                hostPort:
+                                                  format: int32
+                                                  type: integer
+                                                name:
+                                                  type: string
+                                                protocol:
+                                                  default: TCP
+                                                  type: string
+                                              required:
+                                                - containerPort
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - containerPort
+                                              - protocol
+                                            x-kubernetes-list-type: map
+                                          readinessProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          resources:
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          securityContext:
+                                            properties:
+                                              allowPrivilegeEscalation:
+                                                type: boolean
+                                              capabilities:
+                                                properties:
+                                                  add:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  drop:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              privileged:
+                                                type: boolean
+                                              procMount:
+                                                type: string
+                                              readOnlyRootFilesystem:
+                                                type: boolean
+                                              runAsGroup:
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                type: boolean
+                                              runAsUser:
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                properties:
+                                                  level:
+                                                    type: string
+                                                  role:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                  user:
+                                                    type: string
+                                                type: object
+                                              windowsOptions:
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    type: string
+                                                  runAsUserName:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          startupProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          stdin:
+                                            type: boolean
+                                          stdinOnce:
+                                            type: boolean
+                                          terminationMessagePath:
+                                            type: string
+                                          terminationMessagePolicy:
+                                            type: string
+                                          tty:
+                                            type: boolean
+                                          volumeDevices:
+                                            items:
+                                              properties:
+                                                devicePath:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              required:
+                                                - devicePath
+                                                - name
+                                              type: object
+                                            type: array
+                                          volumeMounts:
+                                            items:
+                                              properties:
+                                                mountPath:
+                                                  type: string
+                                                mountPropagation:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                subPath:
+                                                  type: string
+                                                subPathExpr:
+                                                  type: string
+                                              required:
+                                                - mountPath
+                                                - name
+                                              type: object
+                                            type: array
+                                          workingDir:
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
                                       type: array
-                                    dataSource:
+                                    dnsConfig:
                                       properties:
-                                        apiGroup:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    resources:
-                                      properties:
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                      type: object
-                                    selector:
-                                      properties:
-                                        matchExpressions:
+                                        nameservers:
+                                          items:
+                                            type: string
+                                          type: array
+                                        options:
                                           items:
                                             properties:
-                                              key:
+                                              name:
                                                 type: string
-                                              operator:
+                                              value:
                                                 type: string
-                                              values:
+                                            type: object
+                                          type: array
+                                        searches:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    dnsPolicy:
+                                      type: string
+                                    enableServiceLinks:
+                                      type: boolean
+                                    ephemeralContainers:
+                                      items:
+                                        properties:
+                                          args:
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                          env:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                                valueFrom:
+                                                  properties:
+                                                    configMapKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      required:
+                                                        - fieldPath
+                                                      type: object
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      required:
+                                                        - resource
+                                                      type: object
+                                                    secretKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                  type: object
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                          envFrom:
+                                            items:
+                                              properties:
+                                                configMapRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                prefix:
+                                                  type: string
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                              type: object
+                                            type: array
+                                          image:
+                                            type: string
+                                          imagePullPolicy:
+                                            type: string
+                                          lifecycle:
+                                            properties:
+                                              postStart:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                            - name
+                                                            - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                      - port
+                                                    type: object
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                      - port
+                                                    type: object
+                                                type: object
+                                              preStop:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                            - name
+                                                            - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                      - port
+                                                    type: object
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                      - port
+                                                    type: object
+                                                type: object
+                                            type: object
+                                          livenessProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          name:
+                                            type: string
+                                          ports:
+                                            items:
+                                              properties:
+                                                containerPort:
+                                                  format: int32
+                                                  type: integer
+                                                hostIP:
+                                                  type: string
+                                                hostPort:
+                                                  format: int32
+                                                  type: integer
+                                                name:
+                                                  type: string
+                                                protocol:
+                                                  default: TCP
+                                                  type: string
+                                              required:
+                                                - containerPort
+                                              type: object
+                                            type: array
+                                          readinessProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          resources:
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          securityContext:
+                                            properties:
+                                              allowPrivilegeEscalation:
+                                                type: boolean
+                                              capabilities:
+                                                properties:
+                                                  add:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  drop:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              privileged:
+                                                type: boolean
+                                              procMount:
+                                                type: string
+                                              readOnlyRootFilesystem:
+                                                type: boolean
+                                              runAsGroup:
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                type: boolean
+                                              runAsUser:
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                properties:
+                                                  level:
+                                                    type: string
+                                                  role:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                  user:
+                                                    type: string
+                                                type: object
+                                              windowsOptions:
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    type: string
+                                                  runAsUserName:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          startupProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          stdin:
+                                            type: boolean
+                                          stdinOnce:
+                                            type: boolean
+                                          targetContainerName:
+                                            type: string
+                                          terminationMessagePath:
+                                            type: string
+                                          terminationMessagePolicy:
+                                            type: string
+                                          tty:
+                                            type: boolean
+                                          volumeDevices:
+                                            items:
+                                              properties:
+                                                devicePath:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              required:
+                                                - devicePath
+                                                - name
+                                              type: object
+                                            type: array
+                                          volumeMounts:
+                                            items:
+                                              properties:
+                                                mountPath:
+                                                  type: string
+                                                mountPropagation:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                subPath:
+                                                  type: string
+                                                subPathExpr:
+                                                  type: string
+                                              required:
+                                                - mountPath
+                                                - name
+                                              type: object
+                                            type: array
+                                          workingDir:
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
+                                      type: array
+                                    hostAliases:
+                                      items:
+                                        properties:
+                                          hostnames:
+                                            items:
+                                              type: string
+                                            type: array
+                                          ip:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    hostIPC:
+                                      type: boolean
+                                    hostNetwork:
+                                      type: boolean
+                                    hostPID:
+                                      type: boolean
+                                    hostname:
+                                      type: string
+                                    imagePullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    initContainers:
+                                      items:
+                                        properties:
+                                          args:
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                          env:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                                valueFrom:
+                                                  properties:
+                                                    configMapKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      required:
+                                                        - fieldPath
+                                                      type: object
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      required:
+                                                        - resource
+                                                      type: object
+                                                    secretKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                  type: object
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                          envFrom:
+                                            items:
+                                              properties:
+                                                configMapRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                prefix:
+                                                  type: string
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                              type: object
+                                            type: array
+                                          image:
+                                            type: string
+                                          imagePullPolicy:
+                                            type: string
+                                          lifecycle:
+                                            properties:
+                                              postStart:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                            - name
+                                                            - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                      - port
+                                                    type: object
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                      - port
+                                                    type: object
+                                                type: object
+                                              preStop:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                            - name
+                                                            - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                      - port
+                                                    type: object
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                      - port
+                                                    type: object
+                                                type: object
+                                            type: object
+                                          livenessProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          name:
+                                            type: string
+                                          ports:
+                                            items:
+                                              properties:
+                                                containerPort:
+                                                  format: int32
+                                                  type: integer
+                                                hostIP:
+                                                  type: string
+                                                hostPort:
+                                                  format: int32
+                                                  type: integer
+                                                name:
+                                                  type: string
+                                                protocol:
+                                                  default: TCP
+                                                  type: string
+                                              required:
+                                                - containerPort
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - containerPort
+                                              - protocol
+                                            x-kubernetes-list-type: map
+                                          readinessProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          resources:
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          securityContext:
+                                            properties:
+                                              allowPrivilegeEscalation:
+                                                type: boolean
+                                              capabilities:
+                                                properties:
+                                                  add:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  drop:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              privileged:
+                                                type: boolean
+                                              procMount:
+                                                type: string
+                                              readOnlyRootFilesystem:
+                                                type: boolean
+                                              runAsGroup:
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                type: boolean
+                                              runAsUser:
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                properties:
+                                                  level:
+                                                    type: string
+                                                  role:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                  user:
+                                                    type: string
+                                                type: object
+                                              windowsOptions:
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    type: string
+                                                  runAsUserName:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          startupProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          stdin:
+                                            type: boolean
+                                          stdinOnce:
+                                            type: boolean
+                                          terminationMessagePath:
+                                            type: string
+                                          terminationMessagePolicy:
+                                            type: string
+                                          tty:
+                                            type: boolean
+                                          volumeDevices:
+                                            items:
+                                              properties:
+                                                devicePath:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              required:
+                                                - devicePath
+                                                - name
+                                              type: object
+                                            type: array
+                                          volumeMounts:
+                                            items:
+                                              properties:
+                                                mountPath:
+                                                  type: string
+                                                mountPropagation:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                subPath:
+                                                  type: string
+                                                subPathExpr:
+                                                  type: string
+                                              required:
+                                                - mountPath
+                                                - name
+                                              type: object
+                                            type: array
+                                          workingDir:
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
+                                      type: array
+                                    nodeName:
+                                      type: string
+                                    nodeSelector:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    overhead:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    preemptionPolicy:
+                                      type: string
+                                    priority:
+                                      format: int32
+                                      type: integer
+                                    priorityClassName:
+                                      type: string
+                                    readinessGates:
+                                      items:
+                                        properties:
+                                          conditionType:
+                                            type: string
+                                        required:
+                                          - conditionType
+                                        type: object
+                                      type: array
+                                    restartPolicy:
+                                      type: string
+                                    runtimeClassName:
+                                      type: string
+                                    schedulerName:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        fsGroup:
+                                          format: int64
+                                          type: integer
+                                        fsGroupChangePolicy:
+                                          type: string
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        supplementalGroups:
+                                          items:
+                                            format: int64
+                                            type: integer
+                                          type: array
+                                        sysctls:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                              - name
+                                              - value
+                                            type: object
+                                          type: array
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    serviceAccount:
+                                      type: string
+                                    serviceAccountName:
+                                      type: string
+                                    shareProcessNamespace:
+                                      type: boolean
+                                    subdomain:
+                                      type: string
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    tolerations:
+                                      items:
+                                        properties:
+                                          effect:
+                                            type: string
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          tolerationSeconds:
+                                            format: int64
+                                            type: integer
+                                          value:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    topologySpreadConstraints:
+                                      items:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          maxSkew:
+                                            format: int32
+                                            type: integer
+                                          topologyKey:
+                                            type: string
+                                          whenUnsatisfiable:
+                                            type: string
+                                        required:
+                                          - maxSkew
+                                          - topologyKey
+                                          - whenUnsatisfiable
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - topologyKey
+                                        - whenUnsatisfiable
+                                      x-kubernetes-list-type: map
+                                    volumes:
+                                      items:
+                                        properties:
+                                          awsElasticBlockStore:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              partition:
+                                                format: int32
+                                                type: integer
+                                              readOnly:
+                                                type: boolean
+                                              volumeID:
+                                                type: string
+                                            required:
+                                              - volumeID
+                                            type: object
+                                          azureDisk:
+                                            properties:
+                                              cachingMode:
+                                                type: string
+                                              diskName:
+                                                type: string
+                                              diskURI:
+                                                type: string
+                                              fsType:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                            required:
+                                              - diskName
+                                              - diskURI
+                                            type: object
+                                          azureFile:
+                                            properties:
+                                              readOnly:
+                                                type: boolean
+                                              secretName:
+                                                type: string
+                                              shareName:
+                                                type: string
+                                            required:
+                                              - secretName
+                                              - shareName
+                                            type: object
+                                          cephfs:
+                                            properties:
+                                              monitors:
                                                 items:
                                                   type: string
                                                 type: array
+                                              path:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              secretFile:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              user:
+                                                type: string
                                             required:
-                                            - key
-                                            - operator
+                                              - monitors
                                             type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
+                                          cinder:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              volumeID:
+                                                type: string
+                                            required:
+                                              - volumeID
+                                            type: object
+                                          configMap:
+                                            properties:
+                                              defaultMode:
+                                                format: int32
+                                                type: integer
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    mode:
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                  type: object
+                                                type: array
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                          csi:
+                                            properties:
+                                              driver:
+                                                type: string
+                                              fsType:
+                                                type: string
+                                              nodePublishSecretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              readOnly:
+                                                type: boolean
+                                              volumeAttributes:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            required:
+                                              - driver
+                                            type: object
+                                          downwardAPI:
+                                            properties:
+                                              defaultMode:
+                                                format: int32
+                                                type: integer
+                                              items:
+                                                items:
+                                                  properties:
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      required:
+                                                        - fieldPath
+                                                      type: object
+                                                    mode:
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      required:
+                                                        - resource
+                                                      type: object
+                                                  required:
+                                                    - path
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          emptyDir:
+                                            properties:
+                                              medium:
+                                                type: string
+                                              sizeLimit:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          fc:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              lun:
+                                                format: int32
+                                                type: integer
+                                              readOnly:
+                                                type: boolean
+                                              targetWWNs:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              wwids:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          flexVolume:
+                                            properties:
+                                              driver:
+                                                type: string
+                                              fsType:
+                                                type: string
+                                              options:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              readOnly:
+                                                type: boolean
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                type: object
+                                            required:
+                                              - driver
+                                            type: object
+                                          flocker:
+                                            properties:
+                                              datasetName:
+                                                type: string
+                                              datasetUUID:
+                                                type: string
+                                            type: object
+                                          gcePersistentDisk:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              partition:
+                                                format: int32
+                                                type: integer
+                                              pdName:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                            required:
+                                              - pdName
+                                            type: object
+                                          gitRepo:
+                                            properties:
+                                              directory:
+                                                type: string
+                                              repository:
+                                                type: string
+                                              revision:
+                                                type: string
+                                            required:
+                                              - repository
+                                            type: object
+                                          glusterfs:
+                                            properties:
+                                              endpoints:
+                                                type: string
+                                              path:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                            required:
+                                              - endpoints
+                                              - path
+                                            type: object
+                                          hostPath:
+                                            properties:
+                                              path:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - path
+                                            type: object
+                                          iscsi:
+                                            properties:
+                                              chapAuthDiscovery:
+                                                type: boolean
+                                              chapAuthSession:
+                                                type: boolean
+                                              fsType:
+                                                type: string
+                                              initiatorName:
+                                                type: string
+                                              iqn:
+                                                type: string
+                                              iscsiInterface:
+                                                type: string
+                                              lun:
+                                                format: int32
+                                                type: integer
+                                              portals:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              readOnly:
+                                                type: boolean
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              targetPortal:
+                                                type: string
+                                            required:
+                                              - iqn
+                                              - lun
+                                              - targetPortal
+                                            type: object
+                                          name:
                                             type: string
-                                          type: object
-                                      type: object
-                                    storageClassName:
-                                      type: string
-                                    volumeMode:
-                                      type: string
-                                    volumeName:
-                                      type: string
+                                          nfs:
+                                            properties:
+                                              path:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              server:
+                                                type: string
+                                            required:
+                                              - path
+                                              - server
+                                            type: object
+                                          persistentVolumeClaim:
+                                            properties:
+                                              claimName:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                            required:
+                                              - claimName
+                                            type: object
+                                          photonPersistentDisk:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              pdID:
+                                                type: string
+                                            required:
+                                              - pdID
+                                            type: object
+                                          portworxVolume:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              volumeID:
+                                                type: string
+                                            required:
+                                              - volumeID
+                                            type: object
+                                          projected:
+                                            properties:
+                                              defaultMode:
+                                                format: int32
+                                                type: integer
+                                              sources:
+                                                items:
+                                                  properties:
+                                                    configMap:
+                                                      properties:
+                                                        items:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              mode:
+                                                                format: int32
+                                                                type: integer
+                                                              path:
+                                                                type: string
+                                                            required:
+                                                              - key
+                                                              - path
+                                                            type: object
+                                                          type: array
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    downwardAPI:
+                                                      properties:
+                                                        items:
+                                                          items:
+                                                            properties:
+                                                              fieldRef:
+                                                                properties:
+                                                                  apiVersion:
+                                                                    type: string
+                                                                  fieldPath:
+                                                                    type: string
+                                                                required:
+                                                                  - fieldPath
+                                                                type: object
+                                                              mode:
+                                                                format: int32
+                                                                type: integer
+                                                              path:
+                                                                type: string
+                                                              resourceFieldRef:
+                                                                properties:
+                                                                  containerName:
+                                                                    type: string
+                                                                  divisor:
+                                                                    anyOf:
+                                                                      - type: integer
+                                                                      - type: string
+                                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                    x-kubernetes-int-or-string: true
+                                                                  resource:
+                                                                    type: string
+                                                                required:
+                                                                  - resource
+                                                                type: object
+                                                            required:
+                                                              - path
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    secret:
+                                                      properties:
+                                                        items:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              mode:
+                                                                format: int32
+                                                                type: integer
+                                                              path:
+                                                                type: string
+                                                            required:
+                                                              - key
+                                                              - path
+                                                            type: object
+                                                          type: array
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    serviceAccountToken:
+                                                      properties:
+                                                        audience:
+                                                          type: string
+                                                        expirationSeconds:
+                                                          format: int64
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                      required:
+                                                        - path
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                            required:
+                                              - sources
+                                            type: object
+                                          quobyte:
+                                            properties:
+                                              group:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              registry:
+                                                type: string
+                                              tenant:
+                                                type: string
+                                              user:
+                                                type: string
+                                              volume:
+                                                type: string
+                                            required:
+                                              - registry
+                                              - volume
+                                            type: object
+                                          rbd:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              image:
+                                                type: string
+                                              keyring:
+                                                type: string
+                                              monitors:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              pool:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              user:
+                                                type: string
+                                            required:
+                                              - image
+                                              - monitors
+                                            type: object
+                                          scaleIO:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              gateway:
+                                                type: string
+                                              protectionDomain:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              sslEnabled:
+                                                type: boolean
+                                              storageMode:
+                                                type: string
+                                              storagePool:
+                                                type: string
+                                              system:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                              - gateway
+                                              - secretRef
+                                              - system
+                                            type: object
+                                          secret:
+                                            properties:
+                                              defaultMode:
+                                                format: int32
+                                                type: integer
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    mode:
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                  type: object
+                                                type: array
+                                              optional:
+                                                type: boolean
+                                              secretName:
+                                                type: string
+                                            type: object
+                                          storageos:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              volumeName:
+                                                type: string
+                                              volumeNamespace:
+                                                type: string
+                                            type: object
+                                          vsphereVolume:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              storagePolicyID:
+                                                type: string
+                                              storagePolicyName:
+                                                type: string
+                                              volumePath:
+                                                type: string
+                                            required:
+                                              - volumePath
+                                            type: object
+                                        required:
+                                          - name
+                                        type: object
+                                      type: array
+                                  required:
+                                    - containers
                                   type: object
                               type: object
-                            type: array
-                        type: object
-                    type: object
-                type: object
-              persistence:
-                default:
-                  storage: 10Gi
-                description: The settings for the persistent storage desired for each
-                  Pod in the RabbitmqCluster.
-                properties:
-                  storage:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    default: 10Gi
-                    description: The requested size of the persistent volume attached
-                      to each Pod in the RabbitmqCluster.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  storageClassName:
-                    description: StorageClassName is the name of the StorageClass
-                      to claim a PersistentVolume from.
-                    type: string
-                type: object
-              rabbitmq:
-                description: Rabbitmq related configurations
-                properties:
-                  additionalConfig:
-                    description: Modify to add to the rabbitmq.conf file in addition
-                      to default configurations set by the operator. Modifying this
-                      property on an existing RabbitmqCluster will trigger a StatefulSet
-                      rolling restart and will cause rabbitmq downtime.
-                    maxLength: 2000
-                    type: string
-                  additionalPlugins:
-                    description: 'List of plugins to enable in addition to essential
-                      plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s.'
-                    items:
-                      description: kubebuilder validating tags 'Pattern' and 'MaxLength'
-                        must be specified on string type. Alias type 'string' as 'Plugin'
-                        to specify schema validation on items of the list 'AdditionalPlugins'
-                      maxLength: 100
-                      pattern: ^\w+$
-                      type: string
-                    maxItems: 100
-                    type: array
-                  advancedConfig:
-                    description: Specify any rabbitmq advanced.config configurations
-                    maxLength: 100000
-                    type: string
-                  envConfig:
-                    description: Modify to add to the rabbitmq-env.conf file. Modifying
-                      this property on an existing RabbitmqCluster will trigger a
-                      StatefulSet rolling restart and will cause rabbitmq downtime.
-                    maxLength: 100000
-                    type: string
-                type: object
-              replicas:
-                default: 1
-                description: Replicas is the number of nodes in the RabbitMQ cluster.
-                  Each node is deployed as a Replica in a StatefulSet. Only 1, 3,
-                  5 replicas clusters are tested.
-                format: int32
-                minimum: 0
-                type: integer
-              resources:
-                default:
-                  limits:
-                    cpu: 2000m
-                    memory: 2Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 2Gi
-                description: ResourceRequirements describes the compute resource requirements.
-                properties:
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                type: object
-              service:
-                default:
-                  type: ClusterIP
-                description: Settable attributes for the Service resource.
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    description: Annotations to add to the Service.
-                    type: object
-                  type:
-                    default: ClusterIP
-                    description: Service Type string describes ingress methods for
-                      a service
-                    enum:
-                    - ClusterIP
-                    - LoadBalancer
-                    - NodePort
-                    type: string
-                type: object
-              skipPostDeploySteps:
-                description: If unset, or set to false, the cluster will run `rabbitmq-queues
-                  rebalance all` whenever the cluster is updated. Has no effect if
-                  the cluster only consists of one node. For more information, see
-                  https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
-                type: boolean
-              terminationGracePeriodSeconds:
-                default: 604800
-                description: 'TerminationGracePeriodSeconds is the timeout that each
-                  rabbitmqcluster pod will have to terminate gracefully. It defaults
-                  to 604800 seconds ( a week long) to ensure that the container preStop
-                  lifecycle hook can finish running. For more information, see: https://github.com/rabbitmq/cluster-operator/blob/main/docs/design/20200520-graceful-pod-termination.md'
-                format: int64
-                minimum: 0
-                type: integer
-              tls:
-                properties:
-                  caSecretName:
-                    description: Name of a Secret in the same Namespace as the RabbitmqCluster,
-                      containing the Certificate Authority's public certificate for
-                      TLS. The Secret must store this as ca.crt. Used for mTLS, and
-                      TLS for rabbitmq_web_stomp and rabbitmq_web_mqtt.
-                    type: string
-                  secretName:
-                    description: Name of a Secret in the same Namespace as the RabbitmqCluster,
-                      containing the server's private key & public certificate for
-                      TLS. The Secret must store these as tls.key and tls.crt, respectively.
-                    type: string
-                type: object
-              tolerations:
-                description: Tolerations is the list of Toleration resources attached
-                  to each Pod in the RabbitmqCluster.
-                items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
+                            updateStrategy:
+                              properties:
+                                rollingUpdate:
+                                  properties:
+                                    partition:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                type:
+                                  type: string
+                              type: object
+                            volumeClaimTemplates:
+                              items:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  metadata:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    type: object
+                                  spec:
+                                    properties:
+                                      accessModes:
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        properties:
+                                          apiGroup:
+                                            type: string
+                                          kind:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      selector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      storageClassName:
+                                        type: string
+                                      volumeMode:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                persistence:
+                  default:
+                    storage: 10Gi
+                  description: The settings for the persistent storage desired for each Pod in the RabbitmqCluster.
                   properties:
-                    effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
-                      type: string
-                    key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
-                      type: string
-                    operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
-                      type: string
-                    tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
-                      format: int64
-                      type: integer
-                    value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
+                    storage:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      default: 10Gi
+                      description: The requested size of the persistent volume attached to each Pod in the RabbitmqCluster.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    storageClassName:
+                      description: StorageClassName is the name of the StorageClass to claim a PersistentVolume from.
                       type: string
                   type: object
-                type: array
-            type: object
-          status:
-            description: Status presents the observed state of RabbitmqCluster
-            properties:
-              clusterStatus:
-                type: string
-              conditions:
-                description: Set of Conditions describing the current state of the
-                  RabbitmqCluster
-                items:
+                rabbitmq:
+                  description: Rabbitmq related configurations
                   properties:
-                    lastTransitionTime:
-                      description: The last time this Condition type changed.
-                      format: date-time
+                    additionalConfig:
+                      description: Modify to add to the rabbitmq.conf file in addition to default configurations set by the operator. Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime.
+                      maxLength: 2000
                       type: string
-                    message:
-                      description: Full text reason for current status of the condition.
+                    additionalPlugins:
+                      description: 'List of plugins to enable in addition to essential plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s.'
+                      items:
+                        description: kubebuilder validating tags 'Pattern' and 'MaxLength' must be specified on string type. Alias type 'string' as 'Plugin' to specify schema validation on items of the list 'AdditionalPlugins'
+                        maxLength: 100
+                        pattern: ^\w+$
+                        type: string
+                      maxItems: 100
+                      type: array
+                    advancedConfig:
+                      description: Specify any rabbitmq advanced.config configurations
+                      maxLength: 100000
                       type: string
-                    reason:
-                      description: One word, camel-case reason for current status
-                        of the condition.
+                    envConfig:
+                      description: Modify to add to the rabbitmq-env.conf file. Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime.
+                      maxLength: 100000
                       type: string
-                    status:
-                      description: True, False, or Unknown
-                      type: string
+                  type: object
+                replicas:
+                  default: 1
+                  description: Replicas is the number of nodes in the RabbitMQ cluster. Each node is deployed as a Replica in a StatefulSet. Only 1, 3, 5 replicas clusters are tested.
+                  format: int32
+                  minimum: 0
+                  type: integer
+                resources:
+                  default:
+                    limits:
+                      cpu: 2000m
+                      memory: 2Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 2Gi
+                  description: ResourceRequirements describes the compute resource requirements.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                service:
+                  default:
+                    type: ClusterIP
+                  description: Settable attributes for the Service resource.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations to add to the Service.
+                      type: object
                     type:
-                      description: Type indicates the scope of RabbitmqCluster status
-                        addressed by the condition.
+                      default: ClusterIP
+                      description: Service Type string describes ingress methods for a service
+                      enum:
+                        - ClusterIP
+                        - LoadBalancer
+                        - NodePort
                       type: string
-                  required:
-                  - status
-                  - type
                   type: object
-                type: array
-              defaultUser:
-                description: Identifying information on internal resources
-                properties:
-                  secretReference:
+                skipPostDeploySteps:
+                  description: If unset, or set to false, the cluster will run `rabbitmq-queues rebalance all` whenever the cluster is updated. Has no effect if the cluster only consists of one node. For more information, see https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
+                  type: boolean
+                terminationGracePeriodSeconds:
+                  default: 604800
+                  description: 'TerminationGracePeriodSeconds is the timeout that each rabbitmqcluster pod will have to terminate gracefully. It defaults to 604800 seconds ( a week long) to ensure that the container preStop lifecycle hook can finish running. For more information, see: https://github.com/rabbitmq/cluster-operator/blob/main/docs/design/20200520-graceful-pod-termination.md'
+                  format: int64
+                  minimum: 0
+                  type: integer
+                tls:
+                  properties:
+                    caSecretName:
+                      description: Name of a Secret in the same Namespace as the RabbitmqCluster, containing the Certificate Authority's public certificate for TLS. The Secret must store this as ca.crt. Used for mTLS, and TLS for rabbitmq_web_stomp and rabbitmq_web_mqtt.
+                      type: string
+                    disableNonTLSListeners:
+                      description: 'When set to true, the RabbitmqCluster disables non-TLS listeners for RabbitMQ and for any enabled plugins in the following list: stomp, mqtt, web_stomp, web_mqtt. Only TLS-enabled clients will be able to connect.'
+                      type: boolean
+                    secretName:
+                      description: Name of a Secret in the same Namespace as the RabbitmqCluster, containing the server's private key & public certificate for TLS. The Secret must store these as tls.key and tls.crt, respectively.
+                      type: string
+                  type: object
+                tolerations:
+                  description: Tolerations is the list of Toleration resources attached to each Pod in the RabbitmqCluster.
+                  items:
+                    description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                     properties:
-                      keys:
-                        additionalProperties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: Status presents the observed state of RabbitmqCluster
+              properties:
+                clusterStatus:
+                  type: string
+                conditions:
+                  description: Set of Conditions describing the current state of the RabbitmqCluster
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: The last time this Condition type changed.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Full text reason for current status of the condition.
+                        type: string
+                      reason:
+                        description: One word, camel-case reason for current status of the condition.
+                        type: string
+                      status:
+                        description: True, False, or Unknown
+                        type: string
+                      type:
+                        description: Type indicates the scope of RabbitmqCluster status addressed by the condition.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                defaultUser:
+                  description: Identifying information on internal resources
+                  properties:
+                    secretReference:
+                      properties:
+                        keys:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
                           type: string
-                        type: object
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - keys
-                    - name
-                    - namespace
-                    type: object
-                  serviceReference:
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    - namespace
-                    type: object
-                type: object
-            required:
-            - conditions
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                        namespace:
+                          type: string
+                      required:
+                        - keys
+                        - name
+                        - namespace
+                      type: object
+                    serviceReference:
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
+                  type: object
+              required:
+                - conditions
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -106,11 +106,8 @@ func (r *RabbitmqClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 		return ctrl.Result{}, err
 	}
 
-	// TLS: check if specified, and if secret exists
-	if rabbitmqCluster.TLSEnabled() {
-		if result, err := r.checkTLSSecrets(ctx, rabbitmqCluster); err != nil {
-			return result, err
-		}
+	if err := r.reconcileTLS(ctx, rabbitmqCluster); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	childResources, err := r.getChildResources(ctx, *rabbitmqCluster)

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -1067,7 +1067,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 					TargetPort: amqpTargetPort,
 				},
 				corev1.ServicePort{
-					Name:       "http",
+					Name:       "management",
 					Port:       15672,
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: managementTargetPort,

--- a/controllers/reconcile_tls.go
+++ b/controllers/reconcile_tls.go
@@ -8,10 +8,25 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (r *RabbitmqClusterReconciler) checkTLSSecrets(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) (ctrl.Result, error) {
+func (r *RabbitmqClusterReconciler) reconcileTLS(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
+	if rabbitmqCluster.DisableNonTLSListeners() && !rabbitmqCluster.TLSEnabled() {
+		err := errors.NewBadRequest("TLS must be enabled if disableNonTLSListeners is set to true")
+		r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError", err.Error())
+		r.Log.Error(err, "Error setting up TLS", "namespace", rabbitmqCluster.Namespace, "name", rabbitmqCluster.Name)
+		return err
+	}
+
+	if rabbitmqCluster.TLSEnabled() {
+		if err := r.checkTLSSecrets(ctx, rabbitmqCluster); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *RabbitmqClusterReconciler) checkTLSSecrets(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
 	secretName := rabbitmqCluster.Spec.TLS.SecretName
 	r.Log.Info("TLS enabled, looking for secret", "secret", secretName, "namespace", rabbitmqCluster.Namespace)
 
@@ -21,7 +36,7 @@ func (r *RabbitmqClusterReconciler) checkTLSSecrets(ctx context.Context, rabbitm
 		r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError",
 			fmt.Sprintf("Failed to get TLS secret %s in namespace %s: %v", secretName, rabbitmqCluster.Namespace, err.Error()))
 		r.Log.Error(err, "Error setting up TLS", "namespace", rabbitmqCluster.Namespace, "name", rabbitmqCluster.Name)
-		return ctrl.Result{}, err
+		return err
 	}
 	// check if secret has the right keys
 	_, hasTLSKey := secret.Data["tls.key"]
@@ -30,7 +45,7 @@ func (r *RabbitmqClusterReconciler) checkTLSSecrets(ctx context.Context, rabbitm
 		err := errors.NewBadRequest(fmt.Sprintf("TLS secret %s in namespace %s does not have the fields tls.crt and tls.key", secretName, rabbitmqCluster.Namespace))
 		r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError", err.Error())
 		r.Log.Error(err, "Error setting up TLS", "namespace", rabbitmqCluster.Namespace, "name", rabbitmqCluster.Name)
-		return ctrl.Result{}, err
+		return err
 	}
 
 	// Mutual TLS: check if CA certificate is stored in a separate secret
@@ -45,7 +60,7 @@ func (r *RabbitmqClusterReconciler) checkTLSSecrets(ctx context.Context, rabbitm
 				r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError",
 					fmt.Sprintf("Failed to get CA certificate secret %v in namespace %v: %v", secretName, rabbitmqCluster.Namespace, err.Error()))
 				r.Log.Error(err, "Error setting up TLS", "namespace", rabbitmqCluster.Namespace, "name", rabbitmqCluster.Name)
-				return ctrl.Result{}, err
+				return err
 			}
 		}
 
@@ -54,8 +69,8 @@ func (r *RabbitmqClusterReconciler) checkTLSSecrets(ctx context.Context, rabbitm
 			err := errors.NewBadRequest(fmt.Sprintf("TLS secret %s in namespace %s does not have the field ca.crt", rabbitmqCluster.Spec.TLS.CaSecretName, rabbitmqCluster.Namespace))
 			r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError", err.Error())
 			r.Log.Error(err, "Error setting up TLS", "namespace", rabbitmqCluster.Namespace, "name", rabbitmqCluster.Name)
-			return ctrl.Result{}, err
+			return err
 		}
 	}
-	return ctrl.Result{}, nil
+	return nil
 }

--- a/controllers/reconcile_tls_test.go
+++ b/controllers/reconcile_tls_test.go
@@ -201,6 +201,20 @@ var _ = Describe("Reconcile TLS", func() {
 			})
 		})
 	})
+
+	When("DiableNonTLSListeners set to true", func() {
+		It("errors and logs TLSError when TLS is not enabled", func() {
+			tlsSpec := rabbitmqv1beta1.TLSSpec{
+				DisableNonTLSListeners: true,
+			}
+			cluster = rabbitmqClusterWithTLS(ctx, "rabbitmq-disablenontlslisteners", defaultNamespace, tlsSpec)
+
+			verifyTLSErrorEvents(ctx, cluster, "TLS must be enabled if disableNonTLSListeners is set to true")
+
+			_, err := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, cluster.ChildResourceName("server"), metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })
 
 func tlsSecretWithCACert(ctx context.Context, secretName, namespace string) {

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -89,14 +89,29 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 		if err := cfg.Append([]byte(defaultTLSConf)); err != nil {
 			return err
 		}
+		if builder.Instance.DisableNonTLSListeners() {
+			if _, err := defaultSection.NewKey("listeners.tcp", "none"); err != nil {
+				return err
+			}
+		}
 		if builder.Instance.AdditionalPluginEnabled("rabbitmq_mqtt") {
 			if _, err := defaultSection.NewKey("mqtt.listeners.ssl.default", "8883"); err != nil {
 				return err
+			}
+			if builder.Instance.DisableNonTLSListeners() {
+				if _, err := defaultSection.NewKey("mqtt.listeners.tcp", "none"); err != nil {
+					return err
+				}
 			}
 		}
 		if builder.Instance.AdditionalPluginEnabled("rabbitmq_stomp") {
 			if _, err := defaultSection.NewKey("stomp.listeners.ssl.1", "61614"); err != nil {
 				return err
+			}
+			if builder.Instance.DisableNonTLSListeners() {
+				if _, err := defaultSection.NewKey("stomp.listeners.tcp", "none"); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -125,6 +140,11 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 			if _, err := defaultSection.NewKey("web_mqtt.ssl.keyfile", tlsKeyPath); err != nil {
 				return err
 			}
+			if builder.Instance.DisableNonTLSListeners() {
+				if _, err := defaultSection.NewKey("web_mqtt.tcp.listener", "none"); err != nil {
+					return err
+				}
+			}
 		}
 		if builder.Instance.AdditionalPluginEnabled("rabbitmq_web_stomp") {
 			if _, err := defaultSection.NewKey("web_stomp.ssl.port", "15673"); err != nil {
@@ -138,6 +158,11 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 			}
 			if _, err := defaultSection.NewKey("web_stomp.ssl.keyfile", tlsKeyPath); err != nil {
 				return err
+			}
+			if builder.Instance.DisableNonTLSListeners() {
+				if _, err := defaultSection.NewKey("web_stomp.tcp.listener", "none"); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/internal/resource/service.go
+++ b/internal/resource/service.go
@@ -117,11 +117,11 @@ func (builder *ServiceBuilder) updatePorts(servicePorts []corev1.ServicePort) []
 			TargetPort: intstr.FromInt(5672),
 			Name:       "amqp",
 		},
-		"http": {
+		"management": {
 			Protocol:   corev1.ProtocolTCP,
 			Port:       15672,
 			TargetPort: intstr.FromInt(15672),
-			Name:       "http",
+			Name:       "management",
 		},
 	}
 	if builder.Instance.AdditionalPluginEnabled("rabbitmq_mqtt") {

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -72,27 +72,24 @@ var _ = Context("Services", func() {
 		})
 
 		Context("TLS", func() {
-			It("opens ports for amqps and management-tls on the service", func() {
-				instance := &rabbitmqv1beta1.RabbitmqCluster{
-					ObjectMeta: v1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "foo-namespace",
-					},
-					Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-						TLS: rabbitmqv1beta1.TLSSpec{
-							SecretName: "tls-secret",
-						},
-					},
-				}
-				builder.Instance = instance
-				serviceBuilder := builder.Service()
-				svc := &corev1.Service{
+			var (
+				svc            *corev1.Service
+				serviceBuilder *resource.ServiceBuilder
+			)
+			BeforeEach(func() {
+				svc = &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo-service",
 						Namespace: "foo-namespace",
 					},
 				}
-
+				serviceBuilder = builder.Service()
+				instance = generateRabbitmqCluster()
+				instance.Spec.TLS = rabbitmqv1beta1.TLSSpec{
+					SecretName: "tls-secret",
+				}
+			})
+			It("opens ports for amqps and management-tls on the service", func() {
 				Expect(serviceBuilder.Update(svc)).To(Succeed())
 				Expect(svc.Spec.Ports).Should(ContainElements([]corev1.ServicePort{
 					{
@@ -112,29 +109,7 @@ var _ = Context("Services", func() {
 
 			When("mqtt and stomp are enabled", func() {
 				It("opens ports for those plugins", func() {
-					instance := &rabbitmqv1beta1.RabbitmqCluster{
-						ObjectMeta: v1.ObjectMeta{
-							Name:      "foo",
-							Namespace: "foo-namespace",
-						},
-						Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-							TLS: rabbitmqv1beta1.TLSSpec{
-								SecretName: "tls-secret",
-							},
-							Rabbitmq: rabbitmqv1beta1.RabbitmqClusterConfigurationSpec{
-								AdditionalPlugins: []rabbitmqv1beta1.Plugin{"rabbitmq_mqtt", "rabbitmq_stomp"},
-							},
-						},
-					}
-					builder.Instance = instance
-					serviceBuilder := builder.Service()
-					svc := &corev1.Service{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "foo-service",
-							Namespace: "foo-namespace",
-						},
-					}
-
+					instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_mqtt", "rabbitmq_stomp"}
 					Expect(serviceBuilder.Update(svc)).To(Succeed())
 					Expect(svc.Spec.Ports).Should(ContainElements([]corev1.ServicePort{
 						{
@@ -155,30 +130,8 @@ var _ = Context("Services", func() {
 
 			When("rabbitmq_web_mqtt and rabbitmq_web_stomp are enabled", func() {
 				It("opens ports for those plugins", func() {
-					instance := &rabbitmqv1beta1.RabbitmqCluster{
-						ObjectMeta: v1.ObjectMeta{
-							Name:      "foo",
-							Namespace: "foo-namespace",
-						},
-						Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-							TLS: rabbitmqv1beta1.TLSSpec{
-								SecretName:   "tls-secret",
-								CaSecretName: "ca-secret",
-							},
-							Rabbitmq: rabbitmqv1beta1.RabbitmqClusterConfigurationSpec{
-								AdditionalPlugins: []rabbitmqv1beta1.Plugin{"rabbitmq_web_mqtt", "rabbitmq_web_stomp"},
-							},
-						},
-					}
-					builder.Instance = instance
-					serviceBuilder := builder.Service()
-					svc := &corev1.Service{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "foo-service",
-							Namespace: "foo-namespace",
-						},
-					}
-
+					instance.Spec.TLS.CaSecretName = "caname"
+					instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_web_mqtt", "rabbitmq_web_stomp"}
 					Expect(serviceBuilder.Update(svc)).To(Succeed())
 					Expect(svc.Spec.Ports).Should(ContainElements([]corev1.ServicePort{
 						{
@@ -195,6 +148,60 @@ var _ = Context("Services", func() {
 						},
 					}))
 				})
+			})
+
+			When("DisableNonTLSListeners is set to true", func() {
+				It("only exposes tls ports in the service", func() {
+					instance.Spec.TLS.DisableNonTLSListeners = true
+					Expect(serviceBuilder.Update(svc)).To(Succeed())
+					Expect(svc.Spec.Ports).Should(ConsistOf([]corev1.ServicePort{
+						{
+							Name:       "amqps",
+							Protocol:   corev1.ProtocolTCP,
+							Port:       5671,
+							TargetPort: intstr.FromInt(5671),
+						},
+						{
+							Name:       "management-tls",
+							Protocol:   corev1.ProtocolTCP,
+							Port:       15671,
+							TargetPort: intstr.FromInt(15671),
+						},
+					}))
+				})
+				DescribeTable("only exposes tls ports in the service for enabled plugins",
+					func(plugin, servicePortName string, port int) {
+						instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{rabbitmqv1beta1.Plugin(plugin)}
+						instance.Spec.TLS.DisableNonTLSListeners = true
+						instance.Spec.TLS.CaSecretName = "somecacertname"
+						Expect(serviceBuilder.Update(svc)).To(Succeed())
+						amqpsPort := corev1.ServicePort{
+
+							Name:       "amqps",
+							Protocol:   corev1.ProtocolTCP,
+							Port:       5671,
+							TargetPort: intstr.FromInt(5671),
+						}
+						managementTLSPort := corev1.ServicePort{
+
+							Name:       "management-tls",
+							Protocol:   corev1.ProtocolTCP,
+							Port:       15671,
+							TargetPort: intstr.FromInt(15671),
+						}
+						expectedPort := corev1.ServicePort{
+							Name:       servicePortName,
+							Port:       int32(port),
+							TargetPort: intstr.FromInt(port),
+							Protocol:   corev1.ProtocolTCP,
+						}
+						Expect(svc.Spec.Ports).To(ConsistOf(amqpsPort, managementTLSPort, expectedPort))
+					},
+					Entry("MQTT", "rabbitmq_mqtt", "mqtts", 8883),
+					Entry("MQTT-over-WebSockets", "rabbitmq_web_mqtt", "web-mqtt-tls", 15676),
+					Entry("STOMP", "rabbitmq_stomp", "stomps", 61614),
+					Entry("STOMP-over-WebSockets", "rabbitmq_web_stomp", "web-stomp-tls", 15673),
+				)
 			})
 		})
 

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -393,13 +393,13 @@ var _ = Context("Services", func() {
 					TargetPort: intstr.FromInt(5672),
 					Protocol:   corev1.ProtocolTCP,
 				}
-				httpPort := corev1.ServicePort{
-					Name:       "http",
+				managementPort := corev1.ServicePort{
+					Name:       "management",
 					Port:       15672,
 					TargetPort: intstr.FromInt(15672),
 					Protocol:   corev1.ProtocolTCP,
 				}
-				Expect(svc.Spec.Ports).To(ConsistOf(amqpPort, httpPort))
+				Expect(svc.Spec.Ports).To(ConsistOf(amqpPort, managementPort))
 			})
 
 			DescribeTable("plugins exposing ports",
@@ -444,7 +444,7 @@ var _ = Context("Services", func() {
 					{
 						Protocol:   corev1.ProtocolTCP,
 						Port:       15672,
-						Name:       "http",
+						Name:       "management",
 						TargetPort: intstr.FromInt(15672),
 						NodePort:   1234,
 					},
@@ -461,16 +461,16 @@ var _ = Context("Services", func() {
 					TargetPort: intstr.FromInt(5672),
 					NodePort:   12345,
 				}
-				expectedHTTPServicePort := corev1.ServicePort{
+				expectedManagementServicePort := corev1.ServicePort{
 					Protocol:   corev1.ProtocolTCP,
 					Port:       15672,
-					Name:       "http",
+					Name:       "management",
 					TargetPort: intstr.FromInt(15672),
 					NodePort:   1234,
 				}
 
 				Expect(svc.Spec.Ports).To(ContainElement(expectedAmqpServicePort))
-				Expect(svc.Spec.Ports).To(ContainElement(expectedHTTPServicePort))
+				Expect(svc.Spec.Ports).To(ContainElement(expectedManagementServicePort))
 			})
 
 			It("unsets nodePort after updating from NodePort to ClusterIP", func() {
@@ -614,7 +614,7 @@ var _ = Context("Services", func() {
 						Protocol:   corev1.ProtocolTCP,
 					},
 					corev1.ServicePort{
-						Name:       "http",
+						Name:       "management",
 						Port:       15672,
 						TargetPort: intstr.FromInt(15672),
 						Protocol:   corev1.ProtocolTCP,

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -19,7 +19,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"gopkg.in/ini.v1"
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -178,15 +177,7 @@ cluster_keepalive_interval = 10000`
 				waitForRabbitmqUpdate(cluster)
 
 				// verify that rabbitmq.conf contains provided configurations
-				output, err := kubectlExec(namespace,
-					statefulSetPodName(cluster, 0),
-					"cat",
-					"/etc/rabbitmq/rabbitmq.conf",
-				)
-				Expect(err).NotTo(HaveOccurred())
-				cfg, err := ini.Load(output)
-				Expect(err).NotTo(HaveOccurred())
-				cfgMap := cfg.Section("").KeysHash()
+				cfgMap := getConfigFileFromPod(namespace, cluster, "/etc/rabbitmq/rabbitmq.conf")
 				Expect(cfgMap).To(HaveKeyWithValue("vm_memory_high_watermark_paging_ratio", "0.5"))
 				Expect(cfgMap).To(HaveKeyWithValue("cluster_keepalive_interval", "10000"))
 				Expect(cfgMap).To(HaveKeyWithValue("cluster_partition_handling", "ignore"))
@@ -321,7 +312,7 @@ CONSOLE_LOG=new`
 	})
 
 	Context("TLS", func() {
-		When("TLS is correctly configured", func() {
+		When("TLS is correctly configured and enforced", func() {
 			var (
 				cluster               *rabbitmqv1beta1.RabbitmqCluster
 				hostname              string
@@ -350,6 +341,7 @@ CONSOLE_LOG=new`
 				// Update RabbitmqCluster with TLS secret name
 				Expect(updateRabbitmqCluster(ctx, rmqClusterClient, cluster.Name, cluster.Namespace, func(cluster *rabbitmqv1beta1.RabbitmqCluster) {
 					cluster.Spec.TLS.SecretName = "rabbitmq-tls-test-secret"
+					cluster.Spec.TLS.DisableNonTLSListeners = true
 				})).To(Succeed())
 				waitForRabbitmqUpdate(cluster)
 			})
@@ -414,6 +406,24 @@ CONSOLE_LOG=new`
 					username, password, err = getUsernameAndPassword(ctx, clientSet, "rabbitmq-system", "tls-test-rabbit")
 					Expect(err).NotTo(HaveOccurred())
 					publishAndConsumeSTOMPMsg(hostname, rabbitmqNodePort(ctx, clientSet, cluster, "stomps"), username, password, cfg)
+				})
+
+				By("disabling non TLS listeners", func() {
+					// verify that rabbitmq.conf contains listeners.tcp = none
+					cfgMap := getConfigFileFromPod(namespace, cluster, "/etc/rabbitmq/rabbitmq.conf")
+					Expect(cfgMap).To(HaveKeyWithValue("listeners.tcp", "none"))
+					Expect(cfgMap).To(HaveKeyWithValue("stomp.listeners.tcp", "none"))
+					Expect(cfgMap).To(HaveKeyWithValue("mqtt.listeners.tcp", "none"))
+
+					// verify that only tls ports are exposed in service
+					service, err := clientSet.CoreV1().Services(cluster.Namespace).Get(ctx, cluster.ChildResourceName(""), metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					ports := service.Spec.Ports
+					Expect(ports).To(HaveLen(4))
+					Expect(containsPort(ports, "amqps")).To(BeTrue())
+					Expect(containsPort(ports, "management-tls")).To(BeTrue())
+					Expect(containsPort(ports, "mqtts")).To(BeTrue())
+					Expect(containsPort(ports, "stomps")).To(BeTrue())
 				})
 			})
 		})

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -49,7 +49,7 @@ var _ = Describe("Operator", func() {
 			waitForRabbitmqRunning(cluster)
 
 			hostname = kubernetesNodeIp(ctx, clientSet)
-			port = rabbitmqNodePort(ctx, clientSet, cluster, "http")
+			port = rabbitmqNodePort(ctx, clientSet, cluster, "management")
 
 			var err error
 			username, password, err = getUsernameAndPassword(ctx, clientSet, cluster.Namespace, cluster.Name)
@@ -249,7 +249,7 @@ CONSOLE_LOG=new`
 			waitForRabbitmqRunning(cluster)
 
 			hostname = kubernetesNodeIp(ctx, clientSet)
-			port = rabbitmqNodePort(ctx, clientSet, cluster, "http")
+			port = rabbitmqNodePort(ctx, clientSet, cluster, "management")
 
 			var err error
 			username, password, err = getUsernameAndPassword(ctx, clientSet, cluster.Namespace, cluster.Name)
@@ -309,7 +309,7 @@ CONSOLE_LOG=new`
 			It("works", func() {
 				username, password, err := getUsernameAndPassword(ctx, clientSet, cluster.Namespace, cluster.Name)
 				hostname := kubernetesNodeIp(ctx, clientSet)
-				port := rabbitmqNodePort(ctx, clientSet, cluster, "http")
+				port := rabbitmqNodePort(ctx, clientSet, cluster, "management")
 				Expect(err).NotTo(HaveOccurred())
 				assertHttpReady(hostname, port)
 


### PR DESCRIPTION
This closes #459 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Add `spec.tls.disableNonTLSListeners` property, when set to true, the operator disables non TLS listeners in given RabbitmqCluster
- ` spec.tls.disableNonTLSListeners` also means tcp readiness probe would use port `amqps` instead of `amqp`
- The property can only configure to true if TLS is enabled, or else there will be errors logged and published to events
- when ` spec.tls.disableNonTLSListeners` set to true, the epmd 4369 and the prometheus 15692 ports remains open on the container level for clustering and for prometheus scraping (neither of them are exposed in the outfacing service object)
- tcp listeners disabled for any enabled plugins as well by setting plugins specific tcp config:

```
mqtt.listeners.tcp   = none
stomp.listeners.tcp   = none
rabbitmq_web_mqtt.tcp_config = none
rabbitmq_web_stomp.tcp_config = none
```

- extracted func `reconcileTLS()`

## Additional Context

Some additional refactoring in system tests when asserting content of `rabbitmq.conf` using `kubectl` and ini library.

## Local Testing
