### PR TITLE
Update production ready example

### DIFF
--- a/docs/examples/production-ready/rabbitmq.yaml
+++ b/docs/examples/production-ready/rabbitmq.yaml
@@ -12,6 +12,8 @@ spec:
       cpu: 4
       memory: 10Gi
   rabbitmq:
+    additionalPlugins:
+      - rabbitmq_peer_discovery_k8s
     additionalConfig: |
       cluster_partition_handling = pause_minority
       vm_memory_high_watermark_paging_ratio = 0.99


### PR DESCRIPTION
## Summary Of Changes

Added rabbitmq_peer_discovery_k8s to the production-ready example

## Additional Context

Without the rabbitmq_peer_discovery_k8s plugin the replicas wont join into a cluster.  Instead of a production-ready deployment you end up with 3 separate instances of RabbitMQ
