### PR TITLE
Increase collect_statistics_interval

### DIFF
--- a/docs/examples/production-ready/rabbitmq.yaml
+++ b/docs/examples/production-ready/rabbitmq.yaml
@@ -16,6 +16,7 @@ spec:
       cluster_partition_handling = pause_minority
       vm_memory_high_watermark_paging_ratio = 0.99
       disk_free_limit.relative = 1.0
+      collect_statistics_interval = 10000
   persistence:
     storageClassName: ssd
     storage: "500Gi"


### PR DESCRIPTION
https://www.rabbitmq.com/prometheus.html#prometheus:

> For production systems, we recommend a minimum value of 15s for
> Prometheus scrape interval and a 10000 (10s) value for RabbitMQ's
> collect_statistics_interval. With these values, Prometheus doesn't
> scrape RabbitMQ too frequently, and RabbitMQ doesn't update metrics
> unnecessarily.

The previous `collect_statistics_interval` was `5000` (5 seconds).