### PR TITLE
Pause reconciliation label

### DIFF
--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -52,6 +52,15 @@ USAGE:
   Enable all feature flags on an INSTANCE
     kubectl rabbitmq enable-all-feature-flags INSTANCE
 
+  Pause reconciliation for an instance
+    kubectl rabbitmq pause-reconciliation INSTANCE
+
+  Resume reconciliation for an instance
+    kubectl rabbitmq resume-reconciliation INSTANCE
+
+  List all instances that has the pause reconciliation label
+    kubectl rabbitmq list-pause-reconciliation-instances
+
   Run perf-test against an instance - you can pass as many perf test parameters as you want
     kubectl rabbitmq perf-test INSTANCE --rate 100
   If you want to monitor perf-test, create the following ServiceMonitor:
@@ -233,6 +242,18 @@ enable_all_feature_flags() {
     kubectl exec "${1}-server-0" -- bash -c "rabbitmqctl list_feature_flags | grep disabled | cut -f 1 | xargs -r -L1 rabbitmqctl enable_feature_flag"
 }
 
+pause-reconciliation() {
+    kubectl label rabbitmqclusters "${1}" rabbitmq.com/pauseReconciliation=true
+}
+
+resume-reconciliation() {
+    kubectl label rabbitmqclusters "${1}" rabbitmq.com/pauseReconciliation-
+}
+
+list-pause-reconciliation-instances() {
+    kubectl get rabbitmqclusters -l rabbitmq.com/pauseReconciliation=true --show-labels
+}
+
 secrets() {
     get_instance_details "$@"
     echo "username: ${username}"
@@ -329,6 +350,25 @@ main() {
             exit 1
         fi
         enable_all_feature_flags "$1"
+        ;;
+    "pause-reconciliation")
+        shift 1
+        if [[ "$#" -ne 1 ]]; then
+            usage
+            exit 1
+        fi
+        pause-reconciliation "$1"
+        ;;
+    "resume-reconciliation")
+        shift 1
+        if [[ "$#" -ne 1 ]]; then
+            usage
+            exit 1
+        fi
+        resume-reconciliation "$1"
+        ;;
+    "list-pause-reconciliation-instances")
+        list-pause-reconciliation-instances
         ;;
     "install-cluster-operator")
         shift 1

--- a/bin/kubectl-rabbitmq.bats
+++ b/bin/kubectl-rabbitmq.bats
@@ -98,6 +98,19 @@ eventually() {
   [[ "$output" == *"secret/bats-default-erlang-cookie"* ]]
 }
 
+@test "pause-and-resume-reconciliation" {
+  kubectl rabbitmq pause-reconciliation bats-default
+  kubectl get rabbitmqclusters.rabbitmq.com bats-default --show-labels | grep rabbitmq.com/pauseReconciliation
+
+  run kubectl rabbitmq list-pause-reconciliation-instances
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bats-default"* ]]
+
+  kubectl rabbitmq resume-reconciliation bats-default
+  kubectl get rabbitmqclusters.rabbitmq.com bats-default --show-labels | grep none
+}
+
 @test "secrets prints secrets of default-user" {
   run kubectl rabbitmq secrets bats-default
 

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	ClusterCreationTimeout = 5 * time.Second
+	ClusterCreationTimeout = 10 * time.Second
 	ClusterDeletionTimeout = 5 * time.Second
 )
 
@@ -79,19 +79,15 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})
 
 			By("creating the server conf configmap", func() {
-				configMapName := cluster.ChildResourceName("server-conf")
-				configMap, err := clientSet.CoreV1().ConfigMaps(cluster.Namespace).Get(ctx, configMapName, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(configMap.Name).To(Equal(configMapName))
-				Expect(configMap.OwnerReferences[0].Name).To(Equal(cluster.Name))
+				cfm := configMap(ctx, cluster, "server-conf")
+				Expect(cfm.Name).To(Equal(cluster.ChildResourceName("server-conf")))
+				Expect(cfm.OwnerReferences[0].Name).To(Equal(cluster.Name))
 			})
 
 			By("creating the plugins conf configmap", func() {
-				configMapName := cluster.ChildResourceName("plugins-conf")
-				configMap, err := clientSet.CoreV1().ConfigMaps(cluster.Namespace).Get(ctx, configMapName, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(configMap.Name).To(Equal(configMapName))
-				Expect(configMap.OwnerReferences[0].Name).To(Equal(cluster.Name))
+				cfm := configMap(ctx, cluster, "plugins-conf")
+				Expect(cfm.Name).To(Equal(cluster.ChildResourceName("plugins-conf")))
+				Expect(cfm.OwnerReferences[0].Name).To(Equal(cluster.Name))
 			})
 
 			By("creating a rabbitmq default-user secret", func() {
@@ -352,10 +348,6 @@ var _ = Describe("RabbitmqClusterController", func() {
 	})
 
 	Context("Custom Resource updates", func() {
-		var (
-			svcName string
-			stsName string
-		)
 		BeforeEach(func() {
 			cluster = &rabbitmqv1beta1.RabbitmqCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -363,8 +355,6 @@ var _ = Describe("RabbitmqClusterController", func() {
 					Namespace: defaultNamespace,
 				},
 			}
-			svcName = cluster.ChildResourceName("")
-			stsName = cluster.ChildResourceName("server")
 
 			Expect(client.Create(ctx, cluster)).To(Succeed())
 			waitForClusterCreation(ctx, cluster, client)
@@ -381,8 +371,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})).To(Succeed())
 
 			Eventually(func() map[string]string {
-				svcName := cluster.ChildResourceName("")
-				svc, _ := clientSet.CoreV1().Services(cluster.Namespace).Get(ctx, svcName, metav1.GetOptions{})
+				svc := service(ctx, cluster, "")
 				return svc.Annotations
 			}, 3).Should(HaveKeyWithValue("test-key", "test-value"))
 
@@ -409,8 +398,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})).To(Succeed())
 
 			Eventually(func() corev1.ResourceList {
-				sts, err := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				sts := statefulSet(ctx, cluster)
 				resourceRequirements = sts.Spec.Template.Spec.Containers[0].Resources
 				return resourceRequirements.Requests
 			}, 3).Should(HaveKeyWithValue(corev1.ResourceCPU, expectedRequirements.Requests[corev1.ResourceCPU]))
@@ -430,7 +418,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})).To(Succeed())
 
 			Eventually(func() string {
-				sts, _ := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
+				sts := statefulSet(ctx, cluster)
 				return sts.Spec.Template.Spec.Containers[0].Image
 			}, 3).Should(Equal("rabbitmq:3.8.0"))
 		})
@@ -441,7 +429,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})).To(Succeed())
 
 			Eventually(func() []corev1.LocalObjectReference {
-				sts, _ := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
+				sts := statefulSet(ctx, cluster)
 				return sts.Spec.Template.Spec.ImagePullSecrets
 			}, 3).Should(ConsistOf(corev1.LocalObjectReference{Name: "my-new-secret"}))
 		})
@@ -453,13 +441,11 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})).To(Succeed())
 
 			Eventually(func() map[string]string {
-				service, err := clientSet.CoreV1().Services(cluster.Namespace).Get(ctx, svcName, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				return service.Labels
+				svc := service(ctx, cluster, "")
+				return svc.Labels
 			}, 3).Should(HaveKeyWithValue("foo", "bar"))
-			var sts *appsv1.StatefulSet
 			Eventually(func() map[string]string {
-				sts, _ = clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
+				sts := statefulSet(ctx, cluster)
 				return sts.Labels
 			}, 3).Should(HaveKeyWithValue("foo", "bar"))
 		})
@@ -477,22 +463,19 @@ var _ = Describe("RabbitmqClusterController", func() {
 
 			It("updates annotations for services", func() {
 				Eventually(func() map[string]string {
-					service, err := clientSet.CoreV1().Services(cluster.Namespace).Get(ctx, cluster.ChildResourceName("nodes"), metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-					return service.Annotations
+					svc := service(ctx, cluster, "nodes")
+					return svc.Annotations
 				}, 3).Should(HaveKeyWithValue(annotationKey, annotationValue))
 
 				Eventually(func() map[string]string {
-					service, err := clientSet.CoreV1().Services(cluster.Namespace).Get(ctx, cluster.ChildResourceName(""), metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-					return service.Annotations
+					svc := service(ctx, cluster, "")
+					return svc.Annotations
 				}, 3).Should(HaveKeyWithValue(annotationKey, annotationValue))
 			})
 
 			It("updates annotations for stateful set", func() {
 				Eventually(func() map[string]string {
-					sts, err := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
+					sts := statefulSet(ctx, cluster)
 					return sts.Annotations
 				}, 3).Should(HaveKeyWithValue(annotationKey, annotationValue))
 			})
@@ -542,9 +525,8 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})).To(Succeed())
 
 			Eventually(func() string {
-				service, err := clientSet.CoreV1().Services(cluster.Namespace).Get(ctx, cluster.ChildResourceName(""), metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				return string(service.Spec.Type)
+				svc := service(ctx, cluster, "")
+				return string(svc.Spec.Type)
 			}, 3).Should(Equal("NodePort"))
 		})
 
@@ -572,7 +554,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})).To(Succeed())
 
 			Eventually(func() *corev1.Affinity {
-				sts, _ := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
+				sts := statefulSet(ctx, cluster)
 				return sts.Spec.Template.Spec.Affinity
 			}, 3).Should(Equal(affinity))
 
@@ -587,7 +569,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 				r.Spec.Affinity = affinity
 			})).To(Succeed())
 			Eventually(func() *corev1.Affinity {
-				sts, _ := clientSet.AppsV1().StatefulSets(cluster.Namespace).Get(ctx, stsName, metav1.GetOptions{})
+				sts := statefulSet(ctx, cluster)
 				return sts.Spec.Template.Spec.Affinity
 			}, 3).Should(BeNil())
 		})
@@ -621,13 +603,9 @@ var _ = Describe("RabbitmqClusterController", func() {
 		})
 
 		It("recreates child resources after deletion", func() {
-			oldConfMap, err := clientSet.CoreV1().ConfigMaps(defaultNamespace).Get(ctx, configMapName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
+			oldConfMap := configMap(ctx, cluster, "server-conf")
 			oldClientSvc := service(ctx, cluster, "")
-
 			oldHeadlessSvc := service(ctx, cluster, "nodes")
-
 			oldSts := statefulSet(ctx, cluster)
 
 			Expect(clientSet.AppsV1().StatefulSets(defaultNamespace).Delete(ctx, stsName, metav1.DeleteOptions{})).NotTo(HaveOccurred())
@@ -636,26 +614,17 @@ var _ = Describe("RabbitmqClusterController", func() {
 			Expect(clientSet.CoreV1().Services(defaultNamespace).Delete(ctx, headlessServiceName, metav1.DeleteOptions{})).NotTo(HaveOccurred())
 
 			Eventually(func() bool {
-				sts, err := clientSet.AppsV1().StatefulSets(defaultNamespace).Get(ctx, stsName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
+				sts := statefulSet(ctx, cluster)
 				return string(sts.UID) != string(oldSts.UID)
 			}, 10).Should(BeTrue())
 
 			Eventually(func() bool {
-				clientSvc, err := clientSet.CoreV1().Services(defaultNamespace).Get(ctx, svcName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
+				clientSvc := service(ctx, cluster, "")
 				return string(clientSvc.UID) != string(oldClientSvc.UID)
 			}, 5).Should(BeTrue())
 
 			Eventually(func() bool {
-				headlessSvc, err := clientSet.CoreV1().Services(defaultNamespace).Get(ctx, headlessServiceName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
+				headlessSvc := service(ctx, cluster, "nodes")
 				return string(headlessSvc.UID) != string(oldHeadlessSvc.UID)
 			}, 5).Should(Not(Equal(oldHeadlessSvc.UID)))
 
@@ -1096,6 +1065,94 @@ var _ = Describe("RabbitmqClusterController", func() {
 		})
 	})
 
+	Context("Pause reconciliation", func() {
+		BeforeEach(func() {
+			cluster = &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rabbitmq-pause-reconcile",
+					Namespace: defaultNamespace,
+				},
+			}
+			Expect(client.Create(ctx, cluster)).To(Succeed())
+			waitForClusterCreation(ctx, cluster, client)
+		})
+
+		AfterEach(func() {
+			Expect(client.Delete(ctx, cluster)).To(Succeed())
+		})
+
+		It("works", func() {
+			By("skipping reconciling if label is set to true", func() {
+				Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
+					r.Labels = map[string]string{"rabbitmq.com/pauseReconciliation": "true"}
+					r.Spec.Service.Type = "LoadBalancer"
+					r.Spec.Rabbitmq.AdditionalConfig = "test=test"
+				})).To(Succeed())
+
+				// service type is unchanged
+				Consistently(func() corev1.ServiceType {
+					return service(ctx, cluster, "").Spec.Type
+				}, 10*time.Second).Should(Equal(corev1.ServiceTypeClusterIP))
+
+				// configMap and statefulSet do not have their update and restart annotations set
+				Expect(configMap(ctx, cluster, "server-conf").Annotations).ShouldNot(HaveKey("rabbitmq.com/serverConfUpdatedAt"))
+				Expect(statefulSet(ctx, cluster).Annotations).ShouldNot(HaveKey("rabbitmq.com/lastRestartAt"))
+
+				// PausedReconciliation event is published
+				Expect(aggregateEventMsgs(ctx, cluster, "PausedReconciliation")).To(
+					ContainSubstring("label 'rabbitmq.com/pauseReconciliation' is set to true"))
+
+				// NoWarnings status.condition is set to false with reason 'reconciliation paused'
+				Eventually(func() string {
+					rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+					Expect(client.Get(ctx,
+						types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)).To(Succeed())
+					for i := range rmq.Status.Conditions {
+						if rmq.Status.Conditions[i].Type == status.NoWarnings {
+							return fmt.Sprintf("NoWarnings status: %s with reason: %s",
+								rmq.Status.Conditions[i].Status,
+								rmq.Status.Conditions[i].Reason)
+						}
+					}
+					return "NoWarnings status: condition not present"
+				}, 5).Should(Equal("NoWarnings status: False with reason: reconciliation paused"))
+			})
+
+			By("resuming reconciliation when label is removed", func() {
+				Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
+					r.Labels = map[string]string{}
+				})).To(Succeed())
+
+				// service type is updated
+				Eventually(func() corev1.ServiceType {
+					svc := service(ctx, cluster, "")
+					return svc.Spec.Type
+				}, 10*time.Second).Should(Equal(corev1.ServiceTypeLoadBalancer))
+
+				// configMap and statefulSet now have their update and restart annotations set
+				Eventually(func() map[string]string {
+					return configMap(ctx, cluster, "server-conf").Annotations
+				}, 10*time.Second).Should(HaveKey("rabbitmq.com/serverConfUpdatedAt"))
+				Eventually(func() map[string]string {
+					return statefulSet(ctx, cluster).Spec.Template.Annotations
+				}, 10*time.Second).Should(HaveKey("rabbitmq.com/lastRestartAt"))
+
+				// NoWarnings status.condition is set to true
+				Eventually(func() string {
+					rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+					Expect(client.Get(ctx,
+						types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)).To(Succeed())
+					for i := range rmq.Status.Conditions {
+						if rmq.Status.Conditions[i].Type == status.NoWarnings {
+							return fmt.Sprintf("NoWarnings status: %s", rmq.Status.Conditions[i].Status)
+						}
+					}
+					return "NoWarnings status: condition not present"
+				}, 5).Should(Equal("NoWarnings status: True"))
+			})
+		})
+	})
+
 })
 
 func extractContainer(containers []corev1.Container, containerName string) corev1.Container {
@@ -1142,6 +1199,17 @@ func service(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqClust
 		return err
 	}, 10).Should(Succeed())
 	return svc
+}
+
+func configMap(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster, configMapName string) *corev1.ConfigMap {
+	cfmName := rabbitmqCluster.ChildResourceName(configMapName)
+	var cfm *corev1.ConfigMap
+	EventuallyWithOffset(1, func() error {
+		var err error
+		cfm, err = clientSet.CoreV1().ConfigMaps(rabbitmqCluster.Namespace).Get(ctx, cfmName, metav1.GetOptions{})
+		return err
+	}, 10).Should(Succeed())
+	return cfm
 }
 
 func createSecret(ctx context.Context, secretName string, namespace string, data map[string]string) (corev1.Secret, error) {


### PR DESCRIPTION
This closes #509

This PR is an updated version of PR #511. Updated based on feedback https://github.com/rabbitmq/cluster-operator/pull/511#issuecomment-740023563

## Summary Of Changes

- users can set label "rabbitmq.com/pauseReconciliation" to true to signal that they would like to pause reconciliation for this CR
- added helper command: `pause-reconciliation` which adds the label to a cr, `resume-reconciliation` which deletes the label from a cr, and `list-pause-reconciliation-instances` which lists all rabbitmqclusters with the label set to true in the current targeted namespace
- When `Reconcile()` detects the label, it logs, publishes events and sets NoWarnings status condition to false with reason `paused reconciliation`
- Deleting the label, or setting the label to any value other than 'true' will resume reconciliation, and NoWarnings status condition will be set to its original value (it can remain false if the resource requirement is configured wrong for example)
- tested at integration level, system test not needed imo

## Additional Context

**Label vs Annotation**

The purpose of this issue is to provide a way for users to skip reconciliation, in case that a rolling restart of the sts is needed, after an operator upgrade. In this particular use case, it's likely that users would have multiple rabbitmq clusters that they have paused reconciliation at the same time. Labels have the advantage of filtering and therefore better suited for fleet management.

## Local Testing

Have run unit, integration, and system tests.