### PR TITLE
Use namespaced name for RabbitMQ cluster_name

### DIFF
--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -81,7 +81,7 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 	}
 	defaultSection := cfg.Section("")
 
-	if _, err := defaultSection.NewKey("cluster_name", builder.Instance.Name); err != nil {
+	if _, err := defaultSection.NewKey("cluster_name", fmt.Sprintf("%s/%s", builder.Instance.Namespace, builder.Instance.Name)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Before this PR, the Grafana RabbitMQ Overview dashboard was mixing metrics of multiple RabbitMQ clusters if they have the same (CRD) name but are in different namespaces.

For example having RabbitMQ cluster A in namespace 1, and a separate RabbitMQ cluster with the same name A in namespace 2, the Grafana RabbitMQ Overview dashboard only allowed filtering for RabbitMQ cluster A which then mixed / combined all metrics of the two separate clusters (e.g. showing 6 nodes in total although each had 3 nodes).

Two solutions come to my mind:
1. solution as implemented in this PR is to prepend the namespace to the `cluster_name`.

2. solution is to build new Grafana dashboards specifically for RabbitMQ on K8s.  That's possible because the `rabbitmq_identity_info` metric contains a `namespace` label: e.g. `rabbitmq_identity_info{rabbitmq_cluster="myrabbit", namespace="mynamesspace"}`.

I think it's simpler and cheaper to go with the 1st solution instead of maintaining a separate set of dashboards for K8s (2nd solution).

The (only) drawback of the 1st solution is that renaming existing clusters is a breaking change.
The [federation plugin docs](https://www.rabbitmq.com/federation-reference.html#cluster-name) state:
> The federation plugin uses the cluster name defined within the server to identify itself to other nodes in the federation graph. The default is constructed from the RabbitMQ node name and the fully-qualified domain name of the first node to form the cluster.

Therefore, existing clusters using federation would need to overwrite the `cluster_name` via `spec.rabbbitmq.additionalConfig` to avoid having the federated queues being doubled.

What are you thoughts @gerhard @mkuratczyk?