### PR TITLE
Add prometheus  tls example

### DIFF
--- a/docs/examples/prometheus/README.md
+++ b/docs/examples/prometheus/README.md
@@ -9,3 +9,9 @@ kubectl apply -f rabbitmq-podmonitor.yaml
 
 Alternatively, if you deployed the Prometheus Operator via the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) Helm chart,
 set the values in [kube-prometheus-stack-values.yaml.example](kube-prometheus-stack-values.yaml.example) when installing / upgrading the Helm chart.
+
+---
+## TLS Endpoints
+
+With `TLS` enabled you should use `-tls` files to deploy the secure prometheus endpoints. 
+_Note_: The standard Prometheus (15692) port is disabled with the option `disableNonTLSListeners=true`.  

--- a/docs/examples/prometheus/kube-prometheus-stack-values-tls.yaml.example
+++ b/docs/examples/prometheus/kube-prometheus-stack-values-tls.yaml.example
@@ -1,4 +1,3 @@
-## Version > 1.3.0
 ---
 prometheus:
   additionalPodMonitors:

--- a/docs/examples/prometheus/kube-prometheus-stack-values-tls.yaml.example
+++ b/docs/examples/prometheus/kube-prometheus-stack-values-tls.yaml.example
@@ -1,14 +1,15 @@
 ## Version > 1.3.0
 ---
-additionalPodMonitors:
-- name: rabbitmq
- podMetricsEndpoints:
- - port: prometheus-tls
-   scheme: https
-   tlsConfig:
-     insecureSkipVerify: true
- selector:
-   matchLabels:
-     app.kubernetes.io/component: rabbitmq
- namespaceSelector:
-   any: true
+prometheus:
+  additionalPodMonitors:
+   - name: rabbitmq
+     podMetricsEndpoints:
+     - port: prometheus-tls
+       scheme: https
+       tlsConfig:
+           insecureSkipVerify: true
+     selector:
+       matchLabels:
+         app.kubernetes.io/component: rabbitmq
+     namespaceSelector:
+       any: true

--- a/docs/examples/prometheus/kube-prometheus-stack-values-tls.yaml.example
+++ b/docs/examples/prometheus/kube-prometheus-stack-values-tls.yaml.example
@@ -1,0 +1,14 @@
+## Version > 1.3.0
+---
+additionalPodMonitors:
+- name: rabbitmq
+ podMetricsEndpoints:
+ - port: prometheus-tls
+   scheme: https
+   tlsConfig:
+     insecureSkipVerify: true
+ selector:
+   matchLabels:
+     app.kubernetes.io/component: rabbitmq
+ namespaceSelector:
+   any: true

--- a/docs/examples/prometheus/rabbitmq-podmonitor-tls.yaml
+++ b/docs/examples/prometheus/rabbitmq-podmonitor-tls.yaml
@@ -1,0 +1,16 @@
+## Version > 1.3.0
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: rabbitmq
+spec:
+  podMetricsEndpoints:
+  - interval: 15s
+    scheme: https
+    port: prometheus-tls
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: rabbitmq
+  namespaceSelector:
+    any: true

--- a/docs/examples/prometheus/rabbitmq-podmonitor-tls.yaml
+++ b/docs/examples/prometheus/rabbitmq-podmonitor-tls.yaml
@@ -1,4 +1,3 @@
-## Version > 1.3.0
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor


### PR DESCRIPTION
## Summary Of Changes

With this PR https://github.com/rabbitmq/cluster-operator/pull/533 it is possible to enable the Prometheus tls endpoint. 

Update the example to show how to use them
