### PR TITLE
Add Slack notifications on failed GitHub actions

### DIFF
--- a/.github/workflows/publish-versioned-api-ref.yml
+++ b/.github/workflows/publish-versioned-api-ref.yml
@@ -36,3 +36,10 @@ jobs:
           git add ./API_Reference_${{ steps.get_version.outputs.VERSION }}.asciidoc
           git add ./Wiki_Sidebar.md
           git commit -m "Publish version ${{ steps.get_version.outputs.VERSION }} API Reference" && git push
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,action,eventName
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,10 @@ jobs:
       uses: rajatjindal/krew-release-bot@v0.0.38
       with:
         krew_template_file: hack/rabbitmq.yaml
+    - uses: 8398a7/action-slack@v3
+      with:
+        status: ${{ job.status }}
+        fields: repo,message,action,eventName
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      if: failure()

--- a/.github/workflows/update-latest-api-ref.yml
+++ b/.github/workflows/update-latest-api-ref.yml
@@ -28,3 +28,10 @@ jobs:
           cp ../cluster-operator/docs/api/rabbitmq.com.ref.asciidoc ./API_Reference.asciidoc
           git add ./API_Reference.asciidoc
           git diff-index --quiet HEAD || git commit -m "Update Latest API Reference" && git push
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,action,eventName
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()


### PR DESCRIPTION
We don't add the notifications for failed PRs since it would create too much noise in our Slack channel whenever someone opens a PR where tests are failing.

However, let's add notifications when other GitHub actions fail, e.g. failing to update the krew index. This one was unnoticed for a week.