### PR TITLE
Fix mnesia permissions in PV

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -509,7 +509,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 							"&& chmod 600 /var/lib/rabbitmq/.erlang.cookie ; " +
 							"cp /tmp/rabbitmq-plugins/enabled_plugins /operator/enabled_plugins " +
 							"&& chown 999:999 /operator/enabled_plugins ; " +
-							"chgrp 999 /var/lib/rabbitmq/mnesia/ ; " +
+							"chown 999:999 /var/lib/rabbitmq/mnesia/ ; " +
 							"echo '[default]' > /var/lib/rabbitmq/.rabbitmqadmin.conf " +
 							"&& sed -e 's/default_user/username/' -e 's/default_pass/password/' /tmp/default_user.conf >> /var/lib/rabbitmq/.rabbitmqadmin.conf " +
 							"&& chown 999:999 /var/lib/rabbitmq/.rabbitmqadmin.conf " +

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1088,7 +1088,7 @@ var _ = Describe("StatefulSet", func() {
 						"&& chmod 600 /var/lib/rabbitmq/.erlang.cookie ; "+
 						"cp /tmp/rabbitmq-plugins/enabled_plugins /operator/enabled_plugins "+
 						"&& chown 999:999 /operator/enabled_plugins ; "+
-						"chgrp 999 /var/lib/rabbitmq/mnesia/ ; "+
+						"chown 999:999 /var/lib/rabbitmq/mnesia/ ; "+
 						"echo '[default]' > /var/lib/rabbitmq/.rabbitmqadmin.conf "+
 						"&& sed -e 's/default_user/username/' -e 's/default_pass/password/' /tmp/default_user.conf >> /var/lib/rabbitmq/.rabbitmqadmin.conf "+
 						"&& chown 999:999 /var/lib/rabbitmq/.rabbitmqadmin.conf "+


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
Sets the UID on /var/lib/rabbitmq/mnesia/

## Additional Context
Clusters fail to start on Rancher 2.5.2 Kubernetes 1.19.3 using vSphere CSI with the following error:
```
Configuring logger redirection

18:25:52.996 [warning] Failed to write PID file "/var/lib/rabbitmq/mnesia/rabbit@hello-world-server-0.hello-world-nodes.default.pid": permission denied
18:25:53.316 [error] Failed to create Ra data directory at '/var/lib/rabbitmq/mnesia/rabbit@hello-world-server-0.hello-world-nodes.default/quorum/rabbit@hello-world-server-0.hello-world-nodes.default', file system operation error: enoent
18:25:53.317 [error] Supervisor ra_sup had child ra_system_sup started with ra_system_sup:start_link() at undefined exit with reason {error,"Ra could not create its data directory. See the log for details."} in context start_error
18:25:53.317 [error] CRASH REPORT Process <0.247.0> with 0 neighbours exited with reason: {error,"Ra could not create its data directory. See the log for details."} in ra_system_sup:init/1 line 43
18:25:53.318 [error] CRASH REPORT Process <0.241.0> with 0 neighbours exited with reason: {{shutdown,{failed_to_start_child,ra_system_sup,{error,"Ra could not create its data directory. See the log for details."}}},{ra_app,start,[normal,[]]}} in application_master:init/4 line 138
{"Kernel pid terminated",application_controller,"{application_start_failure,ra,{{shutdown,{failed_to_start_child,ra_system_sup,{error,\"Ra could not create its data directory. See the log for details.\"}}},{ra_app,start,[normal,[]]}}}"}

Kernel pid terminated (application_controller) ({application_start_failure,ra,{{shutdown,{failed_to_start_child,ra_system_sup,{error,"Ra could not create its data directory. See the log for details."}

Crash dump is being written to: erl_crash.dump...
```

Setting the UID allows the pod to write to the PV

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
