### PR TITLE
Support PVC expansion 🤩 

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,7 +62,7 @@ jobs:
         make install-tools
         kind create cluster --image kindest/node:"$K8S_VERSION"
         DOCKER_REGISTRY_SERVER=local-server OPERATOR_IMAGE=local-operator make deploy-kind
-        make system-tests
+        SUPPORT_VOLUME_EXPANSION=false make system-tests
 
   kubectl_tests:
     name: kubectl rabbitmq tests

--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -9,6 +9,7 @@
 package v1beta1
 
 import (
+	"strconv"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -362,6 +363,10 @@ type RabbitmqClusterList struct {
 
 func (cluster RabbitmqCluster) ChildResourceName(name string) string {
 	return strings.TrimSuffix(strings.Join([]string{cluster.Name, name}, "-"), "-")
+}
+
+func (cluster RabbitmqCluster) PVCName(i int) string {
+	return strings.Join([]string{"persistence", cluster.Name, "server", strconv.Itoa(i)}, "-")
 }
 
 func init() {

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -456,6 +456,12 @@ var _ = Describe("RabbitmqCluster", func() {
 			Expect(updatedCondition.LastTransitionTime.Before(&notExpectedTime)).To(BeFalse())
 		})
 	})
+	Context("PVC Name helper function", func() {
+		It("returns the correct PVC name", func() {
+			r := generateRabbitmqClusterObject("testrabbit")
+			Expect(r.PVCName(0)).To(Equal("persistence-testrabbit-server-0"))
+		})
+	})
 })
 
 func getKey(cluster *RabbitmqCluster) types.NamespacedName {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -43,6 +43,16 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -161,12 +161,15 @@ func (r *RabbitmqClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 
-		if err = r.reconcilePVC(ctx, builder, rabbitmqCluster, resource); err != nil {
-			rabbitmqCluster.Status.SetCondition(status.ReconcileSuccess, corev1.ConditionFalse, "FailedReconcilePVC", err.Error())
-			if statusErr := r.Status().Update(ctx, rabbitmqCluster); statusErr != nil {
-				logger.Error(statusErr, "Failed to update ReconcileSuccess condition state")
+		// only StatefulSetBuilder returns true
+		if  builder.UpdateMayRequireStsRecreate() {
+			if err = r.reconcilePVC(ctx, builder, rabbitmqCluster, resource); err != nil {
+				rabbitmqCluster.Status.SetCondition(status.ReconcileSuccess, corev1.ConditionFalse, "FailedReconcilePVC", err.Error())
+				if statusErr := r.Status().Update(ctx, rabbitmqCluster); statusErr != nil {
+					logger.Error(statusErr, "Failed to update ReconcileSuccess condition state")
+				}
+				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, err
 		}
 
 		var operationResult controllerutil.OperationResult

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -78,6 +78,7 @@ type RabbitmqClusterReconciler struct {
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;create;patch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update
 
@@ -157,6 +158,10 @@ func (r *RabbitmqClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	for _, builder := range builders {
 		resource, err := builder.Build()
 		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if err = r.reconcilePVC(ctx, builder, rabbitmqCluster, resource); err != nil  {
 			return ctrl.Result{}, err
 		}
 

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -161,7 +161,11 @@ func (r *RabbitmqClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 
-		if err = r.reconcilePVC(ctx, builder, rabbitmqCluster, resource); err != nil  {
+		if err = r.reconcilePVC(ctx, builder, rabbitmqCluster, resource); err != nil {
+			rabbitmqCluster.Status.SetCondition(status.ReconcileSuccess, corev1.ConditionFalse, "FailedReconcilePVC", err.Error())
+			if statusErr := r.Status().Update(ctx, rabbitmqCluster); statusErr != nil {
+				logger.Error(statusErr, "Failed to update ReconcileSuccess condition state")
+			}
 			return ctrl.Result{}, err
 		}
 

--- a/controllers/reconcile_persistence.go
+++ b/controllers/reconcile_persistence.go
@@ -1,0 +1,171 @@
+package controllers
+
+import (
+	"errors"
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
+	"github.com/rabbitmq/cluster-operator/internal/resource"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+
+func (r *RabbitmqClusterReconciler) reconcilePVC(ctx context.Context, builder resource.ResourceBuilder, cluster *rabbitmqv1beta1.RabbitmqCluster, resource client.Object) error {
+	logger := ctrl.LoggerFrom(ctx)
+
+	switch sts := resource.(type) {
+	case *appsv1.StatefulSet:
+		current, err := r.statefulSet(ctx, cluster)
+		if client.IgnoreNotFound(err) != nil {
+			return err
+		} else if k8serrors.IsNotFound(err) {
+			logger.Info("statefulSet not created yet, skipping checks to expand PersistentVolumeClaims")
+			return nil
+		}
+
+		if err := builder.Update(sts); err != nil {
+			return err
+		}
+
+		resize, err := r.needsPVCResize(current, sts)
+
+		if err != nil {
+			return err
+		}
+
+		if resize {
+			if err := r.expandPVC(ctx, cluster, current, sts); err != nil {
+				logger.Error(err, "Failed to expand PersistentVolumeClaims", "statefulSet", cluster.ChildResourceName("server"))
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (r *RabbitmqClusterReconciler) expandPVC(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster, current, desired *appsv1.StatefulSet) error {
+	logger := ctrl.LoggerFrom(ctx)
+
+	currentCapacity, err := persistenceStorageCapacity(current.Spec.VolumeClaimTemplates)
+	if err != nil {
+		return err
+	}
+
+	desiredCapacity, err := persistenceStorageCapacity(desired.Spec.VolumeClaimTemplates)
+	if err != nil {
+		return err
+	}
+
+	logger.Info(fmt.Sprintf("updating storage capacity from %v to %v", currentCapacity, desiredCapacity))
+
+	if err := r.deleteSts(ctx, rmq); err != nil {
+		return err
+	}
+
+	if err := r.updatePVC(ctx, rmq,  *current.Spec.Replicas, desiredCapacity); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *RabbitmqClusterReconciler) updatePVC(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster, replicas int32, desiredCapacity k8sresource.Quantity) error {
+	logger := ctrl.LoggerFrom(ctx)
+	logger.Info("expanding PersistentVolumeClaims")
+
+	for i := 0; i < int(replicas); i++ {
+		PVCName := rmq.PVCName(i)
+		PVC := corev1.PersistentVolumeClaim{}
+
+		if err := r.Client.Get(ctx, types.NamespacedName{Namespace: rmq.Namespace, Name: PVCName}, &PVC); err != nil {
+			logger.Error(err, "failed to get PersistentVolumeClaim")
+			return err
+		}
+		PVC.Spec.Resources.Requests[corev1.ResourceStorage] = desiredCapacity
+		if err := r.Client.Update(ctx, &PVC, &client.UpdateOptions{}); err != nil {
+			logger.Error(err, "failed to update PersistentVolumeClaim")
+			return err
+		}
+		logger.Info("successfully expanded", "PVC", PVCName)
+	}
+	return nil
+}
+
+func (r *RabbitmqClusterReconciler) needsPVCResize(current, desired *appsv1.StatefulSet) (bool, error) {
+	currentCapacity, err := persistenceStorageCapacity(current.Spec.VolumeClaimTemplates)
+	if err != nil {
+		return false, err
+	}
+
+	desiredCapacity, err := persistenceStorageCapacity(desired.Spec.VolumeClaimTemplates)
+	if err != nil {
+		return false, err
+	}
+
+	if currentCapacity.Cmp(desiredCapacity) != 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func persistenceStorageCapacity(templates []corev1.PersistentVolumeClaim)  (k8sresource.Quantity, error) {
+	for _, t := range templates {
+		if t.Name == "persistence" {
+			return t.Spec.Resources.Requests[corev1.ResourceStorage], nil
+		}
+	}
+	return k8sresource.Quantity{}, errors.New("cannot find PersistentVolumeClaim 'persistence'")
+}
+
+
+// deleteSts deletes a sts without deleting pods and PVCs
+// using DeletePropagationPolicy set to 'Orphan'
+func (r *RabbitmqClusterReconciler) deleteSts(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
+	logger.Info("deleting statefulSet (pods won't be deleted)", "statefulSet", rmq.ChildResourceName("server"))
+	deletePropagationPolicy := metav1.DeletePropagationOrphan
+	deleteOptions := &client.DeleteOptions{PropagationPolicy: &deletePropagationPolicy}
+	stsName := rmq.ChildResourceName("server")
+	current, err := r.statefulSet(ctx, rmq)
+	if err != nil {
+		return err
+	}
+	if err := r.Delete(ctx, current, deleteOptions); err != nil {
+		logger.Error(err, "failed to delete statefulSet", "statefulSet", stsName)
+		return err
+	}
+
+	if err := retryWithInterval(logger, "delete statefulSet", 10, 3*time.Second, func() bool {
+		_, getErr := r.statefulSet(ctx, rmq)
+		if k8serrors.IsNotFound(getErr) {
+			return true
+		}
+		return false
+	}); err != nil {
+		logger.Error(err, "statefulSet not deleting after 50 seconds", "statefulSet", stsName)
+		return err
+	}
+	logger.Info("statefulSet deleted", "statefulSet", stsName)
+	return nil
+}
+
+func retryWithInterval(logger logr.Logger, msg string, retry int, interval time.Duration, f func() bool) (err error) {
+	for i := 0; i < retry; i++ {
+		if ok := f(); ok {
+			return
+		}
+		time.Sleep(interval)
+		logger.Info("retrying again", "action", msg, "interval", interval, "attempt", i+1)
+	}
+	return fmt.Errorf("failed to %s after %d retries", msg, retry)
+}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -2,8 +2,6 @@ package controllers
 
 import (
 	"context"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -11,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (r *RabbitmqClusterReconciler) exec(namespace, podName, containerName string, command ...string) (string, string, error) {

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -77,6 +77,10 @@ func (builder *ServerConfigMapBuilder) Build() (client.Object, error) {
 	}, nil
 }
 
+func (builder *ServerConfigMapBuilder) UpdateMayRequireStsRecreate() bool {
+	return false
+}
+
 func (builder *ServerConfigMapBuilder) Update(object client.Object) error {
 	configMap := object.(*corev1.ConfigMap)
 

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -542,6 +542,12 @@ CONSOLE_LOG=new`
 			Expect(configMap.Annotations).To(BeEmpty())
 		})
 	})
+
+	Context("UpdateMayRequireStsRecreate", func() {
+		It("returns false", func() {
+			Expect(configMapBuilder.UpdateMayRequireStsRecreate()).To(BeFalse())
+		})
+	})
 })
 
 // iniString formats the input string using "gopkg.in/ini.v1"

--- a/internal/resource/default_user_secret.go
+++ b/internal/resource/default_user_secret.go
@@ -70,6 +70,10 @@ func (builder *DefaultUserSecretBuilder) Build() (client.Object, error) {
 	}, nil
 }
 
+func (builder *DefaultUserSecretBuilder) UpdateMayRequireStsRecreate() bool {
+	return false
+}
+
 func (builder *DefaultUserSecretBuilder) Update(object client.Object) error {
 	secret := object.(*corev1.Secret)
 	secret.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/default_user_secret_test.go
+++ b/internal/resource/default_user_secret_test.go
@@ -201,4 +201,10 @@ var _ = Describe("DefaultUserSecret", func() {
 		Expect(defaultUserSecretBuilder.Update(secret)).NotTo(HaveOccurred())
 		Expect(secret.OwnerReferences[0].Name).To(Equal(instance.Name))
 	})
+
+	Context("UpdateMayRequireStsRecreate", func() {
+		It("returns false", func() {
+			Expect(defaultUserSecretBuilder.UpdateMayRequireStsRecreate()).To(BeFalse())
+		})
+	})
 })

--- a/internal/resource/erlang_cookie.go
+++ b/internal/resource/erlang_cookie.go
@@ -57,6 +57,10 @@ func (builder *ErlangCookieBuilder) Build() (client.Object, error) {
 	}, nil
 }
 
+func (builder *ErlangCookieBuilder) UpdateMayRequireStsRecreate() bool {
+	return false
+}
+
 func (builder *ErlangCookieBuilder) Update(object client.Object) error {
 	secret := object.(*corev1.Secret)
 	secret.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/erlang_cookie_test.go
+++ b/internal/resource/erlang_cookie_test.go
@@ -174,4 +174,10 @@ var _ = Describe("ErlangCookie", func() {
 		Expect(erlangCookieBuilder.Update(secret)).NotTo(HaveOccurred())
 		Expect(secret.OwnerReferences[0].Name).To(Equal(instance.Name))
 	})
+
+	Context("UpdateMayRequireStsRecreate", func() {
+		It("returns false", func() {
+			Expect(erlangCookieBuilder.UpdateMayRequireStsRecreate()).To(BeFalse())
+		})
+	})
 })

--- a/internal/resource/headless_service.go
+++ b/internal/resource/headless_service.go
@@ -38,6 +38,10 @@ func (builder *RabbitmqResourceBuilder) HeadlessService() *HeadlessServiceBuilde
 	}
 }
 
+func (builder *HeadlessServiceBuilder) UpdateMayRequireStsRecreate() bool {
+	return false
+}
+
 func (builder *HeadlessServiceBuilder) Build() (client.Object, error) {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/resource/headless_service_test.go
+++ b/internal/resource/headless_service_test.go
@@ -213,4 +213,10 @@ var _ = Describe("HeadlessService", func() {
 		Expect(serviceBuilder.Update(service)).NotTo(HaveOccurred())
 		Expect(service.OwnerReferences[0].Name).To(Equal(instance.Name))
 	})
+
+	Context("UpdateMayRequireStsRecreate", func() {
+		It("returns false", func() {
+			Expect(serviceBuilder.UpdateMayRequireStsRecreate()).To(BeFalse())
+		})
+	})
 })

--- a/internal/resource/rabbitmq_plugins.go
+++ b/internal/resource/rabbitmq_plugins.go
@@ -48,6 +48,10 @@ func (builder *RabbitmqPluginsConfigMapBuilder) Build() (client.Object, error) {
 	}, nil
 }
 
+func (builder *RabbitmqPluginsConfigMapBuilder) UpdateMayRequireStsRecreate() bool {
+	return false
+}
+
 func (builder *RabbitmqPluginsConfigMapBuilder) Update(object client.Object) error {
 	configMap := object.(*corev1.ConfigMap)
 

--- a/internal/resource/rabbitmq_plugins_test.go
+++ b/internal/resource/rabbitmq_plugins_test.go
@@ -248,5 +248,11 @@ var _ = Describe("RabbitMQPlugins", func() {
 				Expect(configMap.Annotations).To(BeEmpty())
 			})
 		})
+
+		Context("UpdateMayRequireStsRecreate", func() {
+			It("returns false", func() {
+				Expect(configMapBuilder.UpdateMayRequireStsRecreate()).To(BeFalse())
+			})
+		})
 	})
 })

--- a/internal/resource/rabbitmq_resource_builder.go
+++ b/internal/resource/rabbitmq_resource_builder.go
@@ -23,6 +23,7 @@ type RabbitmqResourceBuilder struct {
 type ResourceBuilder interface {
 	Build() (client.Object, error)
 	Update(client.Object) error
+	UpdateMayRequireStsRecreate() bool
 }
 
 func (builder *RabbitmqResourceBuilder) ResourceBuilders() ([]ResourceBuilder, error) {

--- a/internal/resource/role.go
+++ b/internal/resource/role.go
@@ -46,6 +46,11 @@ func (builder *RoleBuilder) Build() (client.Object, error) {
 	}, nil
 }
 
+
+func (builder *RoleBuilder) UpdateMayRequireStsRecreate() bool {
+	return false
+}
+
 func (builder *RoleBuilder) Update(object client.Object) error {
 	role := object.(*rbacv1.Role)
 	role.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/role_binding.go
+++ b/internal/resource/role_binding.go
@@ -37,6 +37,10 @@ func (builder *RabbitmqResourceBuilder) RoleBinding() *RoleBindingBuilder {
 	}
 }
 
+func (builder *RoleBindingBuilder) UpdateMayRequireStsRecreate() bool {
+	return false
+}
+
 func (builder *RoleBindingBuilder) Update(object client.Object) error {
 	roleBinding := object.(*rbacv1.RoleBinding)
 	roleBinding.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/role_binding_test.go
+++ b/internal/resource/role_binding_test.go
@@ -192,4 +192,10 @@ var _ = Describe("RoleBinding", func() {
 			Expect(roleBinding.Annotations).To(Equal(expectedAnnotations))
 		})
 	})
+
+	Context("UpdateMayRequireStsRecreate", func() {
+		It("returns false", func() {
+			Expect(roleBindingBuilder.UpdateMayRequireStsRecreate()).To(BeFalse())
+		})
+	})
 })

--- a/internal/resource/role_test.go
+++ b/internal/resource/role_test.go
@@ -190,4 +190,10 @@ var _ = Describe("Role", func() {
 			Expect(role.Annotations).To(Equal(expectedAnnotations))
 		})
 	})
+
+	Context("UpdateMayRequireStsRecreate", func() {
+		It("returns false", func() {
+			Expect(roleBuilder.UpdateMayRequireStsRecreate()).To(BeFalse())
+		})
+	})
 })

--- a/internal/resource/service.go
+++ b/internal/resource/service.go
@@ -50,6 +50,11 @@ func (builder *ServiceBuilder) Build() (client.Object, error) {
 	}, nil
 }
 
+
+func (builder *ServiceBuilder) UpdateMayRequireStsRecreate() bool {
+	return false
+}
+
 func (builder *ServiceBuilder) Update(object client.Object) error {
 	service := object.(*corev1.Service)
 	builder.setAnnotations(service)

--- a/internal/resource/service_account.go
+++ b/internal/resource/service_account.go
@@ -46,6 +46,11 @@ func (builder *ServiceAccountBuilder) Build() (client.Object, error) {
 	}, nil
 }
 
+
+func (builder *ServiceAccountBuilder) UpdateMayRequireStsRecreate() bool {
+	return false
+}
+
 func (builder *ServiceAccountBuilder) Update(object client.Object) error {
 	serviceAccount := object.(*corev1.ServiceAccount)
 	serviceAccount.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)

--- a/internal/resource/service_account_test.go
+++ b/internal/resource/service_account_test.go
@@ -153,4 +153,10 @@ var _ = Describe("ServiceAccount", func() {
 			})
 		})
 	})
+
+	Context("UpdateMayRequireStsRecreate", func() {
+		It("returns false", func() {
+			Expect(serviceAccountBuilder.UpdateMayRequireStsRecreate()).To(BeFalse())
+		})
+	})
 })

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -660,6 +660,26 @@ var _ = Context("Services", func() {
 			})
 		})
 	})
+
+	Context("UpdateMayRequireStsRecreate", func() {
+		BeforeEach(func() {
+			BeforeEach(func() {
+				scheme = runtime.NewScheme()
+				Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
+				Expect(defaultscheme.AddToScheme(scheme)).To(Succeed())
+				instance = generateRabbitmqCluster()
+				builder = resource.RabbitmqResourceBuilder{
+					Instance: &instance,
+					Scheme:   scheme,
+				}
+
+			})
+			It("returns false", func() {
+				serviceBuilder := builder.Service()
+				Expect(serviceBuilder.UpdateMayRequireStsRecreate()).To(BeFalse())
+			})
+		})
+	})
 })
 
 func updateServiceWithAnnotations(rmqBuilder resource.RabbitmqResourceBuilder, instanceAnnotations, serviceAnnotations map[string]string) *corev1.Service {

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -102,6 +102,11 @@ func (builder *StatefulSetBuilder) Build() (client.Object, error) {
 	return sts, nil
 }
 
+// updates to storage capacity will recreate sts
+func (builder *StatefulSetBuilder) UpdateMayRequireStsRecreate() bool {
+	return true
+}
+
 func (builder *StatefulSetBuilder) Update(object client.Object) error {
 	sts := object.(*appsv1.StatefulSet)
 

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -33,6 +33,7 @@ import (
 const (
 	initContainerCPU    string = "100m"
 	initContainerMemory string = "500Mi"
+	defaultPVCName      string = "persistence"
 	DeletionMarker      string = "skipPreStopChecks"
 )
 
@@ -121,6 +122,9 @@ func (builder *StatefulSetBuilder) Update(object client.Object) error {
 	//Labels
 	sts.Labels = metadata.GetLabels(builder.Instance.Name, builder.Instance.Labels)
 
+	// PVC storage capacity
+	updatePersistenceStorageCapacity(&sts.Spec.VolumeClaimTemplates, builder.Instance.Spec.Persistence.Storage)
+
 	// pod template
 	sts.Spec.Template = builder.podTemplateSpec(sts.Spec.Template.Annotations)
 
@@ -139,6 +143,14 @@ func (builder *StatefulSetBuilder) Update(object client.Object) error {
 		return fmt.Errorf("failed setting controller reference: %v", err)
 	}
 	return nil
+}
+
+func updatePersistenceStorageCapacity(templates *[]corev1.PersistentVolumeClaim, capacity *k8sresource.Quantity) {
+	for _, t := range *templates {
+		if t.Name == defaultPVCName {
+			t.Spec.Resources.Requests[corev1.ResourceStorage] = *capacity
+		}
+	}
 }
 
 func applyStsOverride(sts *appsv1.StatefulSet, stsOverride *rabbitmqv1beta1.StatefulSet) error {
@@ -178,7 +190,7 @@ func applyStsOverride(sts *appsv1.StatefulSet, stsOverride *rabbitmqv1beta1.Stat
 func persistentVolumeClaim(instance *rabbitmqv1beta1.RabbitmqCluster, scheme *runtime.Scheme) ([]corev1.PersistentVolumeClaim, error) {
 	pvc := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "persistence",
+			Name:        defaultPVCName,
 			Namespace:   instance.GetNamespace(),
 			Labels:      metadata.Label(instance.Name),
 			Annotations: metadata.ReconcileAndFilterAnnotations(map[string]string{}, instance.Annotations),
@@ -275,7 +287,7 @@ func sortVolumeMounts(mounts []corev1.VolumeMount) {
 			mounts[0], mounts[i] = mounts[i], mounts[0]
 			continue
 		}
-		if m.Name == "persistence" {
+		if m.Name == defaultPVCName {
 			mounts[1], mounts[i] = mounts[i], mounts[1]
 		}
 	}

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -428,7 +428,7 @@ var _ = Describe("StatefulSet", func() {
 			Expect(statefulSet.Spec.UpdateStrategy).To(Equal(updateStrategy))
 		})
 
-		It("updates tolerations", func() {
+		It("updates toleration", func() {
 			newToleration := corev1.Toleration{
 				Key:      "update",
 				Operator: "equals",
@@ -1283,7 +1283,7 @@ var _ = Describe("StatefulSet", func() {
 			Expect(statefulSet.Spec.Template.Spec.Containers[0].Lifecycle.PreStop.Exec.Command).To(Equal(expectedPreStopCommand))
 		})
 
-		It("checks mirror and querum queue status in preStop hook", func() {
+		It("checks mirror and quorum queue status in preStop hook", func() {
 			stsBuilder := builder.StatefulSet()
 			Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 
@@ -1370,6 +1370,32 @@ var _ = Describe("StatefulSet", func() {
 			stsBuilder := builder.StatefulSet()
 			Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 			Expect(*statefulSet.Spec.Replicas).To(Equal(int32(3)))
+		})
+
+		It("updates the PersistentVolumeClaim storage capacity", func() {
+			defaultCapacity, _ := k8sresource.ParseQuantity("10Gi")
+
+			statefulSet.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "persistence",
+						Namespace: instance.Namespace,
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]k8sresource.Quantity{
+								corev1.ResourceStorage: defaultCapacity,
+							},
+						},
+					},
+				},
+			}
+
+			newCapacity, _ := k8sresource.ParseQuantity("21Gi")
+			stsBuilder.Instance.Spec.Persistence.Storage = &newCapacity
+			Expect(stsBuilder.Update(statefulSet)).To(Succeed())
+			Expect(statefulSet.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests["storage"]).To(Equal(newCapacity))
 		})
 
 		When("stateful set override are provided", func() {

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1892,6 +1892,12 @@ var _ = Describe("StatefulSet", func() {
 			})
 		})
 	})
+
+	Context("UpdateMayRequireStsRecreate", func() {
+		It("returns true", func() {
+			Expect(stsBuilder.UpdateMayRequireStsRecreate()).To(BeTrue())
+		})
+	})
 })
 
 func extractContainer(containers []corev1.Container, containerName string) corev1.Container {

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -14,11 +14,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
-	storagev1 "k8s.io/api/storage/v1"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"strconv"
 	"strings"
@@ -288,7 +285,7 @@ CONSOLE_LOG=new`
 		})
 	})
 
-	Context("PVC resize", func() {
+	Context("Persistence expansion", func() {
 		var cluster  *rabbitmqv1beta1.RabbitmqCluster
 
 		AfterEach(func() {
@@ -303,7 +300,7 @@ CONSOLE_LOG=new`
 
 			cluster = newRabbitmqCluster(namespace, "resize-rabbit")
 			cluster.Spec.Persistence = rabbitmqv1beta1.RabbitmqClusterPersistenceSpec{
-				StorageClassName: pointer.StringPtr("persistent-test"),
+				StorageClassName: pointer.StringPtr(storageClassName),
 			}
 			Expect(createRabbitmqCluster(ctx, rmqClusterClient, cluster)).To(Succeed())
 			waitForRabbitmqRunning(cluster)
@@ -314,10 +311,6 @@ CONSOLE_LOG=new`
 			output, err := kubectlExec(namespace, statefulSetPodName(cluster, 0), "df", "/var/lib/rabbitmq/mnesia")
 			Expect(err).ToNot(HaveOccurred())
 			previousDiskSize, err := strconv.Atoi(strings.Fields(strings.Split(string(output), "\n")[1])[1])
-
-			storageClass := &storagev1.StorageClass{}
-			Expect(rmqClusterClient.Get(ctx, types.NamespacedName{Name: *cluster.Spec.Persistence.StorageClassName, Namespace: namespace}, storageClass)).To(Succeed())
-			Expect(*storageClass.AllowVolumeExpansion).To(BeTrue(), fmt.Sprintf(" 'AllowVolumeExpansion' set to false for storage class %s", storageClassName))
 
 			newCapacity, _ := k8sresource.ParseQuantity("12Gi")
 			Expect(updateRabbitmqCluster(ctx, rmqClusterClient, cluster.Name, cluster.Namespace, func(cluster *rabbitmqv1beta1.RabbitmqCluster) {

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -240,10 +240,6 @@ CONSOLE_LOG=new`
 			password string
 		)
 
-		AfterEach(func() {
-			Expect(rmqClusterClient.Delete(context.TODO(), cluster)).To(Succeed())
-		})
-
 		BeforeEach(func() {
 			cluster = newRabbitmqCluster(namespace, "persistence-rabbit")
 			Expect(createRabbitmqCluster(ctx, rmqClusterClient, cluster)).To(Succeed())
@@ -257,6 +253,10 @@ CONSOLE_LOG=new`
 			username, password, err = getUsernameAndPassword(ctx, clientSet, cluster.Namespace, cluster.Name)
 			Expect(err).NotTo(HaveOccurred())
 			assertHttpReady(hostname, port)
+		})
+
+		AfterEach(func() {
+			Expect(rmqClusterClient.Delete(context.TODO(), cluster)).To(Succeed())
 		})
 
 		It("persists messages", func() {
@@ -296,7 +296,7 @@ CONSOLE_LOG=new`
 		})
 
 		BeforeEach(func() {
-			// volume expansion is supported in kinD which is use in github action
+			// volume expansion is not supported in kinD which is use in github action
 			if os.Getenv("SUPPORT_VOLUME_EXPANSION") == "false" {
 				Skip("SUPPORT_VOLUME_EXPANSION is set to false; skipping volume expansion test")
 			}

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -14,7 +14,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	storagev1 "k8s.io/api/storage/v1"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"strconv"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -235,6 +241,9 @@ CONSOLE_LOG=new`
 
 		BeforeEach(func() {
 			cluster = newRabbitmqCluster(namespace, "persistence-rabbit")
+			cluster.Spec.Persistence = rabbitmqv1beta1.RabbitmqClusterPersistenceSpec{
+				StorageClassName: pointer.StringPtr("persistent-test"),
+			}
 			Expect(createRabbitmqCluster(ctx, rmqClusterClient, cluster)).To(Succeed())
 
 			waitForRabbitmqRunning(cluster)
@@ -277,6 +286,42 @@ CONSOLE_LOG=new`
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvc.OwnerReferences).To(HaveLen(1))
 				Expect(pvc.OwnerReferences[0].Name).To(Equal(cluster.Name))
+			})
+
+			By("allowing volume expansion", func() {
+				podUID := pod(ctx, clientSet, cluster, 0).UID
+				output, err := kubectlExec(namespace, statefulSetPodName(cluster, 0), "df", "/var/lib/rabbitmq/mnesia")
+				Expect(err).ToNot(HaveOccurred())
+				previousDiskSize, err := strconv.Atoi(strings.Fields(strings.Split(string(output), "\n")[1])[1])
+
+				storageClass := &storagev1.StorageClass{}
+				Expect(rmqClusterClient.Get(ctx, types.NamespacedName{Name: storageClassName, Namespace: namespace}, storageClass)).To(Succeed())
+				Expect(*storageClass.AllowVolumeExpansion).To(BeTrue(), fmt.Sprintf(" 'AllowVolumeExpansion' set to false for storage class %s", storageClassName))
+
+				newCapacity, _ := k8sresource.ParseQuantity("12Gi")
+				Expect(updateRabbitmqCluster(ctx, rmqClusterClient, cluster.Name, cluster.Namespace, func(cluster *rabbitmqv1beta1.RabbitmqCluster) {
+					cluster.Spec.Persistence.Storage = &newCapacity
+				})).To(Succeed())
+
+				// PVC storage capacity updated
+				Eventually(func() k8sresource.Quantity {
+					pvcName := cluster.PVCName(0)
+					pvc, err := clientSet.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return pvc.Spec.Resources.Requests["storage"]
+				}, 120, 5).Should(Equal(newCapacity))
+
+				// storage capacity reflected in the pod
+				Eventually(func() int {
+					output, err = kubectlExec(namespace, statefulSetPodName(cluster, 0), "df", "/var/lib/rabbitmq/mnesia")
+					Expect(err).ToNot(HaveOccurred())
+					updatedDiskSize, err := strconv.Atoi(strings.Fields(strings.Split(string(output), "\n")[1])[1])
+					Expect(err).ToNot(HaveOccurred())
+					return updatedDiskSize
+				}, 120, 5).Should(BeNumerically(">", previousDiskSize))
+
+				// pod was not recreated
+				Expect(pod(ctx, clientSet, cluster, 0).UID).To(Equal(podUID))
 			})
 		})
 	})

--- a/system_tests/system_tests.go
+++ b/system_tests/system_tests.go
@@ -316,7 +316,7 @@ CONSOLE_LOG=new`
 			previousDiskSize, err := strconv.Atoi(strings.Fields(strings.Split(string(output), "\n")[1])[1])
 
 			storageClass := &storagev1.StorageClass{}
-			Expect(rmqClusterClient.Get(ctx, types.NamespacedName{Name: storageClassName, Namespace: namespace}, storageClass)).To(Succeed())
+			Expect(rmqClusterClient.Get(ctx, types.NamespacedName{Name: *cluster.Spec.Persistence.StorageClassName, Namespace: namespace}, storageClass)).To(Succeed())
 			Expect(*storageClass.AllowVolumeExpansion).To(BeTrue(), fmt.Sprintf(" 'AllowVolumeExpansion' set to false for storage class %s", storageClassName))
 
 			newCapacity, _ := k8sresource.ParseQuantity("12Gi")

--- a/system_tests/system_tests_suite_test.go
+++ b/system_tests/system_tests_suite_test.go
@@ -11,6 +11,7 @@ package system_tests
 
 import (
 	"context"
+	"k8s.io/utils/pointer"
 	"testing"
 
 	storagev1 "k8s.io/api/storage/v1"
@@ -33,10 +34,10 @@ func TestSystemTests(t *testing.T) {
 }
 
 var (
-	rmqClusterClient          client.Client
-	clientSet                 *kubernetes.Clientset
-	namespace                 string
-	specifiedStorageClassName = "persistent-test"
+	rmqClusterClient client.Client
+	clientSet        *kubernetes.Clientset
+	namespace        string
+	storageClassName = "persistent-test"
 )
 
 var _ = BeforeSuite(func() {
@@ -49,7 +50,6 @@ var _ = BeforeSuite(func() {
 
 	rmqClusterClient, err = client.New(restConfig, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
-
 	clientSet, err = createClientSet()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -57,9 +57,10 @@ var _ = BeforeSuite(func() {
 
 	storageClass := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: specifiedStorageClassName,
+			Name: storageClassName,
 		},
-		Provisioner: "kubernetes.io/gce-pd",
+		Provisioner:          "kubernetes.io/gce-pd",
+		AllowVolumeExpansion: pointer.BoolPtr(true),
 	}
 	err = rmqClusterClient.Create(context.TODO(), storageClass)
 	if !apierrors.IsAlreadyExists(err) {

--- a/system_tests/system_tests_suite_test.go
+++ b/system_tests/system_tests_suite_test.go
@@ -55,6 +55,7 @@ var _ = BeforeSuite(func() {
 
 	namespace = MustHaveEnv("NAMESPACE")
 
+	// Create or update the StorageClass used in persistence expansion test spec
 	storageClass := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: storageClassName,
@@ -63,7 +64,9 @@ var _ = BeforeSuite(func() {
 		AllowVolumeExpansion: pointer.BoolPtr(true),
 	}
 	err = rmqClusterClient.Create(context.TODO(), storageClass)
-	if !apierrors.IsAlreadyExists(err) {
+	if apierrors.IsAlreadyExists(err) {
+		Expect(rmqClusterClient.Update(context.TODO(), storageClass)).To(Succeed())
+	} else {
 		Expect(err).NotTo(HaveOccurred())
 	}
 

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -950,3 +950,14 @@ func publishAndConsumeSTOMPMsg(hostname, stompNodePort, username, password strin
 	ExpectWithOffset(1, sub.Unsubscribe()).To(Succeed())
 	ExpectWithOffset(1, conn.Disconnect()).To(Succeed())
 }
+
+func pod(ctx context.Context, clientSet *kubernetes.Clientset, r *rabbitmqv1beta1.RabbitmqCluster, i int) *corev1.Pod {
+	podName := statefulSetPodName(r, i)
+	var pod *corev1.Pod
+	EventuallyWithOffset(1, func() error {
+		var err error
+		pod, err = clientSet.CoreV1().Pods(r.Namespace).Get(ctx, podName, metav1.GetOptions{})
+		return err
+	}, 10).Should(Succeed())
+	return pod
+}


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

1.  update default PVC 'persistence' storage capacity in statefulSetBuilder
2. `reconcilePVC()` check if the default PVC 'persistence' storage capacity has updated; if yes: 
     1. delete current statefulSet with delete propagation policy set to "Orphan"
     2. update PVCs manually
     3. recreate statefulSet (statefulSet will be automatically created by the CreateOrUpdate() call later as a result of its deletion in step 1; does not need to be done in `reconcilePVC()` explicitly)
3. tested on the system test level (unfortunately testEnv does not create any PVC). The system test makes sure that PVC storage capacity is updated and the new capacity is reflected in the rabbitmq pod, while making sure that the pod was not recreated in this process. I've set 2min timeout for both the PVC and the pod storage capacity update because the speed of such operations seem to be dependent on the k8s cluster load
4. The PVC controller does not allow shrinking. If users try to shrink the size in RabbitmqCluster CRD, the operator will accept the input but `Reconcile()` will fail at updating PVCs.
5. Volume expansion system test is skipped in github action. KinD does not support that.


**This feature does not work for any additional PVC that's added via statefulSet override** If the default PVC 'persistence' is updated via override, expansion will work only for PVC 'persistence', but not for any additional PVCs. I intentionally left added PVCs out of this feature. We can add the support in the future if necessary. 

## Additional Context

## Local Testing

Unit, integration, and system tests all passing
