### PR TITLE
Add support for  prometheus TLS

### DIFF
--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -43,9 +43,9 @@ management.ssl.certfile   = /etc/rabbitmq-tls/tls.crt
 management.ssl.keyfile    = /etc/rabbitmq-tls/tls.key
 management.ssl.port       = 15671
 
-prometheus.ssl.certfile = /etc/rabbitmq-tls/tls.crt
+prometheus.ssl.certfile  = /etc/rabbitmq-tls/tls.crt
 prometheus.ssl.keyfile   = /etc/rabbitmq-tls/tls.key
-prometheus.ssl.port       = 15691
+prometheus.ssl.port      = 15691
 `
 	caCertPath  = "/etc/rabbitmq-tls/ca.crt"
 	tlsCertPath = "/etc/rabbitmq-tls/tls.crt"

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -42,6 +42,10 @@ listeners.ssl.default = 5671
 management.ssl.certfile   = /etc/rabbitmq-tls/tls.crt
 management.ssl.keyfile    = /etc/rabbitmq-tls/tls.key
 management.ssl.port       = 15671
+
+prometheus.ssl.certfile = /etc/rabbitmq-tls/tls.crt
+prometheus.ssl.keyfile   = /etc/rabbitmq-tls/tls.key
+prometheus.ssl.port       = 15691
 `
 	caCertPath  = "/etc/rabbitmq-tls/ca.crt"
 	tlsCertPath = "/etc/rabbitmq-tls/tls.crt"

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -251,7 +251,12 @@ listeners.ssl.default = 5671
 management.ssl.certfile   = /etc/rabbitmq-tls/tls.crt
 management.ssl.keyfile    = /etc/rabbitmq-tls/tls.key
 management.ssl.port       = 15671
-management.tcp.port       = 15672
+
+prometheus.ssl.certfile = /etc/rabbitmq-tls/tls.crt
+prometheus.ssl.keyfile  = /etc/rabbitmq-tls/tls.key
+prometheus.ssl.port     = 15691
+management.tcp.port     = 15672
+
 `)
 
 				Expect(configMapBuilder.Update(configMap)).To(Succeed())
@@ -274,6 +279,11 @@ listeners.ssl.default = 5671
 management.ssl.certfile   = /etc/rabbitmq-tls/tls.crt
 management.ssl.keyfile    = /etc/rabbitmq-tls/tls.key
 management.ssl.port       = 15671
+
+prometheus.ssl.certfile = /etc/rabbitmq-tls/tls.crt
+prometheus.ssl.keyfile   = /etc/rabbitmq-tls/tls.key
+prometheus.ssl.port       = 15691
+
 management.tcp.port       = 15672
 
 mqtt.listeners.ssl.default = 8883
@@ -301,6 +311,11 @@ listeners.ssl.default  = 5671
 management.ssl.certfile   = /etc/rabbitmq-tls/tls.crt
 management.ssl.keyfile    = /etc/rabbitmq-tls/tls.key
 management.ssl.port       = 15671
+
+prometheus.ssl.certfile = /etc/rabbitmq-tls/tls.crt
+prometheus.ssl.keyfile   = /etc/rabbitmq-tls/tls.key
+prometheus.ssl.port       = 15691
+
 management.tcp.port       = 15672
 
 ssl_options.cacertfile = /etc/rabbitmq-tls/ca.crt
@@ -329,6 +344,11 @@ management.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
 			management.ssl.certfile   = /etc/rabbitmq-tls/tls.crt
 			management.ssl.keyfile    = /etc/rabbitmq-tls/tls.key
 			management.ssl.port       = 15671
+
+			prometheus.ssl.certfile = /etc/rabbitmq-tls/tls.crt
+			prometheus.ssl.keyfile   = /etc/rabbitmq-tls/tls.key
+			prometheus.ssl.port       = 15691
+			
 			management.tcp.port       = 15672
 
 			ssl_options.cacertfile = /etc/rabbitmq-tls/ca.crt
@@ -376,6 +396,10 @@ management.ssl.certfile   = /etc/rabbitmq-tls/tls.crt
 management.ssl.keyfile    = /etc/rabbitmq-tls/tls.key
 management.ssl.port       = 15671
 
+prometheus.ssl.certfile = /etc/rabbitmq-tls/tls.crt
+prometheus.ssl.keyfile   = /etc/rabbitmq-tls/tls.key
+prometheus.ssl.port       = 15691
+
 listeners.tcp = none
 `)
 
@@ -410,6 +434,11 @@ listeners.ssl.default  = 5671
 management.ssl.certfile   = /etc/rabbitmq-tls/tls.crt
 management.ssl.keyfile    = /etc/rabbitmq-tls/tls.key
 management.ssl.port       = 15671
+
+prometheus.ssl.certfile = /etc/rabbitmq-tls/tls.crt
+prometheus.ssl.keyfile   = /etc/rabbitmq-tls/tls.key
+prometheus.ssl.port       = 15691
+
 listeners.tcp = none
 
 mqtt.listeners.ssl.default = 8883
@@ -451,6 +480,11 @@ listeners.ssl.default  = 5671
 management.ssl.certfile   = /etc/rabbitmq-tls/tls.crt
 management.ssl.keyfile    = /etc/rabbitmq-tls/tls.key
 management.ssl.port       = 15671
+
+prometheus.ssl.certfile                  = /etc/rabbitmq-tls/tls.crt
+prometheus.ssl.keyfile                   = /etc/rabbitmq-tls/tls.key
+prometheus.ssl.port                      = 15691
+
 listeners.tcp = none
 
 ssl_options.cacertfile = /etc/rabbitmq-tls/ca.crt

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -255,6 +255,7 @@ management.ssl.port       = 15671
 prometheus.ssl.certfile = /etc/rabbitmq-tls/tls.crt
 prometheus.ssl.keyfile  = /etc/rabbitmq-tls/tls.key
 prometheus.ssl.port     = 15691
+
 management.tcp.port     = 15672
 
 `)

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -772,7 +772,7 @@ func (builder *StatefulSetBuilder) updateContainerPortsOnlyTLSListeners() []core
 			ContainerPort: 15671,
 		},
 		{
-			Name:          "prometheus",
+			Name:          "prometheus-tls",
 			ContainerPort: 15691,
 		},
 	}

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -280,9 +280,14 @@ func sortVolumeMounts(mounts []corev1.VolumeMount) {
 
 func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[string]string) corev1.PodTemplateSpec {
 	// default pod annotations used for prometheus metrics
+	prometheusPort := "15692"
+	if builder.Instance.DisableNonTLSListeners() {
+		prometheusPort = "15691"
+	}
+
 	defaultPodAnnotations := map[string]string{
 		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   "15692",
+		"prometheus.io/port":   prometheusPort,
 	}
 
 	//Init Container resources

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -711,6 +711,10 @@ func (builder *StatefulSetBuilder) updateContainerPorts() []corev1.ContainerPort
 				Name:          "management-tls",
 				ContainerPort: 15671,
 			},
+			corev1.ContainerPort{
+				Name:          "prometheus-tls",
+				ContainerPort: 15691,
+			},
 		)
 
 		// enable tls ports for plugins
@@ -764,7 +768,7 @@ func (builder *StatefulSetBuilder) updateContainerPortsOnlyTLSListeners() []core
 		},
 		{
 			Name:          "prometheus",
-			ContainerPort: 15692,
+			ContainerPort: 15691,
 		},
 	}
 

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -706,8 +706,8 @@ var _ = Describe("StatefulSet", func() {
 							ContainerPort: 4369,
 						},
 						{
-							Name:          "prometheus",
-							ContainerPort: 15692,
+							Name:          "prometheus-tls",
+							ContainerPort: 15691,
 						},
 						{
 							Name:          "amqps",
@@ -731,8 +731,8 @@ var _ = Describe("StatefulSet", func() {
 							ContainerPort: 4369,
 						},
 						{
-							Name:          "prometheus",
-							ContainerPort: 15692,
+							Name:          "prometheus-tls",
+							ContainerPort: 15691,
 						},
 						{
 							Name:          "amqps",


### PR DESCRIPTION
This closes https://github.com/rabbitmq/cluster-operator/issues/479

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
Add TLS support for prometheus

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
