### PR TITLE
Add help msg to install tail plugin in rabbitmq plugin

### DIFF
--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -45,6 +45,7 @@ USAGE:
 
   Tail logs from all nodes
     kubectl rabbitmq tail INSTANCE
+    'tail' subcommand requires the 'tail' plugin. You can install it with 'kubectl krew install tail'
 
   Run 'rabbitmq-diagnostics observer' on a specific INSTANCE NODE
     kubectl rabbitmq observe INSTANCE 0


### PR DESCRIPTION
This closes: #587 
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Add a message to remind people to install plugin `tail` in rabbitmq cli plugin help message. I had to Gblame to find the PR to find this particular requirement, not very user friendly.
