### PR TITLE
Mounts and capabilities

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -521,8 +521,20 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 					SecurityContext: &corev1.SecurityContext{
 						RunAsUser: pointer.Int64Ptr(0),
 						Capabilities: &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-							Add:  []corev1.Capability{"CHOWN", "FOWNER"},
+							// drop default set from Docker except for CHOWN, FOWNER, and DAC_OVERRIDE
+							Drop: []corev1.Capability{
+								"FSETID",
+								"KILL",
+								"SETGID",
+								"SETUID",
+								"SETPCAP",
+								"NET_BIND_SERVICE",
+								"NET_RAW",
+								"SYS_CHROOT",
+								"MKNOD",
+								"AUDIT_WRITE",
+								"SETFCAP",
+							},
 						},
 					},
 					Command: []string{

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1086,8 +1086,20 @@ var _ = Describe("StatefulSet", func() {
 				"Image": Equal("rabbitmq-image-from-cr"),
 				"SecurityContext": PointTo(MatchFields(IgnoreExtras, Fields{
 					"Capabilities": PointTo(MatchAllFields(Fields{
-						"Drop": ConsistOf([]corev1.Capability{"ALL"}),
-						"Add":  ConsistOf([]corev1.Capability{"CHOWN", "FOWNER"}),
+						"Drop": ConsistOf([]corev1.Capability{
+							"FSETID",
+							"KILL",
+							"SETGID",
+							"SETUID",
+							"SETPCAP",
+							"NET_BIND_SERVICE",
+							"NET_RAW",
+							"SYS_CHROOT",
+							"MKNOD",
+							"AUDIT_WRITE",
+							"SETFCAP",
+						}),
+						"Add": BeEmpty(),
 					})),
 				})),
 				"Command": ConsistOf(


### PR DESCRIPTION
This fixes issue: https://github.com/rabbitmq/tanzu-cluster-operator/issues/20

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- always mount '/var/lib/rabbitmq/' before '/var/lib/rabbitmq/mnesia/' to avoid shadowing; popular open-sourced container runtimes like docker and containerD will sort mounts in alphabetical order to avoid this issue, but there's no guarantee that all container runtime would do so
- update initContainer capabilities to be able to deploy successfully in cluster with ESXi runtime
- Context on the capabilities: dropping all capabilities except CHOWN, DAC_OVERRIDE, and FOWNER. The first of these capabilities is necessary to change a file's owner, the second is necessary to permit chown to traverse directories to which root doesn't otherwise have access. FOWNER is required for chmod and chgrp

Strictly speaking DAC_OVERRIDE isn't necessary, only DAC_READ_SEARCH is, but as it's not included in the default set using it is slightly more complex. I don't think there's much practical benefit since by default the only process with any capabilities at all is the chown process (everything else runs as 472 and gets no capabilities at all).

## Additional Context

- to make sure that '/var/lib/rabbitmq/' always mounts before '/var/lib/rabbitmq/mnesia/', volumeMounts is handled as a special case if it's patched with override

## Local Testing

unit, integration, and system tests have all passed