### PR TITLE
Make logger configurable

### DIFF
--- a/config/default/overlays/dev/manager_image_patch.yaml
+++ b/config/default/overlays/dev/manager_image_patch.yaml
@@ -17,3 +17,4 @@ spec:
       - image: ((operator_docker_image))
         name: operator
         imagePullPolicy: Always
+        args: ["--zap-devel"]

--- a/config/default/overlays/kind/manager_image_patch.yaml
+++ b/config/default/overlays/kind/manager_image_patch.yaml
@@ -17,3 +17,4 @@ spec:
       - image: ((operator_docker_image))
         name: operator
         imagePullPolicy: IfNotPresent
+        args: ["--zap-devel"]

--- a/main.go
+++ b/main.go
@@ -45,9 +45,13 @@ func init() {
 func main() {
 	var metricsAddr string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":12345", "The address the metric endpoint binds to.")
+
+	opts := zap.Options{}
+	opts.BindFlags(flag.CommandLine)
+
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	operatorNamespace := os.Getenv("OPERATOR_NAMESPACE")
 	if operatorNamespace == "" {


### PR DESCRIPTION
Before this PR, the cluster operator always used a hard-coded logger dev mode, even in production.

After this PR, the logger is prod mode by default.
This means from now on, by default, the logger will log at `Info` level and output JSON.

When developing locally deploying the operator using `make deploy-dev` and `make deploy-kind`, the logger will use dev mode.

Furthermore, users can now configure more zap flags (see https://github.com/kubernetes-sigs/controller-runtime/blob/66537ca5b7439b06f2f3b08901640f934834c9a1/pkg/log/zap/zap.go#L227-L233)

For example, they can set the log level as follows:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
 ...
spec:
 ...
    spec:
      containers:
      - name: operator
        command:
        - /manager
        args:
        - zap-log-level=error
```

This resolves #551.

For more context, read https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/.