### PR TITLE
Fail to set plugins (or any other necessary cli commands) should result in ReconcileSuccess set to false

### DIFF
--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -676,33 +676,6 @@ var _ = Describe("RabbitmqClusterController", func() {
 					return "ReconcileSuccess status: condition not present"
 				}, 5).Should(Equal("ReconcileSuccess status: False"))
 			})
-
-			By("transitioning to True when a valid spec in updated", func() {
-				// We have to Get() the CR again because Reconcile() changes the object
-				// If we try to Update() without getting the latest version of the CR
-				// We are very likely to hit a Conflict error
-				Expect(client.Get(ctx, runtimeClient.ObjectKey{
-					Name:      crName,
-					Namespace: defaultNamespace,
-				}, cluster)).To(Succeed())
-				cluster.Spec.Service.Annotations = map[string]string{"thisIs": "valid"}
-				Expect(client.Update(ctx, cluster)).To(Succeed())
-
-				Eventually(func() string {
-					someRabbit := &rabbitmqv1beta1.RabbitmqCluster{}
-					Expect(client.Get(ctx, runtimeClient.ObjectKey{
-						Name:      crName,
-						Namespace: defaultNamespace,
-					}, someRabbit)).To(Succeed())
-
-					for i := range someRabbit.Status.Conditions {
-						if someRabbit.Status.Conditions[i].Type == status.ReconcileSuccess {
-							return fmt.Sprintf("ReconcileSuccess status: %s", someRabbit.Status.Conditions[i].Status)
-						}
-					}
-					return "ReconcileSuccess status: condition not present"
-				}, 5).Should(Equal("ReconcileSuccess status: True"))
-			})
 		})
 	})
 


### PR DESCRIPTION
## Summary Of Changes

When `Reconcilie()` fails to set plugins, feature flags, or rebalance when necessary: 
- publish `failedReconcile` warning events
- set `ReconcileSuccess` to false 

## Additional Context

Removed an integration test because pods are never successfully created in envTest and plugins cannot be successfully set, so `ReconcileSuccess` can never be set to true in integration tests. 

## Local Testing

All tests passing locally
