### PR TITLE
Remove unused status.clusterStatus

### DIFF
--- a/api/v1beta1/rabbitmqcluster_status.go
+++ b/api/v1beta1/rabbitmqcluster_status.go
@@ -8,8 +8,6 @@ import (
 
 // Status presents the observed state of RabbitmqCluster
 type RabbitmqClusterStatus struct {
-	// Unused.
-	ClusterStatus string `json:"clusterStatus,omitempty"`
 	// Set of Conditions describing the current state of the RabbitmqCluster
 	Conditions []status.RabbitmqClusterCondition `json:"conditions"`
 

--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -25,7 +25,6 @@ import (
 // corresponds to a single RabbitMQ cluster.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.clusterStatus"
 // +kubebuilder:resource:shortName={"rmq"}
 type RabbitmqCluster struct {
 	// Embedded metadata identifying a Kind and API Verison of an object.

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -28,9 +28,6 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-        - jsonPath: .status.clusterStatus
-          name: Status
-          type: string
       name: v1beta1
       schema:
         openAPIV3Schema:
@@ -3624,9 +3621,6 @@ spec:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
-                clusterStatus:
-                  description: Unused.
-                  type: string
                 conditions:
                   description: Set of Conditions describing the current state of the RabbitmqCluster
                   items:

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -325,7 +325,6 @@ Status presents the observed state of RabbitmqCluster
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`clusterStatus`* __string__ | Unused.
 | *`conditions`* __xref:{anchor_prefix}-github-com-rabbitmq-cluster-operator-internal-status-rabbitmqclustercondition[$$RabbitmqClusterCondition$$] array__ | Set of Conditions describing the current state of the RabbitmqCluster
 | *`defaultUser`* __xref:{anchor_prefix}-github-com-rabbitmq-cluster-operator-api-v1beta1-rabbitmqclusterdefaultuser[$$RabbitmqClusterDefaultUser$$]__ | Identifying information on internal resources
 | *`binding`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | Binding exposes a secret containing the binding information for this RabbitmqCluster. It implements the service binding Provisioned Service duck type. See: https://k8s-service-bindings.github.io/spec/#provisioned-service


### PR DESCRIPTION
This closes #636 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- remove unused rabbitmqCluster.status.clusterStatus from cluster status

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
