### PR TITLE
Wider randomized_startup_delay_range

### DIFF
--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -35,8 +35,8 @@ cluster_formation.k8s.address_type = hostname
 cluster_partition_handling = pause_minority
 queue_master_locator = min-masters
 disk_free_limit.absolute = 2GB
-cluster_formation.randomized_startup_delay_range.min = 5
-cluster_formation.randomized_startup_delay_range.max = 30`
+cluster_formation.randomized_startup_delay_range.min = 0
+cluster_formation.randomized_startup_delay_range.max = 60`
 
 	defaultTLSConf = `
 ssl_options.certfile = /etc/rabbitmq-tls/tls.crt

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -33,8 +33,8 @@ cluster_formation.k8s.address_type       = hostname
 cluster_partition_handling               = pause_minority
 queue_master_locator                     = min-masters
 disk_free_limit.absolute                 = 2GB
-cluster_formation.randomized_startup_delay_range.min = 5
-cluster_formation.randomized_startup_delay_range.max = 30
+cluster_formation.randomized_startup_delay_range.min = 0
+cluster_formation.randomized_startup_delay_range.max = 60
 cluster_name                             = ` + instanceName)
 }
 


### PR DESCRIPTION
We've observed cluster formation failures at a rate of about 7%.
With these values, it seems to be below 1% (not a single failure in 100
tests). The ultimate solution remains to implement locking in the k8s
peer discovery plugin but this change should alleviate the issue until
then.

More info: https://github.com/rabbitmq/cluster-operator/issues/662
