### PR TITLE
Use logger from context in Reconcile()

### DIFF
--- a/controllers/reconcile_cli.go
+++ b/controllers/reconcile_cli.go
@@ -103,9 +103,7 @@ func (r *RabbitmqClusterReconciler) runSetPluginsCommand(ctx context.Context, rm
 			return err
 		}
 	}
-	logger.Info("successfully set plugins",
-		"namespace", rmq.Namespace,
-		"name", rmq.Name)
+	logger.Info("successfully set plugins")
 	return r.deleteAnnotation(ctx, configMap, pluginsUpdateAnnotation)
 }
 

--- a/controllers/reconcile_finalizer.go
+++ b/controllers/reconcile_finalizer.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/go-logr/logr"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"
 	appsv1 "k8s.io/api/apps/v1"
@@ -36,7 +37,7 @@ func (r *RabbitmqClusterReconciler) removeFinalizer(ctx context.Context, rabbitm
 	return nil
 }
 
-func (r *RabbitmqClusterReconciler) prepareForDeletion(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
+func (r *RabbitmqClusterReconciler) prepareForDeletion(ctx context.Context, logger logr.Logger, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
 	if controllerutil.ContainsFinalizer(rabbitmqCluster, deletionFinalizer) {
 		if err := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 			sts := &appsv1.StatefulSet{
@@ -58,11 +59,11 @@ func (r *RabbitmqClusterReconciler) prepareForDeletion(ctx context.Context, rabb
 
 			return nil
 		}); err != nil {
-			r.Log.Error(err, "RabbitmqCluster deletion")
+			logger.Error(err, "RabbitmqCluster deletion")
 		}
 
 		if err := r.removeFinalizer(ctx, rabbitmqCluster); err != nil {
-			r.Log.Error(err, "Failed to remove finalizer for deletion")
+			logger.Error(err, "Failed to remove finalizer for deletion")
 			return err
 		}
 	}

--- a/controllers/reconcile_rabbitmq_configurations.go
+++ b/controllers/reconcile_rabbitmq_configurations.go
@@ -3,8 +3,9 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"github.com/go-logr/logr"
 	"time"
+
+	"github.com/go-logr/logr"
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"
@@ -65,7 +66,7 @@ func (r *RabbitmqClusterReconciler) annotateIfNeeded(ctx context.Context, logger
 
 	if err := r.updateAnnotation(ctx, obj, rmq.Namespace, objName, annotationKey, time.Now().Format(time.RFC3339)); err != nil {
 		msg := "failed to annotate " + objName
-		logger.Error(err, msg, "namespace", rmq.Namespace)
+		logger.Error(err, msg)
 		r.Recorder.Event(rmq, corev1.EventTypeWarning, "FailedUpdate", msg)
 		return err
 	}

--- a/controllers/reconcile_tls.go
+++ b/controllers/reconcile_tls.go
@@ -38,7 +38,7 @@ func (r *RabbitmqClusterReconciler) checkTLSSecrets(ctx context.Context, rabbitm
 	if err := r.Get(ctx, types.NamespacedName{Namespace: rabbitmqCluster.Namespace, Name: secretName}, secret); err != nil {
 		r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError",
 			fmt.Sprintf("Failed to get TLS secret %s in namespace %s: %v", secretName, rabbitmqCluster.Namespace, err.Error()))
-		logger.Error(err, "Error setting up TLS", "namespace", rabbitmqCluster.Namespace, "name", rabbitmqCluster.Name)
+		logger.Error(err, "Error setting up TLS")
 		return err
 	}
 	// check if secret has the right keys

--- a/controllers/reconcile_tls.go
+++ b/controllers/reconcile_tls.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/go-logr/logr"
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -10,32 +11,32 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (r *RabbitmqClusterReconciler) reconcileTLS(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
+func (r *RabbitmqClusterReconciler) reconcileTLS(ctx context.Context, logger logr.Logger, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
 	if rabbitmqCluster.DisableNonTLSListeners() && !rabbitmqCluster.TLSEnabled() {
 		err := errors.NewBadRequest("TLS must be enabled if disableNonTLSListeners is set to true")
 		r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError", err.Error())
-		r.Log.Error(err, "Error setting up TLS", "namespace", rabbitmqCluster.Namespace, "name", rabbitmqCluster.Name)
+		logger.Error(err, "Error setting up TLS")
 		return err
 	}
 
 	if rabbitmqCluster.TLSEnabled() {
-		if err := r.checkTLSSecrets(ctx, rabbitmqCluster); err != nil {
+		if err := r.checkTLSSecrets(ctx, logger, rabbitmqCluster); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (r *RabbitmqClusterReconciler) checkTLSSecrets(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
+func (r *RabbitmqClusterReconciler) checkTLSSecrets(ctx context.Context, logger logr.Logger, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
 	secretName := rabbitmqCluster.Spec.TLS.SecretName
-	r.Log.Info("TLS enabled, looking for secret", "secret", secretName, "namespace", rabbitmqCluster.Namespace)
+	logger.Info("TLS enabled, looking for secret", "secret", secretName)
 
 	// check if secret exists
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: rabbitmqCluster.Namespace, Name: secretName}, secret); err != nil {
 		r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError",
 			fmt.Sprintf("Failed to get TLS secret %s in namespace %s: %v", secretName, rabbitmqCluster.Namespace, err.Error()))
-		r.Log.Error(err, "Error setting up TLS", "namespace", rabbitmqCluster.Namespace, "name", rabbitmqCluster.Name)
+		logger.Error(err, "Error setting up TLS", "namespace", rabbitmqCluster.Namespace, "name", rabbitmqCluster.Name)
 		return err
 	}
 	// check if secret has the right keys
@@ -44,7 +45,7 @@ func (r *RabbitmqClusterReconciler) checkTLSSecrets(ctx context.Context, rabbitm
 	if !hasTLSCert || !hasTLSKey {
 		err := errors.NewBadRequest(fmt.Sprintf("TLS secret %s in namespace %s does not have the fields tls.crt and tls.key", secretName, rabbitmqCluster.Namespace))
 		r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError", err.Error())
-		r.Log.Error(err, "Error setting up TLS", "namespace", rabbitmqCluster.Namespace, "name", rabbitmqCluster.Name)
+		logger.Error(err, "Error setting up TLS")
 		return err
 	}
 
@@ -52,14 +53,14 @@ func (r *RabbitmqClusterReconciler) checkTLSSecrets(ctx context.Context, rabbitm
 	if rabbitmqCluster.MutualTLSEnabled() {
 		if !rabbitmqCluster.SingleTLSSecret() {
 			secretName := rabbitmqCluster.Spec.TLS.CaSecretName
-			r.Log.Info("mutual TLS enabled, looking for CA certificate secret", "secret", secretName, "namespace", rabbitmqCluster.Namespace)
+			logger.Info("mutual TLS enabled, looking for CA certificate secret", "secret", secretName)
 
 			// check if secret exists
 			secret = &corev1.Secret{}
 			if err := r.Get(ctx, types.NamespacedName{Namespace: rabbitmqCluster.Namespace, Name: secretName}, secret); err != nil {
 				r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError",
 					fmt.Sprintf("Failed to get CA certificate secret %v in namespace %v: %v", secretName, rabbitmqCluster.Namespace, err.Error()))
-				r.Log.Error(err, "Error setting up TLS", "namespace", rabbitmqCluster.Namespace, "name", rabbitmqCluster.Name)
+				logger.Error(err, "Error setting up TLS")
 				return err
 			}
 		}
@@ -68,7 +69,7 @@ func (r *RabbitmqClusterReconciler) checkTLSSecrets(ctx context.Context, rabbitm
 		if _, hasCaCert := secret.Data["ca.crt"]; !hasCaCert {
 			err := errors.NewBadRequest(fmt.Sprintf("TLS secret %s in namespace %s does not have the field ca.crt", rabbitmqCluster.Spec.TLS.CaSecretName, rabbitmqCluster.Namespace))
 			r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError", err.Error())
-			r.Log.Error(err, "Error setting up TLS", "namespace", rabbitmqCluster.Namespace, "name", rabbitmqCluster.Name)
+			logger.Error(err, "Error setting up TLS")
 			return err
 		}
 	}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -102,7 +102,6 @@ func startManager(scheme *runtime.Scheme) context.CancelFunc {
 	fakeExecutor = &fakePodExecutor{}
 	reconciler := &controllers.RabbitmqClusterReconciler{
 		Client:      client,
-		Log:         ctrl.Log.WithName(controllerName),
 		Scheme:      mgr.GetScheme(),
 		Recorder:    mgr.GetEventRecorderFor(controllerName),
 		Namespace:   "rabbitmq-system",

--- a/main.go
+++ b/main.go
@@ -102,7 +102,6 @@ func main() {
 
 	err = (&controllers.RabbitmqClusterReconciler{
 		Client:        mgr.GetClient(),
-		Log:           ctrl.Log.WithName(controllerName),
 		Scheme:        mgr.GetScheme(),
 		Recorder:      mgr.GetEventRecorderFor(controllerName),
 		Namespace:     operatorNamespace,


### PR DESCRIPTION
Relates to previous PR: #542 

## Summary Of Changes

With controller-runtime 0.7, Reconcile() takes a context.Context object with a logger. The logger is pre populated with controller name, gvk, object name and namespace. Operator using this logger reduces redundancy because operator no longer needs to create its own logger and it doesn't need to include rmq name and namespace manually in every single log.

Before this change, a sample log could look like: 
```
2021-01-07T12:46:12.232Z	INFO	rabbitmqcluster-controller	Finished reconciling RabbitmqCluster	{“namespace”: “rabbitmq-system”, “name”: “sample”}
```

After this change, the same log will look like:
```
2021-01-07T16:27:38.661Z	INFO	controller-runtime.manager.controller.rabbitmqcluster	Finished reconciling	{"reconciler group": "rabbitmq.com", "reconciler kind": "RabbitmqCluster", "name": "sample", "namespace": "rabbitmq-system"}
```

## Additional Context

Related controller runtime PR: https://github.com/kubernetes-sigs/controller-runtime/pull/1054

## Local Testing

Unit, integration, and system tests all passed.