### PR TITLE
Include k8s 1.20 in PR system tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
         export GOPATH=$HOME/go
         export PATH=$PATH:$GOPATH/bin
         make install-tools
-        kind create cluster --image kindest/node:v1.19.1
+        kind create cluster --image kindest/node:v1.20.0
         kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.crds.yaml
         # Create CRD PodMonitor without running Prometheus operator
         curl https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml | sed "s/replicas: 1$/replicas: 0/" | kubectl apply -f -
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: [v1.17.11, v1.18.8, v1.19.1]
+        k8s: [v1.17.11, v1.18.8, v1.19.4, v1.20.0]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -75,7 +75,7 @@ jobs:
       uses: actions/checkout@v2
     - name: kubectl rabbitmq tests
       env:
-        K8S_VERSION: v1.19.1
+        K8S_VERSION: v1.20.0
       run: |
         export GOPATH=$HOME/go
         export PATH=$PATH:$GOPATH/bin


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Add k8s 1.20 in PR system tests
- Bump to k8s 1.19.1 to the latest 1.19.4

## Additional Context

Not removing 1.17 from system tests matrixes just yet since many people are still using older version of k8s and it's not adding any feedback times to our PR workflow since it's parallel anyways