### PR TITLE
Test examples action should only apply YAML

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
         curl https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml | sed "s/replicas: 1$/replicas: 0/" | kubectl apply -f -
         make install
         sleep 3 # otherwise we sporadically observe 'no matches for kind "RabbitmqCluster" in version "rabbitmq.com/v1beta1'
-        kubectl apply --dry-run=server --recursive -f docs/examples/
+        find docs/examples/ -name "*.y*ml" -exec kubectl apply --dry-run=server -f {} \;
 
   system_tests:
     name: system tests


### PR DESCRIPTION
## Summary Of Changes

There are some JSON files in the examples related to RabbitMQ. Kubectl should not apply those JSON files because they don't contain Kubernetes manifests and would cause a failure in the action.

## Additional Context
Related to check errors in #590 
