### PR TITLE
Add RabbitmqClusters to categories all

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -19,13 +19,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +kubebuilder:object:root=true
 
-// RabbitmqCluster is the Schema for the RabbitmqCluster API. Each instance of this object
-// corresponds to a single RabbitMQ cluster.
+// +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:shortName={"rmq"}
+// +kubebuilder:resource:shortName={"rmq"},categories=all
+// RabbitmqCluster is the Schema for the RabbitmqCluster API. Each instance of this object
+// corresponds to a single RabbitMQ cluster.
 type RabbitmqCluster struct {
 	// Embedded metadata identifying a Kind and API Verison of an object.
 	// For more info, see: https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#TypeMeta

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -16,6 +16,8 @@ metadata:
 spec:
   group: rabbitmq.com
   names:
+    categories:
+      - all
     kind: RabbitmqCluster
     listKind: RabbitmqClusterList
     plural: rabbitmqclusters


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Organized kubebuilder markers a bit, it looked a bit messy before.

With this change you can see rabbitmqclusters when doing `kubectl get all`, like

```
❯ k get all
NAME                                             READY   STATUS    RESTARTS   AGE
pod/rabbitmq-cluster-operator-84c7588b78-768tk   1/1     Running   0          13m
pod/sample-server-0                              1/1     Running   0          8m33s

NAME                   TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                          AGE
service/sample         LoadBalancer   10.7.248.214   34.105.166.183   5672:30898/TCP,15672:31213/TCP   8m34s
service/sample-nodes   ClusterIP      None           <none>           4369/TCP,25672/TCP               8m34s

NAME                                        READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/rabbitmq-cluster-operator   1/1     1            1           13m

NAME                                                   DESIRED   CURRENT   READY   AGE
replicaset.apps/rabbitmq-cluster-operator-84c7588b78   1         1         1       13m

NAME                             READY   AGE
statefulset.apps/sample-server   1/1     8m34s

NAME                                  AGE
rabbitmqcluster.rabbitmq.com/sample   8m34s
```

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
