### PR TITLE
Provide container name for pod exec in test examples

### DIFF
--- a/docs/examples/community-plugins/test.sh
+++ b/docs/examples/community-plugins/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-kubectl exec community-plugins-server-0 -- rabbitmq-plugins is_enabled rabbitmq_message_timestamp
+kubectl exec community-plugins-server-0 -c rabbitmq -- rabbitmq-plugins is_enabled rabbitmq_message_timestamp
 

--- a/docs/examples/federation-over-tls/test.sh
+++ b/docs/examples/federation-over-tls/test.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 set -ex
-kubectl exec -it federation-server-0 -- rabbitmqadmin --username admin --password admin \
+kubectl exec -it federation-server-0 -c rabbitmq -- rabbitmqadmin --username admin --password admin \
   --vhost=upstream publish exchange=example routing_key=123 payload="1234"
 
-kubectl exec -it federation-server-0 -- rabbitmqadmin --username admin --password admin \
+kubectl exec -it federation-server-0 -c rabbitmq -- rabbitmqadmin --username admin --password admin \
   --vhost=downstream --format=pretty_json get queue=qq1 ackmode='ack_requeue_false' \
   | jq -e '.[].payload'
 
-kubectl exec -it federation-server-0 -- rabbitmqadmin --username admin --password admin \
+kubectl exec -it federation-server-0 -c rabbitmq -- rabbitmqadmin --username admin --password admin \
   --vhost=downstream --format=pretty_json get queue=cq1 ackmode='ack_requeue_false' \
   | jq -e '.[].payload'
 

--- a/docs/examples/import-definitions/test.sh
+++ b/docs/examples/import-definitions/test.sh
@@ -3,7 +3,7 @@
 pushd "$(mktemp -d)" || exit 1
 
 set -x
-kubectl exec import-definitions-server-0 -- rabbitmqadmin \
+kubectl exec import-definitions-server-0 -c rabbitmq -- rabbitmqadmin \
   --format=raw_json --vhost=hello-world --username=hello-world \
   --password=hello-world --host=import-definitions.examples.svc \
   list queues &> queues.json

--- a/docs/examples/mtls-inter-node/test.sh
+++ b/docs/examples/mtls-inter-node/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 set -ex
-kubectl exec -t mtls-inter-node-server-0 -- rabbitmq-diagnostics command_line_arguments > kubectl.out
+kubectl exec -t mtls-inter-node-server-0 -c rabbitmq -- rabbitmq-diagnostics command_line_arguments > kubectl.out
 grep '{proto_dist,\["inet_tls"\]}' kubectl.out
 

--- a/docs/examples/multiple-disks/test.sh
+++ b/docs/examples/multiple-disks/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-kubectl exec -t multiple-disks-server-0 -- rabbitmqctl environment > rabbitmq-environment.out
+kubectl exec -t multiple-disks-server-0 -c rabbitmq -- rabbitmqctl environment > rabbitmq-environment.out
 
 grep 'data_dir,"/var/lib/rabbitmq/quorum-segments"' rabbitmq-environment.out
 grep "{wal_data_dir,'/var/lib/rabbitmq/quorum-wal'}" rabbitmq-environment.out

--- a/docs/examples/tls/test.sh
+++ b/docs/examples/tls/test.sh
@@ -1,6 +1,6 @@
 
 set -e
-kubectl exec -it tls-server-0 -- openssl s_client -connect tls-nodes.examples.svc.cluster.local:5671 </dev/null
+kubectl exec -it tls-server-0 -c rabbitmq -- openssl s_client -connect tls-nodes.examples.svc.cluster.local:5671 </dev/null
 
-kubectl exec -it tls-server-0 -- openssl s_client -connect tls-nodes.examples.svc.cluster.local:15671 </dev/null
+kubectl exec -it tls-server-0 -c rabbitmq -- openssl s_client -connect tls-nodes.examples.svc.cluster.local:15671 </dev/null
 


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

With kubectl 1.19, when running kubectl exec withnot providing a container name, there would be an additional line of output , for example:
```
k exec basic-rabbit-server-0 -- ls
Defaulted container "rabbitmq" out of: rabbitmq, setup-container (init) # additional line compared to previous
bin
boot
dev
etc
```

This broke the test.sh assertion from import-definition example
```
+ ./test.sh
/tmp/tmp.9yG85cM7iO /tmp/build/03d44872/go/src/github.com/rabbitmq/cluster-operator/docs/examples/import-definitions
+ kubectl exec import-definitions-server-0 -- rabbitmqadmin --format=raw_json --vhost=hello-world --username=hello-world --password=hello-world --host=import-definitions.examples.svc list queues
++ jq '.[0].name' queues.json
parse error: Invalid numeric literal at line 1, column 10
+ [[ '' == \"\c\q\1\" ]]
+ exit 2
```
https://hush-house.pivotal.io/teams/rabbitmq-for-kubernetes/pipelines/operator/jobs/test-examples/builds/73

This PR also set container name for other pod exec, so line `Defaulted container "rabbitmq" out of: rabbitmq, setup-container (init) # additional line compared to previous` doesn't get printed for every single pod exec in test-examples job.


## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
