### PR TITLE
Change default operator metrics port

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func init() {
 
 func main() {
 	var metricsAddr string
-	flag.StringVar(&metricsAddr, "metrics-addr", ":12345", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-addr", ":9782", "The address the metric endpoint binds to.")
 
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)


### PR DESCRIPTION
The new port matches the one listed in https://github.com/prometheus/prometheus/wiki/Default-port-allocations.