### PR TITLE
Provide container name in podExec helper function

### DIFF
--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Operator", func() {
 			By("having required plugins enabled", func() {
 				_, err := kubectlExec(namespace,
 					statefulSetPodName(cluster, 0),
+					"rabbitmq",
 					"rabbitmq-plugins",
 					"is_enabled",
 					"rabbitmq_management",
@@ -120,6 +121,7 @@ var _ = Describe("Operator", func() {
 				Eventually(func() []featureFlag {
 					output, err := kubectlExec(namespace,
 						statefulSetPodName(cluster, 0),
+						"rabbitmq",
 						"rabbitmqctl",
 						"list_feature_flags",
 						"--formatter=json",
@@ -168,6 +170,7 @@ var _ = Describe("Operator", func() {
 
 				_, err := kubectlExec(namespace,
 					statefulSetPodName(cluster, 0),
+					"rabbitmq",
 					"rabbitmq-plugins",
 					"is_enabled",
 					"rabbitmq_management",
@@ -209,6 +212,7 @@ cluster_keepalive_interval = 10000`
 
 				output, err := kubectlExec(namespace,
 					statefulSetPodName(cluster, 0),
+					"rabbitmq",
 					"cat",
 					"/etc/rabbitmq/advanced.config",
 				)
@@ -228,6 +232,7 @@ CONSOLE_LOG=new`
 				// verify that rabbitmq-env.conf contains provided configurations
 				output, err := kubectlExec(namespace,
 					statefulSetPodName(cluster, 0),
+					"rabbitmq",
 					"cat",
 					"/etc/rabbitmq/rabbitmq-env.conf",
 				)
@@ -318,7 +323,7 @@ CONSOLE_LOG=new`
 
 		It("allows volume expansion", func() {
 			podUID := pod(ctx, clientSet, cluster, 0).UID
-			output, err := kubectlExec(namespace, statefulSetPodName(cluster, 0), "df", "/var/lib/rabbitmq/mnesia")
+			output, err := kubectlExec(namespace, statefulSetPodName(cluster, 0), "rabbitmq", "df", "/var/lib/rabbitmq/mnesia")
 			Expect(err).ToNot(HaveOccurred())
 			previousDiskSize, err := strconv.Atoi(strings.Fields(strings.Split(string(output), "\n")[1])[1])
 
@@ -438,14 +443,14 @@ CONSOLE_LOG=new`
 
 				By("supporting tls cert rotation", func() {
 					oldConnectionCertificate := inspectServerCertificate(username, password, hostname, amqpsNodePort, caFilePath)
-					oldServerCert, err := kubectlExec(cluster.Namespace, statefulSetPodName(cluster, 0), "cat", "/etc/rabbitmq-tls/tls.crt")
+					oldServerCert, err := kubectlExec(cluster.Namespace, statefulSetPodName(cluster, 0), "rabbitmq", "cat", "/etc/rabbitmq-tls/tls.crt")
 					Expect(err).NotTo(HaveOccurred())
 
 					updateTLSSecret("rabbitmq-tls-test-secret", namespace, hostname, caCert, caKey)
 
 					// takes time for mounted secret to be updated
 					Eventually(func() []byte {
-						actualCert, err := kubectlExec(cluster.Namespace, statefulSetPodName(cluster, 0), "cat", "/etc/rabbitmq-tls/tls.crt")
+						actualCert, err := kubectlExec(cluster.Namespace, statefulSetPodName(cluster, 0), "rabbitmq", "cat", "/etc/rabbitmq-tls/tls.crt")
 						Expect(err).NotTo(HaveOccurred())
 						return actualCert
 					}, 180, 10).ShouldNot(Equal(oldServerCert))

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -103,12 +103,14 @@ func createRestConfig() (*rest.Config, error) {
 	return config, nil
 }
 
-func kubectlExec(namespace, podname string, args ...string) ([]byte, error) {
+func kubectlExec(namespace, podname, containerName string, args ...string) ([]byte, error) {
 	kubectlArgs := append([]string{
 		"-n",
 		namespace,
 		"exec",
 		podname,
+		"-c",
+		containerName,
 		"--",
 	}, args...)
 
@@ -513,6 +515,7 @@ func kubernetesNodeIp(ctx context.Context, clientSet *kubernetes.Clientset) stri
 func getConfigFileFromPod(namespace string, cluster *rabbitmqv1beta1.RabbitmqCluster, path string) map[string]string {
 	output, err := kubectlExec(namespace,
 		statefulSetPodName(cluster, 0),
+		"rabbitmq",
 		"cat",
 		path,
 	)


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

We bumped the version of kubectl installed in our CI image as a side effect of commit: https://github.com/pivotal/rabbitmq-for-kubernetes-ci/commit/6f3d20bd7e44e585b15a75f4f427d4bc3f0156ba

With kubectl 1.21, when running `kubectl exec` withnot providing a container name, there would be an additional line of output which breaks how certain system tests assertions. For example:

```
k exec basic-rabbit-server-0 -- ls
Defaulted container "rabbitmq" out of: rabbitmq, setup-container (init) # additional line compared to previous
bin
boot
dev
etc
```
- related CI failures are here: https://hush-house.pivotal.io/teams/rabbitmq-for-kubernetes/pipelines/operator/jobs/system-tests-oss-image/builds/119

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
