### PR TITLE
Fix topologySpreadConstraints labelSelector

### DIFF
--- a/docs/examples/production-ready/rabbitmq.yaml
+++ b/docs/examples/production-ready/rabbitmq.yaml
@@ -31,4 +31,4 @@ spec:
               whenUnsatisfiable: DoNotSchedule
               labelSelector:
                 matchLabels:
-                  app.kubernetes.io/component: rabbitmq
+                  app.kubernetes.io/name: production-ready


### PR DESCRIPTION
Ensure all pods of the same RabbitMQ cluster are spread across zones.

As implemented in https://github.com/rabbitmq/cluster-operator/blob/6a15d4bc71c970f4f7ff5f619f3bb21b81bdcdba/internal/resource/statefulset.go#L479-L481