### PR TITLE
fix #648: delete the statefulset with precondition set to the correct…

### DIFF
--- a/controllers/reconcile_finalizer.go
+++ b/controllers/reconcile_finalizer.go
@@ -41,7 +41,7 @@ func (r *RabbitmqClusterReconciler) removeFinalizer(ctx context.Context, rabbitm
 func (r *RabbitmqClusterReconciler) prepareForDeletion(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
 	if controllerutil.ContainsFinalizer(rabbitmqCluster, deletionFinalizer) {
 		if err := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
-			uid, err := r.statefulSetUID(ctx, rabbitmqCluster);
+			uid, err := r.statefulSetUID(ctx, rabbitmqCluster)
 			if err != nil {
 				return err
 			}
@@ -58,6 +58,8 @@ func (r *RabbitmqClusterReconciler) prepareForDeletion(ctx context.Context, rabb
 			// Delete StatefulSet immediately after changing pod labels to minimize risk of them respawning.
 			// There is a window where the StatefulSet could respawn Pods without the deletion label in this order.
 			// But we can't delete it before because the DownwardAPI doesn't update once a Pod enters Terminating.
+			// Addressing #648: if both rabbitmqCluster and the statefulSet returned by r.Get() are stale (and match each other),
+			// setting the stale statefulSet's uid in the precondition can avoid mis-deleting any currently running statefulSet sharing the same name.
 			if err := r.Client.Delete(ctx, sts, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); client.IgnoreNotFound(err) != nil {
 				return fmt.Errorf("cannot delete StatefulSet: %s", err.Error())
 			}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -76,10 +76,10 @@ func (r *RabbitmqClusterReconciler) statefulSetUID(ctx context.Context, rmq *rab
 		return "", fmt.Errorf("failed to get statefulSet: %s", err.Error())
 	}
 	if ref = metav1.GetControllerOf(sts); ref == nil {
-		return "", errors.New("failed to get controller reference for statefulSet")
+		return "", fmt.Errorf("failed to get controller reference for statefulSet %s", sts.GetName())
 	}
 	if string(rmq.GetUID()) != string(ref.UID) {
-		return "", errors.New("statefulSet not owner by current RabbitmqCluster")
+		return "", fmt.Errorf("statefulSet %s not owned by current RabbitmqCluster %s", sts.GetName(), rmq.GetName())
 	}
 	return sts.UID, nil
 }


### PR DESCRIPTION
… UID

This closes #648

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
Ensure that the sts to be deleted has the correct uid (besides the name and namespace). A sts uid is a correct one if the sts's controller ref matches the current rabbitmqCluster's uid.

