### PR TITLE
Fix import-definitions example

### DIFF
--- a/docs/examples/import-definitions/rabbitmq.yaml
+++ b/docs/examples/import-definitions/rabbitmq.yaml
@@ -12,7 +12,7 @@ spec:
             containers:
             - name: rabbitmq
               volumeMounts:
-              - mountPath: /path/to/exported/definitions.json
+              - mountPath: /imported_definitions
                 name: definitions
             volumes:
             - name: definitions
@@ -20,4 +20,5 @@ spec:
                 name: definitions # Name of the ConfigMap which contains definitions you wish to import
   rabbitmq:
     additionalConfig: |
-      load_definitions = /path/to/exported/definitions.json # Path to the mounted definitions file
+      # Path to the mounted definitions file (the file name must correspond to the key of the ConfigMap)
+      load_definitions = /imported_definitions/def.json


### PR DESCRIPTION
Prior to this PR, applying the example results in rabbitmq-server crashing with the following log:
```
2021-02-04 01:16:31.150 [info] <0.515.0> Applying definitions from directory /path/to/exported/definitions.json
2021-02-04 01:16:31.150 [error] <0.515.0> Could not read definitions from file at '/path/to/exported/definitions.json/..2021_02_04_01_16_06.207612518', error: eisdir
```