### PR TITLE
Make target to install Cert Manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ cert-manager-rm:
 	helm uninstall $(CERT_MANAGER_HELM_RELEASE) \
 		--namespace $(CERT_MANAGER_NAMESPACE)
 	kubectl delete namespace $(CERT_MANAGER_NAMESPACE)
+	helm repo remove jetstack
 
 kind-prepare: ## Prepare KIND to support LoadBalancer services
 	# Note that created LoadBalancer services will have an unreachable external IP

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,24 @@ docker-build-dev: check-env-docker-repo  git-commit-sha
 	docker build --build-arg=GIT_COMMIT=$(GIT_COMMIT) -t $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT) .
 	docker push $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT)
 
+CERT_MANAGER_VERSION ?= 1.2.0
+CERT_MANAGER_HELM_RELEASE := cert-manager
+CERT_MANAGER_NAMESPACE := cert-manager
+cert-manager:
+	@echo "Installing Cert Manager"
+	helm repo add jetstack https://charts.jetstack.io
+	helm upgrade $(CERT_MANAGER_HELM_RELEASE) jetstack/$(@) \
+		--install \
+		--namespace $(CERT_MANAGER_NAMESPACE) --create-namespace \
+		--version $(CERT_MANAGER_VERSION) \
+		--wait
+
+cert-manager-rm:
+	@echo "Deleting Cert Manager"
+	helm uninstall $(CERT_MANAGER_HELM_RELEASE) \
+		--namespace $(CERT_MANAGER_NAMESPACE)
+	kubectl delete namespace $(CERT_MANAGER_NAMESPACE)
+
 kind-prepare: ## Prepare KIND to support LoadBalancer services
 	# Note that created LoadBalancer services will have an unreachable external IP
 	@kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml


### PR DESCRIPTION
## Summary Of Changes
This PR adds a make target to install and remove cert manager deployment. It leverages Helm to install/upgrade/uninstall.

## Additional Context
This is useful to install Cert Manager to your current Kubernetes context. Cert Manager is used to generate certificates for TLS related deployments.

## Local Testing

```
kind create cluster
make cert-manager
kubectl get pods --all-namespaces
make cert-manager-rm
``` 
