### PR TITLE
Add versioning to autogenerated API docs

### DIFF
--- a/.github/workflows/publish-versioned-api-ref.yml
+++ b/.github/workflows/publish-versioned-api-ref.yml
@@ -1,0 +1,38 @@
+name: "Publish Versioned API Reference Wiki page"
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish-versioned-api-reference:
+    name: Publish Versioned API Reference Wiki
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout operator codebase
+        uses: actions/checkout@v2
+        with:
+          path: cluster-operator
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Checkout wiki codebase
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki
+      - name: Push to wiki
+        run: |
+          cd wiki
+          git config --local user.email "github-actions@github.com"
+          git config --local user.name "github-actions"
+          # Add the versioned API Reference to the Wiki
+          cp ../cluster-operator/docs/api/rabbitmq.com.ref.asciidoc ./API_Reference_${{ steps.get_version.outputs.VERSION }}.asciidoc
+          # Regenerate the ordered list of API Reference docs for the sidebar
+          export REGENERATED_SIDEBAR="$(../cluster-operator/hack/generate-ordered-api-reference-list.sh .)"
+          echo "$REGENERATED_SIDEBAR" > Wiki_Sidebar.md
+          git add ./API_Reference_${{ steps.get_version.outputs.VERSION }}.asciidoc
+          git add ./Wiki_Sidebar.md
+          git commit -m "Publish version ${{ steps.get_version.outputs.VERSION }} API Reference" && git push

--- a/.github/workflows/update-latest-api-ref.yml
+++ b/.github/workflows/update-latest-api-ref.yml
@@ -1,4 +1,4 @@
-name: "Update API Reference Wiki page"
+name: "Update Latest API Reference Wiki page"
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update-api-reference:
-    name: Update API Reference Wiki
+    name: Update Latest API Reference Wiki
     runs-on: ubuntu-latest
 
     steps:
@@ -24,6 +24,7 @@ jobs:
           cd wiki
           git config --local user.email "github-actions@github.com"
           git config --local user.name "github-actions"
+          # Update the latest API Reference Doc
           cp ../cluster-operator/docs/api/rabbitmq.com.ref.asciidoc ./API_Reference.asciidoc
-          git add .
-          git diff-index --quiet HEAD || git commit -m "Update API Reference" && git push
+          git add ./API_Reference.asciidoc
+          git diff-index --quiet HEAD || git commit -m "Update Latest API Reference" && git push

--- a/hack/generate-ordered-api-reference-list.sh
+++ b/hack/generate-ordered-api-reference-list.sh
@@ -5,11 +5,11 @@ set -euo pipefail
 wikiDir=$1
 
 generateVersionedEntry() {
-  echo "* [$1](https://github.com/rabbitmq/cluster-operator/wiki/API_Reference_$1.asciidoc)"
+  echo "* [$1](https://github.com/rabbitmq/cluster-operator/wiki/API_Reference_$1)"
 }
 
 generateLatestEntry() {
-  echo "* [Latest](https://github.com/rabbitmq/cluster-operator/wiki/API_Reference.asciidoc)"
+  echo "* [Latest](https://github.com/rabbitmq/cluster-operator/wiki/API_Reference)"
 }
 
 lead='^<!--- BEGIN API REFERENCE LIST -->$'

--- a/hack/generate-ordered-api-reference-list.sh
+++ b/hack/generate-ordered-api-reference-list.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+wikiDir=$1
+
+generateVersionedEntry() {
+  echo "* [$1](https://github.com/rabbitmq/cluster-operator/wiki/API_Reference_$1.asciidoc)"
+}
+
+generateLatestEntry() {
+  echo "* [Latest](https://github.com/rabbitmq/cluster-operator/wiki/API_Reference.asciidoc)"
+}
+
+lead='^<!--- BEGIN API REFERENCE LIST -->$'
+tail='^<!--- END API REFERENCE LIST -->$'
+
+unorderedlistfile="$(mktemp)"
+orderedlistfile="$(mktemp)"
+
+apiVersions="$(find $wikiDir/API_Reference_* -printf "%f\n" | sed -r 's/API_Reference_(v[0-9]+.[0-9]+.[0-9]+).asciidoc/\1/' | sort -Vr )"
+for version in $apiVersions
+do
+  echo "$(generateVersionedEntry $version)" >> $unorderedlistfile
+done
+
+# Latest API version is a special case, that is always top of the list
+generateLatestEntry > $orderedlistfile
+cat $unorderedlistfile >> $orderedlistfile
+
+sed -e "/$lead/,/$tail/{ /$lead/{p; r $orderedlistfile
+}; /$tail/p; d }"  "$wikiDir/Wiki_Sidebar.md"


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

This PR changes the API Reference Doc generation to be more version-aware.

On every push to main:
The 'Latest' version of the Doc will be updated if changed.

On every semantic version tag of the repo:
A new versioned API doc is created, of the name `API_Reference_vx.y.z.asciidoc`.
The Wiki sidebar is regenerated to contain all versions of the API reference, in version order, with Latest at the top.

It's likely easier to see rather than read all of this, so I did a quick demo on the fork used for this PR:

![image](https://user-images.githubusercontent.com/23215294/104611413-fb7ae200-567c-11eb-86ad-863b0b4dc62c.png)

[Example Latest Ref Doc](https://github.com/rabbitmq/cluster-operator/wiki/API_Reference)
[Example Versioned Ref Doc](https://github.com/rabbitmq/cluster-operator/wiki/API_Reference_v1.2.0)
[Example Sidebar](https://github.com/rabbitmq/cluster-operator/wiki/Wiki_Sidebar)

