### PR TITLE
Make tests 🥑

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,8 +18,7 @@ jobs:
     - name: Integration tests
       run: make integration-tests
     - name: Helm chart tests
-      working-directory: charts/rabbitmq
-      run: ./test.sh
+      run: make chart-tests
 
   test-all-examples:
     name: test-all-examples

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,16 @@ kind-unprepare:  ## Remove KIND support for LoadBalancer services
 system-tests: install-tools ## run end-to-end tests against Kubernetes cluster defined in ~/.kube/config
 	NAMESPACE="rabbitmq-system" ginkgo -nodes=3 -randomizeAllSpecs -r system_tests/
 
+chart-tests:
+	echo "running charts tests"
+	pushd charts/rabbitmq && ./test.sh && popd
+
+kubectl-plugin-tests:
+	echo "running kubectl plugin tests"
+	./bin/kubectl-rabbitmq.bats
+
+tests: unit-tests integration-tests system-tests chart-tests kubectl-plugin-tests
+
 docker-registry-secret: check-env-docker-credentials operator-namespace
 	echo "creating registry secret and patching default service account"
 	@kubectl -n $(K8S_OPERATOR_NAMESPACE) create secret docker-registry $(DOCKER_REGISTRY_SECRET) --docker-server='$(DOCKER_REGISTRY_SERVER)' --docker-username="$$DOCKER_REGISTRY_USERNAME" --docker-password="$$DOCKER_REGISTRY_PASSWORD" || true

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ system-tests: install-tools ## run end-to-end tests against Kubernetes cluster d
 
 chart-tests:
 	echo "running charts tests"
-	pushd charts/rabbitmq && ./test.sh && popd
+	cd charts/rabbitmq && ./test.sh
 
 kubectl-plugin-tests:
 	echo "running kubectl plugin tests"


### PR DESCRIPTION
This closes #446

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Added new make targets: `make chart-tests`, `make kubectl-plugin-tests`, and `make tests` which runs unit, integration, system, chart, and plugin tests

- Use these new make target in PR workflow
- 
## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
