### PR TITLE
Change prod example to use pause_minority strategy

### DIFF
--- a/docs/examples/production-ready/rabbitmq.yaml
+++ b/docs/examples/production-ready/rabbitmq.yaml
@@ -13,7 +13,7 @@ spec:
       memory: 10Gi
   rabbitmq:
     additionalConfig: |
-      cluster_partition_handling = ignore
+      cluster_partition_handling = pause_minority
       vm_memory_high_watermark_paging_ratio = 0.99
       disk_free_limit.relative = 1.0
   persistence:


### PR DESCRIPTION
As part of [TGIR S01E09](https://www.youtube.com/watch?v=y2HAJBiXsw0),
we found that the ignore strategy was not ideal for production use cases
where a network partition occurred due to the necessity of manual
intervention.

In addition, the readiness probe does not account for the fact that a
pod is partitioned, meaning that in the case of a 3-node quorum queue cluster with a
2-1 network partition, 1/3 of the traffic will be routed via the Service
to pods that cannot serve traffic due to them not establishing quorum.

By contrast, the pause_minority strategy will stop the RabbitMQ app,
meaning that the Service will no longer redirect traffic to the pod
until it regains quorum.
