### PR TITLE
Update supported tested k8s versions to match kind 0.10.0

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
         export GOPATH=$HOME/go
         export PATH=$PATH:$GOPATH/bin
         make install-tools
-        kind create cluster --image kindest/node:v1.20.0
+        kind create cluster --image kindest/node:v1.20.2
         kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.crds.yaml
         # Create CRD PodMonitor without running Prometheus operator
         curl https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml | sed "s/replicas: 1$/replicas: 0/" | kubectl apply -f -
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: [v1.17.11, v1.18.8, v1.19.4, v1.20.0]
+        k8s: [v1.18.15, v1.19.7, v1.20.2]
         rabbitmq-image:
         - rabbitmq:3.8.8-management
         - rabbitmq:3.8.9-management
@@ -77,7 +77,7 @@ jobs:
       uses: actions/checkout@v2
     - name: kubectl rabbitmq tests
       env:
-        K8S_VERSION: v1.20.0
+        K8S_VERSION: v1.20.2
       run: |
         export GOPATH=$HOME/go
         export PATH=$PATH:$GOPATH/bin

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.8.14` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.17` or newer.
+The operator deploys RabbitMQ `3.8.14` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.18` or newer.
 
 ## Versioning
 


### PR DESCRIPTION
- Removed end-of-life v1.17
- Updated testing for v1.18 to v1.18.15
- Updated testing for v1.19 to v1.19.7
- Updated testing for v1.20 to v1.20.2

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
