### PR TITLE
Prometheus fix standard port in TLS deploy

### DIFF
--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -129,17 +129,6 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 				}
 			}
 		}
-		if builder.Instance.AdditionalPluginEnabled("rabbitmq_prometheus") {
-			if _, err := defaultSection.NewKey("prometheus.ssl.port", "61614"); err != nil {
-				return err
-			}
-			if builder.Instance.DisableNonTLSListeners() {
-				if _, err := defaultSection.NewKey("stomp.listeners.tcp", "none"); err != nil {
-					return err
-				}
-			}
-		}
-
 	}
 
 	if builder.Instance.MutualTLSEnabled() {

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -142,6 +142,11 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 		if _, err := defaultSection.NewKey("management.ssl.cacertfile", caCertPath); err != nil {
 			return err
 		}
+
+		if _, err := defaultSection.NewKey("prometheus.ssl.cacertfile", caCertPath); err != nil {
+			return err
+		}
+
 		if builder.Instance.AdditionalPluginEnabled("rabbitmq_web_mqtt") {
 			if _, err := defaultSection.NewKey("web_mqtt.ssl.port", "15676"); err != nil {
 				return err

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -104,6 +104,10 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 			if _, err := defaultSection.NewKey("management.tcp.port", "15672"); err != nil {
 				return err
 			}
+
+			if _, err := defaultSection.NewKey("prometheus.tcp.port", "15692"); err != nil {
+				return err
+			}
 		}
 		if builder.Instance.AdditionalPluginEnabled("rabbitmq_mqtt") {
 			if _, err := defaultSection.NewKey("mqtt.listeners.ssl.default", "8883"); err != nil {
@@ -125,6 +129,17 @@ func (builder *ServerConfigMapBuilder) Update(object runtime.Object) error {
 				}
 			}
 		}
+		if builder.Instance.AdditionalPluginEnabled("rabbitmq_prometheus") {
+			if _, err := defaultSection.NewKey("prometheus.ssl.port", "61614"); err != nil {
+				return err
+			}
+			if builder.Instance.DisableNonTLSListeners() {
+				if _, err := defaultSection.NewKey("stomp.listeners.tcp", "none"); err != nil {
+					return err
+				}
+			}
+		}
+
 	}
 
 	if builder.Instance.MutualTLSEnabled() {

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -257,6 +257,7 @@ prometheus.ssl.keyfile  = /etc/rabbitmq-tls/tls.key
 prometheus.ssl.port     = 15691
 
 management.tcp.port     = 15672
+prometheus.tcp.port     = 15692
 
 `)
 
@@ -286,6 +287,7 @@ prometheus.ssl.keyfile   = /etc/rabbitmq-tls/tls.key
 prometheus.ssl.port       = 15691
 
 management.tcp.port       = 15672
+prometheus.tcp.port       = 15692
 
 mqtt.listeners.ssl.default = 8883
 
@@ -319,6 +321,8 @@ prometheus.ssl.port       = 15691
 
 management.tcp.port       = 15672
 
+prometheus.tcp.port       = 15692
+
 ssl_options.cacertfile = /etc/rabbitmq-tls/ca.crt
 ssl_options.verify     = verify_peer
 management.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
@@ -351,6 +355,7 @@ management.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
 			prometheus.ssl.port       = 15691
 			
 			management.tcp.port       = 15672
+			prometheus.tcp.port       = 15692
 
 			ssl_options.cacertfile = /etc/rabbitmq-tls/ca.crt
 			ssl_options.verify     = verify_peer

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -326,6 +326,8 @@ prometheus.tcp.port       = 15692
 ssl_options.cacertfile = /etc/rabbitmq-tls/ca.crt
 ssl_options.verify     = verify_peer
 management.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
+prometheus.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
+
 `)
 
 				Expect(configMapBuilder.Update(configMap)).To(Succeed())
@@ -360,6 +362,8 @@ management.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
 			ssl_options.cacertfile = /etc/rabbitmq-tls/ca.crt
 			ssl_options.verify     = verify_peer
 			management.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
+			
+			prometheus.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
 
 			web_mqtt.ssl.port       = 15676
 			web_mqtt.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
@@ -496,6 +500,7 @@ listeners.tcp = none
 ssl_options.cacertfile = /etc/rabbitmq-tls/ca.crt
 ssl_options.verify     = verify_peer
 management.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
+prometheus.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
 
 web_mqtt.ssl.port       = 15676
 web_mqtt.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt


### PR DESCRIPTION
Enable the Prometheus standard port with the TLS deploy

I introduced this problem with this PR https://github.com/rabbitmq/cluster-operator/pull/533 found by @mkuratczyk 

To recap the behaviour:

- standard deploy:
![normal](https://user-images.githubusercontent.com/386987/103554650-873b8400-4eaf-11eb-95d2-e377eed49ae7.png)

- tls deploy `disableNonTLSListeners=false`
![all](https://user-images.githubusercontent.com/386987/103554688-991d2700-4eaf-11eb-97cb-fc6ca1e15967.png)

- tls deploy  `disableNonTLSListeners = true`
![disable](https://user-images.githubusercontent.com/386987/103554756-b651f580-4eaf-11eb-9680-f3f121e822b3.png)



