### PR TITLE
Place RabbitMQ configuration in confd

### DIFF
--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -886,19 +886,25 @@ var _ = Describe("RabbitmqClusterController", func() {
 										},
 									},
 								},
+								{
+									ConfigMap: &corev1.ConfigMapProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "rabbitmq-sts-override-server-conf",
+										},
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "operatorDefaults.conf",
+												Path: "operatorDefaults.conf",
+											},
+											{
+												Key:  "additionalConfig.conf",
+												Path: "additionalConfig.conf",
+											},
+										},
+									},
+								},
 							},
 							DefaultMode: &defaultMode,
-						},
-					},
-				},
-				corev1.Volume{
-					Name: "server-conf",
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							DefaultMode: &defaultMode,
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "rabbitmq-sts-override-server-conf",
-							},
 						},
 					},
 				},

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -897,8 +897,8 @@ var _ = Describe("RabbitmqClusterController", func() {
 												Path: "operatorDefaults.conf",
 											},
 											{
-												Key:  "additionalConfig.conf",
-												Path: "additionalConfig.conf",
+												Key:  "userDefinedConfiguration.conf",
+												Path: "userDefinedConfiguration.conf",
 											},
 										},
 									},

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -10,8 +10,9 @@
 package resource
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -198,7 +199,7 @@ func (builder *ServerConfigMapBuilder) Update(object client.Object) error {
 	}
 
 	// TODO refactor: use string builder
-	var rmqConfBuffer bytes.Buffer
+	var rmqConfBuffer strings.Builder
 	if _, err := cfg.WriteTo(&rmqConfBuffer); err != nil {
 		return err
 	}

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -346,8 +346,8 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 										Path: "operatorDefaults.conf",
 									},
 									{
-										Key:  "additionalConfig.conf",
-										Path: "additionalConfig.conf",
+										Key:  "userDefinedConfiguration.conf",
+										Path: "userDefinedConfiguration.conf",
 									},
 								},
 							},
@@ -428,8 +428,8 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 		},
 		{
 			Name:      "rabbitmq-confd",
-			MountPath: "/etc/rabbitmq/conf.d/90-additionalConfig.conf",
-			SubPath:   "additionalConfig.conf",
+			MountPath: "/etc/rabbitmq/conf.d/90-userDefinedConfiguration.conf",
+			SubPath:   "userDefinedConfiguration.conf",
 		},
 		{
 			Name:      "pod-info",

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1010,7 +1010,7 @@ var _ = Describe("StatefulSet", func() {
 						{Name: "pod-info", MountPath: "/etc/pod-info/"},
 						{Name: "rabbitmq-confd", MountPath: "/etc/rabbitmq/conf.d/10-operatorDefaults.conf", SubPath: "operatorDefaults.conf"},
 						{Name: "rabbitmq-confd", MountPath: "/etc/rabbitmq/conf.d/11-default_user.conf", SubPath: "default_user.conf"},
-						{Name: "rabbitmq-confd", MountPath: "/etc/rabbitmq/conf.d/90-additionalConfig.conf", SubPath: "additionalConfig.conf"},
+						{Name: "rabbitmq-confd", MountPath: "/etc/rabbitmq/conf.d/90-userDefinedConfiguration.conf", SubPath: "userDefinedConfiguration.conf"},
 						{Name: "rabbitmq-plugins", MountPath: "/operator"},
 					}
 
@@ -1089,8 +1089,8 @@ var _ = Describe("StatefulSet", func() {
 													Path: "operatorDefaults.conf",
 												},
 												{
-													Key:  "additionalConfig.conf",
-													Path: "additionalConfig.conf",
+													Key:  "userDefinedConfiguration.conf",
+													Path: "userDefinedConfiguration.conf",
 												},
 											},
 										},
@@ -1652,8 +1652,8 @@ var _ = Describe("StatefulSet", func() {
 						},
 						corev1.VolumeMount{
 							Name:      "rabbitmq-confd",
-							MountPath: "/etc/rabbitmq/conf.d/90-additionalConfig.conf",
-							SubPath:   "additionalConfig.conf",
+							MountPath: "/etc/rabbitmq/conf.d/90-userDefinedConfiguration.conf",
+							SubPath:   "userDefinedConfiguration.conf",
 						},
 						corev1.VolumeMount{
 							Name:      "rabbitmq-erlang-cookie",
@@ -1704,7 +1704,7 @@ var _ = Describe("StatefulSet", func() {
 							{Name: "pod-info", MountPath: "/etc/pod-info/"},
 							{Name: "rabbitmq-confd", MountPath: "/etc/rabbitmq/conf.d/10-operatorDefaults.conf", SubPath: "operatorDefaults.conf"},
 							{Name: "rabbitmq-confd", MountPath: "/etc/rabbitmq/conf.d/11-default_user.conf", SubPath: "default_user.conf"},
-							{Name: "rabbitmq-confd", MountPath: "/etc/rabbitmq/conf.d/90-additionalConfig.conf", SubPath: "additionalConfig.conf"},
+							{Name: "rabbitmq-confd", MountPath: "/etc/rabbitmq/conf.d/90-userDefinedConfiguration.conf", SubPath: "userDefinedConfiguration.conf"},
 							{Name: "rabbitmq-plugins", MountPath: "/operator"},
 							{Name: "test", MountPath: "test"},
 						}

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -164,7 +164,7 @@ var _ = Describe("Operator", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			By("updating the rabbitmq.conf file when additionalConfig are modified", func() {
+			By("updating the additionalConfig.conf file when additionalConfig are modified", func() {
 				Expect(updateRabbitmqCluster(ctx, rmqClusterClient, cluster.Name, cluster.Namespace, func(cluster *rabbitmqv1beta1.RabbitmqCluster) {
 					cluster.Spec.Rabbitmq.AdditionalConfig = `vm_memory_high_watermark_paging_ratio = 0.5
 cluster_partition_handling = ignore
@@ -175,7 +175,7 @@ cluster_keepalive_interval = 10000`
 				waitForRabbitmqUpdate(cluster)
 
 				// verify that rabbitmq.conf contains provided configurations
-				cfgMap := getConfigFileFromPod(namespace, cluster, "/etc/rabbitmq/rabbitmq.conf")
+				cfgMap := getConfigFileFromPod(namespace, cluster, "/etc/rabbitmq/conf.d/90-additionalConfig.conf")
 				Expect(cfgMap).To(SatisfyAll(
 					HaveKeyWithValue("vm_memory_high_watermark_paging_ratio", "0.5"),
 					HaveKeyWithValue("cluster_keepalive_interval", "10000"),
@@ -418,7 +418,7 @@ CONSOLE_LOG=new`
 
 				By("disabling non TLS listeners", func() {
 					// verify that rabbitmq.conf contains listeners.tcp = none
-					cfgMap := getConfigFileFromPod(namespace, cluster, "/etc/rabbitmq/rabbitmq.conf")
+					cfgMap := getConfigFileFromPod(namespace, cluster, "/etc/rabbitmq/conf.d/90-additionalConfig.conf")
 					Expect(cfgMap).To(SatisfyAll(
 						HaveKeyWithValue("listeners.tcp", "none"),
 						HaveKeyWithValue("stomp.listeners.tcp", "none"),

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -164,7 +164,7 @@ var _ = Describe("Operator", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			By("updating the additionalConfig.conf file when additionalConfig are modified", func() {
+			By("updating the userDefinedConfiguration.conf file when additionalConfig are modified", func() {
 				Expect(updateRabbitmqCluster(ctx, rmqClusterClient, cluster.Name, cluster.Namespace, func(cluster *rabbitmqv1beta1.RabbitmqCluster) {
 					cluster.Spec.Rabbitmq.AdditionalConfig = `vm_memory_high_watermark_paging_ratio = 0.5
 cluster_partition_handling = ignore
@@ -175,7 +175,7 @@ cluster_keepalive_interval = 10000`
 				waitForRabbitmqUpdate(cluster)
 
 				// verify that rabbitmq.conf contains provided configurations
-				cfgMap := getConfigFileFromPod(namespace, cluster, "/etc/rabbitmq/conf.d/90-additionalConfig.conf")
+				cfgMap := getConfigFileFromPod(namespace, cluster, "/etc/rabbitmq/conf.d/90-userDefinedConfiguration.conf")
 				Expect(cfgMap).To(SatisfyAll(
 					HaveKeyWithValue("vm_memory_high_watermark_paging_ratio", "0.5"),
 					HaveKeyWithValue("cluster_keepalive_interval", "10000"),
@@ -418,7 +418,7 @@ CONSOLE_LOG=new`
 
 				By("disabling non TLS listeners", func() {
 					// verify that rabbitmq.conf contains listeners.tcp = none
-					cfgMap := getConfigFileFromPod(namespace, cluster, "/etc/rabbitmq/conf.d/90-additionalConfig.conf")
+					cfgMap := getConfigFileFromPod(namespace, cluster, "/etc/rabbitmq/conf.d/90-userDefinedConfiguration.conf")
 					Expect(cfgMap).To(SatisfyAll(
 						HaveKeyWithValue("listeners.tcp", "none"),
 						HaveKeyWithValue("stomp.listeners.tcp", "none"),


### PR DESCRIPTION

Related to #503

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
 - RabbitMQ configurations are placed in conf.d
 - RabbitMQ env and advanced config are still placed in the default location.
 - The Server conf ConfigMap is specified as its own volume only when advanced config or env configurations are set in the RabbitmqCluster Spec.
 - The server configuration is always added to a projected volume.

## Additional Context
N/A

## Local Testing

- There are changes to all test suites: unit, integration and system

