### PR TITLE
Small refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RabbitMQ Cluster Kubernetes Operator
 
-Kubernetes operator to deploy and manage [RabbitMQ](https://www.rabbitmq.com/) clusters. This repository contains a [custom controller](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#custom-controllers) and [custom resource definition (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) designed for the lifecyle (creation, upgrade, graceful shutdown) of a RabbitMQ cluster.
+Kubernetes operator to deploy and manage [RabbitMQ](https://www.rabbitmq.com/) clusters. This repository contains a [custom controller](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#custom-controllers) and [custom resource definition (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) designed for the lifecycle (creation, upgrade, graceful shutdown) of a RabbitMQ cluster.
 
 **Note**: this repository is under active development and is provided as **beta** software. Official support for this software is not provided; if you encounter any issues running this software, please feel free to [contribute to the project](#contributing).
 

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -144,18 +144,19 @@ var _ = Describe("RabbitmqClusterController", func() {
 			})
 			By("recording SuccessfulCreate events for all child resources", func() {
 				allEventMsgs := aggregateEventMsgs(ctx, cluster, "SuccessfulCreate")
-				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.StatefulSet", cluster.ChildResourceName("server")))
-				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.Service", cluster.ChildResourceName("")))
-				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.Service", cluster.ChildResourceName("nodes")))
-				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.ConfigMap", cluster.ChildResourceName("plugins-conf")))
-				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.ConfigMap", cluster.ChildResourceName("server-conf")))
-				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.Secret", cluster.ChildResourceName("erlang-cookie")))
-				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.Secret", cluster.ChildResourceName("default-user")))
-				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.ServiceAccount", cluster.ChildResourceName("server")))
-				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.Role", cluster.ChildResourceName("peer-discovery")))
-				Expect(allEventMsgs).To(ContainSubstring("created resource %s of Type *v1.RoleBinding", cluster.ChildResourceName("server")))
+				Expect(allEventMsgs).To(SatisfyAll(
+					ContainSubstring("created resource %s of Type *v1.StatefulSet", cluster.ChildResourceName("server")),
+					ContainSubstring("created resource %s of Type *v1.Service", cluster.ChildResourceName("")),
+					ContainSubstring("created resource %s of Type *v1.Service", cluster.ChildResourceName("nodes")),
+					ContainSubstring("created resource %s of Type *v1.ConfigMap", cluster.ChildResourceName("plugins-conf")),
+					ContainSubstring("created resource %s of Type *v1.ConfigMap", cluster.ChildResourceName("server-conf")),
+					ContainSubstring("created resource %s of Type *v1.Secret", cluster.ChildResourceName("erlang-cookie")),
+					ContainSubstring("created resource %s of Type *v1.Secret", cluster.ChildResourceName("default-user")),
+					ContainSubstring("created resource %s of Type *v1.ServiceAccount", cluster.ChildResourceName("server")),
+					ContainSubstring("created resource %s of Type *v1.Role", cluster.ChildResourceName("peer-discovery")),
+					ContainSubstring("created resource %s of Type *v1.RoleBinding", cluster.ChildResourceName("server")),
+				))
 			})
-
 		})
 	})
 

--- a/docs/examples/mtls/README.md
+++ b/docs/examples/mtls/README.md
@@ -13,7 +13,7 @@ kubectl create secret tls tls-secret --cert=server.pem --key=server-key.pem
 ```
 
 In order to use mTLS, the RabbitMQ nodes must trust a Certificate Authority which has signed the public certificates of any clients which try to connect.
-You must create a Secret containing the CA's public certificate so that the RabbitMQ nodes know to trust any certifiates signed by the CA.
+You must create a Secret containing the CA's public certificate so that the RabbitMQ nodes know to trust any certificates signed by the CA.
 Assuming the CA's certificate is accessible as `ca.pem`, you can create this Secret by running:
 
 ```shell

--- a/docs/examples/production-ready/README.md
+++ b/docs/examples/production-ready/README.md
@@ -6,7 +6,7 @@ Please keep in mind that:
 
 1. It may not be suitable for YOUR production deployment. Please go through the [Production Checklist](https://www.rabbitmq.com/production-checklist.html) to learn more about production deployment considerations.
 
-2. While it is important to correctly deploy RabbitMQ cluster for production deployment, it is even more important to correctly use RabbitMQ from your applications. [Production Checklist](https://www.rabbitmq.com/production-checklist.html) covers some of the common issues such as connection churn and polling cunsumers. Please also consider using [Quorum Queues](https://www.rabbitmq.com/quorum-queues.html) since they provide better data safety.
+2. While it is important to correctly deploy RabbitMQ cluster for production deployment, it is even more important to correctly use RabbitMQ from your applications. [Production Checklist](https://www.rabbitmq.com/production-checklist.html) covers some of the common issues such as connection churn and polling consumers. Please also consider using [Quorum Queues](https://www.rabbitmq.com/quorum-queues.html) since they provide better data safety.
 
 You can deploy this example like this:
 

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -709,7 +709,7 @@ var _ = Describe("StatefulSet", func() {
 
 			It("opens tls ports when mqtt and stomp are configured", func() {
 				instance.Spec.TLS.SecretName = "tls-secret"
-				instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{rabbitmqv1beta1.Plugin("rabbitmq_mqtt"), rabbitmqv1beta1.Plugin("rabbitmq_stomp")}
+				instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_mqtt", "rabbitmq_stomp"}
 				Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 
 				rabbitmqContainerSpec := extractContainer(statefulSet.Spec.Template.Spec.Containers, "rabbitmq")
@@ -730,7 +730,7 @@ var _ = Describe("StatefulSet", func() {
 				It("opens tls ports when rabbitmq_web_mqtt and rabbitmq_web_stomp are configured", func() {
 					instance.Spec.TLS.SecretName = "tls-secret"
 					instance.Spec.TLS.CaSecretName = "tls-secret"
-					instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{rabbitmqv1beta1.Plugin("rabbitmq_web_mqtt"), rabbitmqv1beta1.Plugin("rabbitmq_web_stomp")}
+					instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_web_mqtt", "rabbitmq_web_stomp"}
 					Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 
 					rabbitmqContainerSpec := extractContainer(statefulSet.Spec.Template.Spec.Containers, "rabbitmq")
@@ -812,7 +812,7 @@ var _ = Describe("StatefulSet", func() {
 				})
 
 				It("disables non tls ports for mqtt and stomp when configured", func() {
-					instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{rabbitmqv1beta1.Plugin("rabbitmq_mqtt"), rabbitmqv1beta1.Plugin("rabbitmq_stomp")}
+					instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_mqtt", "rabbitmq_stomp"}
 					Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 
 					rabbitmqContainerSpec := extractContainer(statefulSet.Spec.Template.Spec.Containers, "rabbitmq")

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Status", func() {
 				"Actual transition time %v is before Expected transition time %v", someCondition.LastTransitionTime, someConditionTime)
 		})
 
-		It("preserves the status and transtion time", func() {
+		It("preserves the status and transition time", func() {
 			someCondition.UpdateState("some-status")
 			Expect(someCondition.Status).To(Equal(corev1.ConditionStatus("some-status")))
 			Expect(someCondition.LastTransitionTime).To(Equal(someConditionTime))

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -176,9 +176,11 @@ cluster_keepalive_interval = 10000`
 
 				// verify that rabbitmq.conf contains provided configurations
 				cfgMap := getConfigFileFromPod(namespace, cluster, "/etc/rabbitmq/rabbitmq.conf")
-				Expect(cfgMap).To(HaveKeyWithValue("vm_memory_high_watermark_paging_ratio", "0.5"))
-				Expect(cfgMap).To(HaveKeyWithValue("cluster_keepalive_interval", "10000"))
-				Expect(cfgMap).To(HaveKeyWithValue("cluster_partition_handling", "ignore"))
+				Expect(cfgMap).To(SatisfyAll(
+					HaveKeyWithValue("vm_memory_high_watermark_paging_ratio", "0.5"),
+					HaveKeyWithValue("cluster_keepalive_interval", "10000"),
+					HaveKeyWithValue("cluster_partition_handling", "ignore"),
+				))
 			})
 
 			By("updating the advanced.config file when advancedConfig are modified", func() {

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -445,7 +445,7 @@ func newRabbitmqCluster(namespace, instanceName string) *rabbitmqv1beta1.Rabbitm
 	}
 	if secret := os.Getenv("RABBITMQ_IMAGE_PULL_SECRET"); secret != "" {
 		cluster.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
-			corev1.LocalObjectReference{Name: secret},
+			{Name: secret},
 		}
 	}
 


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Some small refactors that:
* removes redundant type conversion
* fixes typos
* use SatisfyAll when three or more `Expect` on the same object

## Additional Context

## Local Testing

Have run unit and integration tests
