### PR TITLE
Set Pod Management to 'Parallel' and disallow cluster scale down entirely

### DIFF
--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -10,7 +10,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: rabbitmqclusters.rabbitmq.com
 spec:

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -937,7 +937,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 
 		It("updates", func() {
 			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
-				cluster.Spec.Override.StatefulSet.Spec.Replicas = pointer.Int32Ptr(5)
+				cluster.Spec.Override.StatefulSet.Spec.Replicas = pointer.Int32Ptr(15)
 				cluster.Spec.Override.StatefulSet.Spec.Template.Spec.Containers = []corev1.Container{
 					{
 						Name:  "additional-container-2",
@@ -949,7 +949,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 			Eventually(func() int32 {
 				sts := statefulSet(ctx, cluster)
 				return *sts.Spec.Replicas
-			}, 3).Should(Equal(int32(5)))
+			}, 3).Should(Equal(int32(15)))
 
 			Eventually(func() string {
 				sts := statefulSet(ctx, cluster)

--- a/controllers/reconcile_persistence.go
+++ b/controllers/reconcile_persistence.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/go-logr/logr"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
-	"github.com/rabbitmq/cluster-operator/internal/resource"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,23 +17,7 @@ import (
 	"time"
 )
 
-func (r *RabbitmqClusterReconciler) reconcilePVC(ctx context.Context, builder resource.ResourceBuilder, cluster *rabbitmqv1beta1.RabbitmqCluster, resource client.Object) error {
-	logger := ctrl.LoggerFrom(ctx)
-
-	sts := resource.(*appsv1.StatefulSet)
-	current, err := r.statefulSet(ctx, cluster)
-
-	if client.IgnoreNotFound(err) != nil {
-		return err
-	} else if k8serrors.IsNotFound(err) {
-		logger.Info("statefulSet not created yet, skipping checks to expand PersistentVolumeClaims")
-		return nil
-	}
-
-	if err := builder.Update(sts); err != nil {
-		return err
-	}
-
+func (r *RabbitmqClusterReconciler) reconcilePVC(ctx context.Context, cluster *rabbitmqv1beta1.RabbitmqCluster, current, sts *appsv1.StatefulSet) error {
 	resize, err := r.needsPVCResize(current, sts)
 	if err != nil {
 		return err

--- a/controllers/reconcile_scale_down_test.go
+++ b/controllers/reconcile_scale_down_test.go
@@ -1,0 +1,85 @@
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
+	"github.com/rabbitmq/cluster-operator/internal/status"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Cluster scale down", func() {
+	var (
+		cluster          *rabbitmqv1beta1.RabbitmqCluster
+		defaultNamespace = "default"
+		ctx              = context.Background()
+	)
+
+	AfterEach(func() {
+		Expect(client.Delete(ctx, cluster)).To(Succeed())
+		Eventually(func() bool {
+			rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+			err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
+			return apierrors.IsNotFound(err)
+		}, 5).Should(BeTrue())
+	})
+
+	It("does not allow cluster scale down", func() {
+		By("not updating statefulSet replicas", func() {
+			cluster = &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rabbitmq-shrink",
+					Namespace: defaultNamespace,
+				},
+				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
+					Replicas: pointer.Int32Ptr(5),
+				},
+			}
+			Expect(client.Create(ctx, cluster)).To(Succeed())
+			waitForClusterCreation(ctx, cluster, client)
+
+			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
+				r.Spec.Replicas = pointer.Int32Ptr(3)
+			})).To(Succeed())
+			Consistently(func() int32 {
+				sts, err := clientSet.AppsV1().StatefulSets(defaultNamespace).Get(ctx, cluster.ChildResourceName("server"), metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return *sts.Spec.Replicas
+			}, 10, 1).Should(Equal(int32(5)))
+		})
+
+		By("setting 'Warning' events", func() {
+			Expect(aggregateEventMsgs(ctx, cluster, "UnsupportedOperation")).To(
+				ContainSubstring("Cluster Scale down not supported"))
+		})
+
+		By("setting ReconcileSuccess to 'false'", func() {
+			Eventually(func() string {
+				rabbit := &rabbitmqv1beta1.RabbitmqCluster{}
+				Expect(client.Get(ctx, runtimeClient.ObjectKey{
+					Name:      cluster.Name,
+					Namespace: defaultNamespace,
+				}, rabbit)).To(Succeed())
+
+				for i := range rabbit.Status.Conditions {
+					if rabbit.Status.Conditions[i].Type == status.ReconcileSuccess {
+						return fmt.Sprintf(
+							"ReconcileSuccess status: %s, with reason: %s and message: %s",
+							rabbit.Status.Conditions[i].Status,
+							rabbit.Status.Conditions[i].Reason,
+							rabbit.Status.Conditions[i].Message)
+					}
+				}
+				return "ReconcileSuccess status: condition not present"
+			}, 5).Should(Equal("ReconcileSuccess status: False, " +
+				"with reason: UnsupportedOperation " +
+				"and message: Cluster Scale down not supported"))
+		})
+	})
+})

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -34,7 +34,9 @@ cluster_formation.k8s.host = kubernetes.default
 cluster_formation.k8s.address_type = hostname
 cluster_partition_handling = pause_minority
 queue_master_locator = min-masters
-disk_free_limit.absolute = 2GB`
+disk_free_limit.absolute = 2GB
+cluster_formation.randomized_startup_delay_range.min = 5
+cluster_formation.randomized_startup_delay_range.max = 30`
 
 	defaultTLSConf = `
 ssl_options.certfile = /etc/rabbitmq-tls/tls.crt

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -33,6 +33,8 @@ cluster_formation.k8s.address_type       = hostname
 cluster_partition_handling               = pause_minority
 queue_master_locator                     = min-masters
 disk_free_limit.absolute                 = 2GB
+cluster_formation.randomized_startup_delay_range.min = 5
+cluster_formation.randomized_startup_delay_range.max = 30
 cluster_name                             = ` + instanceName)
 }
 

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -67,6 +67,7 @@ func (builder *StatefulSetBuilder) Build() (client.Object, error) {
 				MatchLabels: metadata.LabelSelector(builder.Instance.Name),
 			},
 			VolumeClaimTemplates: pvc,
+			PodManagementPolicy:  appsv1.ParallelPodManagement,
 		},
 	}
 

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -65,6 +65,7 @@ var _ = Describe("StatefulSet", func() {
 
 			Expect(statefulSet.Spec.ServiceName).To(Equal(instance.ChildResourceName("nodes")))
 		})
+
 		It("adds the correct label selector", func() {
 			obj, err := stsBuilder.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -74,7 +75,15 @@ var _ = Describe("StatefulSet", func() {
 			Expect(labels["app.kubernetes.io/name"]).To(Equal(instance.Name))
 		})
 
-		It("references the storageclassname when specified", func() {
+		It("sets pod management policy to 'Parallel' ", func() {
+			obj, err := stsBuilder.Build()
+			Expect(err).NotTo(HaveOccurred())
+			statefulSet := obj.(*appsv1.StatefulSet)
+
+			Expect(statefulSet.Spec.PodManagementPolicy).To(Equal(appsv1.ParallelPodManagement))
+		})
+
+		It("references the storage class name when specified", func() {
 			storageClassName := "my-storage-class"
 			builder.Instance.Spec.Persistence.StorageClassName = &storageClassName
 


### PR DESCRIPTION
This closes #298 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- set `podManagementPolicy` to `Parallel`
- Use cluster_formation.randomized_startup_delay_range to avoid race condition between nodes during initial cluster formation
- This change solves the problem of failing to restart the cluster when all pods are deleted and recreated at once; with podManagementPolicy set to 'OrderedReady', pod 0 is also the first one getting recreated, but it may not be the last node to shut down. This problem was first reported in [community slack](https://rabbitmq.slack.com/archives/CTMSV81HA/p1609882247391800?thread_ts=1609802102.387100&cid=CTMSV81HA)

- **Disallow cluster scale down entirely** After talking to @mkuratczyk @MirahImage @yaronp68, we agreed that the cluster operator should prevent people from scaling down because it's not a properly supported and tested operation. Once `Reconcile()` has detect a scale down request, it will error, publish events, and set ReconcileSuccess to false.

- **PodManagementPolicy is immutable** For existing clusters, operators won't be able to update the policy successfully. Users would need to manually delete the statefulset with `cascading=false` first, and then the operator can recreate the statefulSet with the correct settings. This needs to be mentioned in release notes


## Additional Context

- It would have been a cleaner and more elegant solution if we can mark CRD requirements on `spec.replicas` people from updating it to a less number. That would involve a webhook which adds more component for us to maintain. The current solution is easier to achieve and considering we want to support scale down in the future, it's an OK temporary fix.

- controller-gen was updated in a previous PR, but the crd tag was not updated. I've included the change in this PR since it's a one liner.