### PR TITLE
Set podManagementPolicy to parallel

### DIFF
--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -34,7 +34,9 @@ cluster_formation.k8s.host = kubernetes.default
 cluster_formation.k8s.address_type = hostname
 cluster_partition_handling = pause_minority
 queue_master_locator = min-masters
-disk_free_limit.absolute = 2GB`
+disk_free_limit.absolute = 2GB
+cluster_formation.randomized_startup_delay_range.min = 5
+cluster_formation.randomized_startup_delay_range.max = 30`
 
 	defaultTLSConf = `
 ssl_options.certfile = /etc/rabbitmq-tls/tls.crt

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -33,6 +33,8 @@ cluster_formation.k8s.address_type       = hostname
 cluster_partition_handling               = pause_minority
 queue_master_locator                     = min-masters
 disk_free_limit.absolute                 = 2GB
+cluster_formation.randomized_startup_delay_range.min = 5
+cluster_formation.randomized_startup_delay_range.max = 30
 cluster_name                             = ` + instanceName)
 }
 

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -66,6 +66,7 @@ func (builder *StatefulSetBuilder) Build() (client.Object, error) {
 				MatchLabels: metadata.LabelSelector(builder.Instance.Name),
 			},
 			VolumeClaimTemplates: pvc,
+			PodManagementPolicy:  appsv1.ParallelPodManagement,
 		},
 	}
 

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -65,6 +65,7 @@ var _ = Describe("StatefulSet", func() {
 
 			Expect(statefulSet.Spec.ServiceName).To(Equal(instance.ChildResourceName("nodes")))
 		})
+
 		It("adds the correct label selector", func() {
 			obj, err := stsBuilder.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -74,7 +75,15 @@ var _ = Describe("StatefulSet", func() {
 			Expect(labels["app.kubernetes.io/name"]).To(Equal(instance.Name))
 		})
 
-		It("references the storageclassname when specified", func() {
+		It("sets pod management policy to 'Parallel' ", func() {
+			obj, err := stsBuilder.Build()
+			Expect(err).NotTo(HaveOccurred())
+			statefulSet := obj.(*appsv1.StatefulSet)
+
+			Expect(statefulSet.Spec.PodManagementPolicy).To(Equal(appsv1.ParallelPodManagement))
+		})
+
+		It("references the storage class name when specified", func() {
 			storageClassName := "my-storage-class"
 			builder.Instance.Spec.Persistence.StorageClassName = &storageClassName
 


### PR DESCRIPTION
This closes #298 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Use cluster_formation.randomized_startup_delay_range to avoid race condition between nodes during [initial cluster formation](https://www.rabbitmq.com/cluster-formation.html#initial-formation-race-condition)
- This change solves the problem of failing to restart the cluster when all pods are deleted and recreated at once; with podManagementPolicy set to 'OrderedReady', pod 0 is also the first one getting recreated, but it may not be the last node to shut down. This problem was first reported in [community slack](https://rabbitmq.slack.com/archives/CTMSV81HA/p1609882247391800?thread_ts=1609802102.387100&cid=CTMSV81HA)

## Additional Context

I've chosen (5, 30) as the delayed range. In my test it has worked (no failures at creation for 15 runs of 5 nodes clusters). Setting a broader range can lower the chance of nodes joining at the same time, but increase startup time and may lead to readiness probe report 'failing'. If we would like to set a broader range, I suggest increase the readiness probe `InitialDelaySeconds`, which is currently set to 10s. Feel free to suggest a different range in this PR.

## Impact of this change

**Upgrade**
No impact since  `spec.updateStrategy` is set to `RollingUpdate` with partition 0.

**Creation and deletion of cluster**
In parallel. For creation, `cluster_formation.randomized_startup_delay_range` is used to prevent race condition between nodes.

**Scale up**
New pods get created in parallel, but because of `randomized_startup_delay`, they won't join at the same time and there is no race condition.

**Scale down**
Note: scaling down is not currently supported, but it's on our roadmap.
Scale down with `podManagementPolicy: parallel` can cause data loss. In my initial experiment, which a 5 nodes rmq cluster with a mirrored queue, primary and replica,  located in pod 3 and pod 4, this queue is lost after scaling down from 5 node to 3 node. `rabbitmq-upgrade await_online_synchronized_mirror` in `preStop` hook won't help prevent this problem.
