### PR TITLE
Update app.kubernetes.io/component labels on resources

### DIFF
--- a/config/crd/patches/crd_labels_patch.yaml
+++ b/config/crd/patches/crd_labels_patch.yaml
@@ -13,5 +13,5 @@ metadata:
   name: rabbitmqclusters.rabbitmq.com
   labels:
     app.kubernetes.io/name: rabbitmq-cluster-operator
-    app.kubernetes.io/component: rabbitmq-cluster-operator
+    app.kubernetes.io/component: rabbitmq-operator
     app.kubernetes.io/part-of: rabbitmq

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: system
   labels:
     app.kubernetes.io/name: rabbitmq-cluster-operator
-    app.kubernetes.io/component: rabbitmq-cluster-operator
+    app.kubernetes.io/component: rabbitmq-operator
     app.kubernetes.io/part-of: rabbitmq
 spec:
   selector:
@@ -26,7 +26,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq-cluster-operator
-        app.kubernetes.io/component: rabbitmq-cluster-operator
+        app.kubernetes.io/component: rabbitmq-operator
         app.kubernetes.io/part-of: rabbitmq
     spec:
       serviceAccountName: rabbitmq-cluster-operator

--- a/config/namespace/base/namespace.yaml
+++ b/config/namespace/base/namespace.yaml
@@ -11,6 +11,6 @@ kind: Namespace
 metadata:
   labels:
     app.kubernetes.io/name: rabbitmq-system
-    app.kubernetes.io/component: rabbitmq-cluster-operator
+    app.kubernetes.io/component: rabbitmq-operator
     app.kubernetes.io/part-of: rabbitmq
   name: rabbitmq-system

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -14,7 +14,7 @@ metadata:
   name: leader-election-role
   labels:
     app.kubernetes.io/name: rabbitmq-cluster-operator
-    app.kubernetes.io/component: rabbitmq-cluster-operator
+    app.kubernetes.io/component: rabbitmq-operator
     app.kubernetes.io/part-of: rabbitmq
 rules:
 - apiGroups:

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -13,7 +13,7 @@ metadata:
   name: leader-election-rolebinding
   labels:
     app.kubernetes.io/name: rabbitmq-cluster-operator
-    app.kubernetes.io/component: rabbitmq-cluster-operator
+    app.kubernetes.io/component: rabbitmq-operator
     app.kubernetes.io/part-of: rabbitmq
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -13,7 +13,7 @@ metadata:
   name: operator-rolebinding
   labels:
     app.kubernetes.io/name: rabbitmq-cluster-operator
-    app.kubernetes.io/component: rabbitmq-cluster-operator
+    app.kubernetes.io/component: rabbitmq-operator
     app.kubernetes.io/part-of: rabbitmq
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/role_labels_patch.yaml
+++ b/config/rbac/role_labels_patch.yaml
@@ -14,5 +14,5 @@ metadata:
   name: operator-role
   labels:
     app.kubernetes.io/name: rabbitmq-cluster-operator
-    app.kubernetes.io/component: rabbitmq-cluster-operator
+    app.kubernetes.io/component: rabbitmq-operator
     app.kubernetes.io/part-of: rabbitmq

--- a/observability/prometheus/monitors/README.md
+++ b/observability/prometheus/monitors/README.md
@@ -42,7 +42,7 @@ spec:
     interval: 15s
   selector:
     matchLabels:
-      app.kubernetes.io/component: rabbitmq
+      app.kubernetes.io/component: rabbitmq-operator
   namespaceSelector:
     any: true
 ```

--- a/observability/prometheus/monitors/rabbitmq-cluster-operator-podmonitor.yml
+++ b/observability/prometheus/monitors/rabbitmq-cluster-operator-podmonitor.yml
@@ -9,7 +9,7 @@ spec:
   - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/component: rabbitmq-cluster-operator
+      app.kubernetes.io/component: rabbitmq-operator
   namespaceSelector:
     matchNames:
     - rabbitmq-system

--- a/observability/prometheus/monitors/rabbitmq-servicemonitor.yml
+++ b/observability/prometheus/monitors/rabbitmq-servicemonitor.yml
@@ -18,6 +18,6 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
-      app.kubernetes.io/component: rabbitmq
+      app.kubernetes.io/component: rabbitmq-operator
   namespaceSelector:
     any: true

--- a/observability/prometheus/monitors/rabbitmq-servicemonitor.yml
+++ b/observability/prometheus/monitors/rabbitmq-servicemonitor.yml
@@ -18,6 +18,6 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
-      app.kubernetes.io/component: rabbitmq-operator
+      app.kubernetes.io/component: rabbitmq
   namespaceSelector:
     any: true


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

This sets the component label on resources generated by kustomize to be consistent with the topology operator.

## Additional Context

See also https://github.com/rabbitmq/messaging-topology-operator/pull/122

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
