### PR TITLE
Use Prometheus TLS port if TLS is enabled

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -302,7 +302,7 @@ func sortVolumeMounts(mounts []corev1.VolumeMount) {
 func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[string]string) corev1.PodTemplateSpec {
 	// default pod annotations used for prometheus metrics
 	prometheusPort := "15692"
-	if builder.Instance.DisableNonTLSListeners() {
+	if builder.Instance.TLSEnabled() {
 		prometheusPort = "15691"
 	}
 

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -564,6 +564,18 @@ var _ = Describe("StatefulSet", func() {
 				})
 			})
 
+			When("TLS is enabled", func() {
+				It("updates Prometheus port", func() {
+					stsBuilder.Instance.Spec.TLS.SecretName = "tls-secret"
+					Expect(stsBuilder.Update(statefulSet)).To(Succeed())
+					expectedPodAnnotations := map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/port":   "15691",
+					}
+					Expect(statefulSet.Spec.Template.Annotations).To(Equal(expectedPodAnnotations))
+				})
+			})
+
 			Context("annotation inheritance", func() {
 				var (
 					existingAnnotations            map[string]string
@@ -658,21 +670,6 @@ var _ = Describe("StatefulSet", func() {
 					}
 
 					Expect(statefulSet.Spec.VolumeClaimTemplates[0].Annotations).To(Equal(expectedAnnotations))
-				})
-
-				When("non-TLS listeners get disabled", func() {
-					It("updates pod annotations", func() {
-						stsBuilder.Instance.Spec.TLS.DisableNonTLSListeners = true
-						Expect(stsBuilder.Update(statefulSet)).To(Succeed())
-
-						expectedPodAnnotations := map[string]string{
-							"prometheus.io/scrape":           "true",
-							"prometheus.io/port":             "15691",
-							"this-was-the-previous-pod-anno": "should-be-preserved",
-						}
-
-						Expect(statefulSet.Spec.Template.Annotations).To(Equal(expectedPodAnnotations))
-					})
 				})
 			})
 		})


### PR DESCRIPTION
When TLS is enabled use the prometheus-tls port in the annotation.

This matches the behaviour of the Service:
When TLS is enabled, port 15691 is exposed in the Service.