### PR TITLE
Deploy with rmq 3.8.10 by default

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,7 +48,7 @@ jobs:
         rabbitmq-image:
         - rabbitmq:3.8.8-management
         - rabbitmq:3.8.9-management
-        - rabbitmq:3.8-rc-management
+        - rabbitmq:3.8.10-management
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.8.9` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.17` or newer.
+The operator deploys RabbitMQ `3.8.10` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.17` or newer.
 
 ## Versioning
 

--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -51,7 +51,7 @@ type RabbitmqClusterSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster.
 	// Must be provided together with ImagePullSecrets in order to use an image in a private registry.
-	// +kubebuilder:default:="rabbitmq:3.8.9-management"
+	// +kubebuilder:default:="rabbitmq:3.8.10-management"
 	Image string `json:"image,omitempty"`
 	// List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -474,7 +474,7 @@ func generateRabbitmqClusterObject(clusterName string) *RabbitmqCluster {
 		},
 		Spec: RabbitmqClusterSpec{
 			Replicas:                      pointer.Int32Ptr(1),
-			Image:                         "rabbitmq:3.8.9-management",
+			Image:                         "rabbitmq:3.8.10-management",
 			TerminationGracePeriodSeconds: pointer.Int64Ptr(604800),
 			Service: RabbitmqClusterServiceSpec{
 				Type: "ClusterIP",

--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -22,7 +22,7 @@ USAGE:
     kubectl rabbitmq install-cluster-operator
 
   Create a RabbitMQ custom resource - INSTANCE name required, all other flags optional
-    kubectl rabbitmq create INSTANCE --replicas 1 --service ClusterIP --image rabbitmq:3.8.9-management --image-pull-secret mysecret
+    kubectl rabbitmq create INSTANCE --replicas 1 --service ClusterIP --image rabbitmq:3.8.10-management --image-pull-secret mysecret
       --tls-secret secret-name --storage-class mystorageclass
 
   Get a RabbitMQ custom resource and dependant objects

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -11,7 +11,7 @@ name: rabbitmq
 description: RabbitMQ Cluster
 apiVersion: v2
 version: 0.9.0
-appVersion: 3.8.9
+appVersion: 3.8.10
 keywords:
   - rabbitmq
   - message queue

--- a/charts/rabbitmq/example-configurations.yaml
+++ b/charts/rabbitmq/example-configurations.yaml
@@ -17,7 +17,7 @@ annotations:
 
 replicas: 3
 
-image: "rabbitmq:3.8.9-management"
+image: "rabbitmq:3.8.10-management"
 
 imagePullSecrets:
   - name: foo

--- a/charts/rabbitmq/expected-template-output
+++ b/charts/rabbitmq/expected-template-output
@@ -20,7 +20,7 @@ metadata:
     annotation2: bar
 
 spec:
-  image: rabbitmq:3.8.9-management
+  image: rabbitmq:3.8.10-management
   imagePullSecrets:
   - name: foo
   replicas: 3

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -389,7 +389,7 @@ spec:
                       type: object
                   type: object
                 image:
-                  default: rabbitmq:3.8.9-management
+                  default: rabbitmq:3.8.10-management
                   description: Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster. Must be provided together with ImagePullSecrets in order to use an image in a private registry.
                   type: string
                 imagePullSecrets:


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Deploy with rmq 3.8.10 by default
- Change PR github action check to test on `3.8.8`, `3.8.9`, and `3.8.10`


## Additional Context

