### PR TITLE
Add support for -n/-A to select namespace(s)

### DIFF
--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -271,12 +271,14 @@ install_cluster_operator() {
 main() {
     if [[ "$1" == "--help" ]]; then
         usage
+        exit 0
     fi
 
     while getopts ':n:Ah' opt; do
         case "${opt}" in
         h)
             usage
+            exit 0
             ;;
         A)
             NAMESPACE="--all-namespaces"

--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -10,59 +10,62 @@
 
 set -euo pipefail
 
+NAMESPACE=""
+
 instance=""
 username=""
 password=""
 service=""
 
 usage() {
-  usage=$(cat <<-END
+    usage=$(
+        cat <<-END
 USAGE:
   Install (latest released) RabbitMQ Cluster Operator
     kubectl rabbitmq install-cluster-operator
 
   Create a RabbitMQ custom resource - INSTANCE name required, all other flags optional
-    kubectl rabbitmq create INSTANCE --replicas 1 --service ClusterIP --image rabbitmq:3.8.10-management --image-pull-secret mysecret
+    kubectl rabbitmq [-n NAMESPACE] create INSTANCE --replicas 1 --service ClusterIP --image rabbitmq:3.8.10-management --image-pull-secret mysecret
       --tls-secret secret-name --storage-class mystorageclass
 
   Get a RabbitMQ custom resource and dependant objects
-    kubectl rabbitmq get INSTANCE
+    kubectl rabbitmq [-n NAMESPACE | -A] get INSTANCE
 
   List all RabbitMQ clusters
-    kubectl rabbitmq list
+    kubectl rabbitmq [-n NAMESPACE | -A] list
 
   Delete a RabbitMQ cluster (or multiple clusters)
-    kubectl rabbitmq delete INSTANCE ...
+    kubectl rabbitmq [-n NAMESPACE] delete INSTANCE ...
 
   Print default-user secrets for an instance
-    kubectl rabbitmq secrets INSTANCE
+    kubectl rabbitmq [-n NAMESPACE] secrets INSTANCE
 
   Open Management UI for an instance
-    kubectl rabbitmq manage INSTANCE
+    kubectl rabbitmq [-n NAMESPACE] manage INSTANCE
 
   Set log level to 'debug' on all nodes
-    kubectl rabbitmq debug INSTANCE
+    kubectl rabbitmq [-n NAMESPACE] debug INSTANCE
 
   Tail logs from all nodes
-    kubectl rabbitmq tail INSTANCE
+    kubectl rabbitmq [-n NAMESPACE] tail INSTANCE
 
   Run 'rabbitmq-diagnostics observer' on a specific INSTANCE NODE
-    kubectl rabbitmq observe INSTANCE 0
+    kubectl rabbitmq [-n NAMESPACE] observe INSTANCE 0
 
   Enable all feature flags on an INSTANCE
-    kubectl rabbitmq enable-all-feature-flags INSTANCE
+    kubectl rabbitmq [-n NAMESPACE] enable-all-feature-flags INSTANCE
 
   Pause reconciliation for an instance
-    kubectl rabbitmq pause-reconciliation INSTANCE
+    kubectl rabbitmq [-n NAMESPACE] pause-reconciliation INSTANCE
 
   Resume reconciliation for an instance
-    kubectl rabbitmq resume-reconciliation INSTANCE
+    kubectl rabbitmq [-n NAMESPACE] resume-reconciliation INSTANCE
 
   List all instances that has the pause reconciliation label
-    kubectl rabbitmq list-pause-reconciliation-instances
+    kubectl rabbitmq [-n NAMESPACE | -A] list-pause-reconciliation-instances
 
   Run perf-test against an instance - you can pass as many perf test parameters as you want
-    kubectl rabbitmq perf-test INSTANCE --rate 100
+    kubectl rabbitmq [-n NAMESPACE] perf-test INSTANCE --rate 100
   If you want to monitor perf-test, create the following ServiceMonitor:
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
@@ -82,8 +85,8 @@ USAGE:
   Print kubectl-rabbitmq plugin version
     kubectl rabbitmq version
 END
-)
-  echo "$usage"
+    )
+    echo "$usage"
 }
 
 version() {
@@ -112,8 +115,8 @@ version() {
 
 get_instance_details() {
     instance=${1}
-    username=$(kubectl get secret "${instance}-default-user" -o jsonpath="{.data.username}" | base64 --decode)
-    password=$(kubectl get secret "${instance}-default-user" -o jsonpath="{.data.password}" | base64 --decode)
+    username=$(kubectl get ${NAMESPACE} secret "${instance}-default-user" -o jsonpath="{.data.username}" | base64 --decode)
+    password=$(kubectl get ${NAMESPACE} secret "${instance}-default-user" -o jsonpath="{.data.password}" | base64 --decode)
     service="$instance"
 }
 
@@ -122,7 +125,7 @@ perf_test() {
     shift 1
     perftestopts=$*
 
-    kubectl run perf-test \
+    kubectl ${NAMESPACE} run perf-test \
         --expose=true \
         --port=8080 \
         --labels="app=perf-test,run=perf-test" \
@@ -138,11 +141,11 @@ manage() {
         sleep 2
         open "http://localhost:15672/"
     ) &
-    kubectl port-forward "service/${service}" 15672
+    kubectl ${NAMESPACE} port-forward "service/${service}" 15672
 }
 
 list_rabbitmq_clusters() {
-    kubectl get rabbitmqclusters
+    kubectl get ${NAMESPACE} rabbitmqclusters
 }
 
 create() {
@@ -210,48 +213,48 @@ create() {
             ;;
         esac
     done
-    kubectl apply -f "$rabbitmq_manifest_file"
+    kubectl ${NAMESPACE} apply -f "$rabbitmq_manifest_file"
 }
 
 delete() {
     for cluster in "$@"; do
-        kubectl delete rabbitmqcluster "${cluster}"
+        kubectl ${NAMESPACE} delete rabbitmqcluster "${cluster}"
     done
 }
 
 observe() {
-    kubectl exec -it "${1}-server-${2}" -- rabbitmq-diagnostics observer
+    kubectl ${NAMESPACE} exec -it "${1}-server-${2}" -- rabbitmq-diagnostics observer
 }
 
 get() {
-    kubectl get pods,cm,sts,svc,secrets,rs -l "app.kubernetes.io/name=$1"
+    kubectl get ${NAMESPACE} pods,cm,sts,svc,secrets,rs -l "app.kubernetes.io/name=$1"
 }
 
 debug() {
-    for node in $(kubectl get pods -l "app.kubernetes.io/name=${1}" -ocustom-columns=name:.metadata.name --no-headers); do
+    for node in $(kubectl ${NAMESPACE} get pods -l "app.kubernetes.io/name=${1}" -ocustom-columns=name:.metadata.name --no-headers); do
         echo -n "${node}: "
-        kubectl exec "${node}" -- rabbitmqctl set_log_level debug
+        kubectl ${NAMESPACE} exec "${node}" -- rabbitmqctl set_log_level debug
     done
 }
 
 tail() {
-    kubectl tail --svc "${1}"
+    kubectl ${NAMESPACE} tail --svc "${1}"
 }
 
 enable_all_feature_flags() {
-    kubectl exec "${1}-server-0" -- bash -c "rabbitmqctl list_feature_flags | grep disabled | cut -f 1 | xargs -r -L1 rabbitmqctl enable_feature_flag"
+    kubectl ${NAMESPACE} exec "${1}-server-0" -- bash -c "rabbitmqctl list_feature_flags | grep disabled | cut -f 1 | xargs -r -L1 rabbitmqctl enable_feature_flag"
 }
 
 pause-reconciliation() {
-    kubectl label rabbitmqclusters "${1}" rabbitmq.com/pauseReconciliation=true
+    kubectl ${NAMESPACE} label rabbitmqclusters "${1}" rabbitmq.com/pauseReconciliation=true
 }
 
 resume-reconciliation() {
-    kubectl label rabbitmqclusters "${1}" rabbitmq.com/pauseReconciliation-
+    kubectl ${NAMESPACE} label rabbitmqclusters "${1}" rabbitmq.com/pauseReconciliation-
 }
 
 list-pause-reconciliation-instances() {
-    kubectl get rabbitmqclusters -l rabbitmq.com/pauseReconciliation=true --show-labels
+    kubectl get ${NAMESPACE} rabbitmqclusters -l rabbitmq.com/pauseReconciliation=true --show-labels
 }
 
 secrets() {
@@ -261,10 +264,33 @@ secrets() {
 }
 
 install_cluster_operator() {
-    kubectl apply -f https://github.com/rabbitmq/cluster-operator/releases/latest/download/cluster-operator.yml
+    kubectl ${NAMESPACE} apply -f https://github.com/rabbitmq/cluster-operator/releases/latest/download/cluster-operator.yml
 }
 
 main() {
+    if [[ "$1" == "--help" ]]; then
+        usage
+    fi
+
+    while getopts ':n:Ah' opt; do
+        case "${opt}" in
+        h)
+            usage
+            ;;
+        A)
+            NAMESPACE="--all-namespaces"
+            shift 1
+            ;;
+        n)
+            NAMESPACE="-n ${OPTARG}"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+        esac
+    done
+
     case "$1" in
     "perf-test")
         shift 1
@@ -381,18 +407,11 @@ main() {
     "help")
         usage
         ;;
-    "--help")
-        usage
-        ;;
-    "-h")
-        usage
-        ;;
     "version")
         version
         ;;
     *)
         usage
-        exit 1
         ;;
     esac
 }

--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -413,6 +413,7 @@ main() {
         ;;
     *)
         usage
+        exit 1
         ;;
     esac
 }

--- a/bin/kubectl-rabbitmq.bats
+++ b/bin/kubectl-rabbitmq.bats
@@ -75,13 +75,47 @@ eventually() {
   [[ $(kubectl get pvc persistence-bats-configured-server-0 -o jsonpath='{.spec.storageClassName}') == "$storage_class" ]]
 }
 
-@test "list lists all RabbitMQ clusters" {
+@test "list lists all RabbitMQ clusters in the current namespace" {
   run kubectl rabbitmq list
 
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" =~ ^NAME ]]
   [[ "${lines[1]}" =~ ^bats-configured ]]
   [[ "${lines[2]}" =~ ^bats-default ]]
+}
+
+@test "list supports -n NAMESPACE flag" {
+  CLUSTER_NAMESPACE="$(kubectl config view --minify --output 'jsonpath={..namespace}')"
+
+  kubectl create namespace kubectl-rabbitmq-tests
+  kubectl config set-context --current --namespace=kubectl-rabbitmq-tests
+
+  run kubectl rabbitmq -n "${CLUSTER_NAMESPACE}" list
+
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" =~ ^NAME ]]
+  [[ "${lines[1]}" =~ ^bats-configured ]]
+  [[ "${lines[2]}" =~ ^bats-default ]]
+
+  kubectl config set-context --current --namespace="${CLUSTER_NAMESPACE}"
+  kubectl delete namespace kubectl-rabbitmq-tests
+}
+
+@test "list supports -A flag" {
+  CLUSTER_NAMESPACE="$(kubectl config view --minify --output 'jsonpath={..namespace}')"
+
+  kubectl create namespace kubectl-rabbitmq-tests
+  kubectl config set-context --current --namespace=kubectl-rabbitmq-tests
+
+  run kubectl rabbitmq -A list
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"NAMESPACE"* ]]
+  [[ "$output" == *"bats-configured"* ]]
+  [[ "$output" == *"bats-default"* ]]
+
+  kubectl config set-context --current --namespace="${CLUSTER_NAMESPACE}"
+  kubectl delete namespace kubectl-rabbitmq-tests
 }
 
 @test "get gets child resources" {

--- a/bin/kubectl-rabbitmq.bats
+++ b/bin/kubectl-rabbitmq.bats
@@ -86,6 +86,8 @@ eventually() {
 
 @test "list supports -n NAMESPACE flag" {
   CLUSTER_NAMESPACE="$(kubectl config view --minify --output 'jsonpath={..namespace}')"
+  # if namespace is not set in kube config, take the default namespace
+  CLUSTER_NAMESPACE="${CLUSTER_NAMESPACE:=default}"
 
   kubectl create namespace kubectl-rabbitmq-tests
   kubectl config set-context --current --namespace=kubectl-rabbitmq-tests


### PR DESCRIPTION
You can now use `-n NAMESPACE` in most commands or `-A` in some to list
objects across namespaces.

Note: these flags need to be specified immediately after `kubectl
rabbitmq`. One day we'll probably rewrite the whole plugin in Go and it
will be easier to handle more flexible flag parsing.

This closes #579 
