### PR TITLE
Bump golang to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rabbitmq/cluster-operator
 
-go 1.15
+go 1.16
 
 require (
 	github.com/cloudflare/cfssl v1.5.0


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Use golang 1.16. 

## Additional Context

## Local Testing


