### PR TITLE
Fix API ref docs to include Plugin type description

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -274,6 +274,8 @@ type TLSSpec struct {
 
 // kubebuilder validating tags 'Pattern' and 'MaxLength' must be specified on string type.
 // Alias type 'string' as 'Plugin' to specify schema validation on items of the list 'AdditionalPlugins'
+
+// A Plugin to enable on the RabbitmqCluster.
 // +kubebuilder:validation:Pattern:="^\\w+$"
 // +kubebuilder:validation:MaxLength=100
 type Plugin string

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -84,7 +84,7 @@ PersistentVolumeClaim is an embedded version of k8s.io/api/core/v1.PersistentVol
 [id="{anchor_prefix}-github-com-rabbitmq-cluster-operator-api-v1beta1-plugin"]
 ==== Plugin (string) 
 
-
+A Plugin to enable on the RabbitmqCluster.
 
 .Appears In:
 ****


### PR DESCRIPTION
This is to accommodate the bump to the latest elastic/crd-ref-docs version.
