### PR TITLE
Explore: classic peer discovery with randomised startup delay

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -280,7 +280,7 @@ type Plugin string
 
 // RabbitMQ-related configuration.
 type RabbitmqClusterConfigurationSpec struct {
-	// List of plugins to enable in addition to essential plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s.
+	// List of plugins to enable in addition to essential plugins: rabbitmq_management, and rabbitmq_prometheus.
 	// +kubebuilder:validation:MaxItems:=100
 	AdditionalPlugins []Plugin `json:"additionalPlugins,omitempty"`
 	// Modify to add to the rabbitmq.conf file in addition to default configurations set by the operator.

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -3496,7 +3496,7 @@ spec:
                       maxLength: 2000
                       type: string
                     additionalPlugins:
-                      description: 'List of plugins to enable in addition to essential plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s.'
+                      description: 'List of plugins to enable in addition to essential plugins: rabbitmq_management, and rabbitmq_prometheus.'
                       items:
                         description: A Plugin to enable on the RabbitmqCluster.
                         maxLength: 100

--- a/controllers/reconcile_rabbitmq_configurations.go
+++ b/controllers/reconcile_rabbitmq_configurations.go
@@ -34,7 +34,7 @@ func (r *RabbitmqClusterReconciler) annotateIfNeeded(ctx context.Context, logger
 		annotationKey string
 	)
 
-	switch builder.(type) {
+	switch b := builder.(type) {
 
 	case *resource.RabbitmqPluginsConfigMapBuilder:
 		if operationResult != controllerutil.OperationResultUpdated {
@@ -45,7 +45,7 @@ func (r *RabbitmqClusterReconciler) annotateIfNeeded(ctx context.Context, logger
 		annotationKey = pluginsUpdateAnnotation
 
 	case *resource.ServerConfigMapBuilder:
-		if operationResult != controllerutil.OperationResultUpdated {
+		if operationResult != controllerutil.OperationResultUpdated || !b.UpdateRequiresStsRestart {
 			return nil
 		}
 		obj = &corev1.ConfigMap{}

--- a/controllers/reconcile_rabbitmq_configurations_test.go
+++ b/controllers/reconcile_rabbitmq_configurations_test.go
@@ -1,14 +1,16 @@
 package controllers_test
 
 import (
-	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"time"
+
+	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("Reconcile rabbitmq Configurations", func() {
@@ -16,66 +18,96 @@ var _ = Describe("Reconcile rabbitmq Configurations", func() {
 		cluster          *rabbitmqv1beta1.RabbitmqCluster
 		defaultNamespace = "default"
 	)
-	DescribeTable("Server configurations updates",
-		func(testCase string) {
-			// create rabbitmqcluster
-			cluster = &rabbitmqv1beta1.RabbitmqCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "rabbitmq-" + testCase,
-					Namespace: defaultNamespace,
-				},
+
+	AfterEach(func() {
+		Expect(client.Delete(ctx, cluster)).To(Succeed())
+		waitForClusterDeletion(ctx, cluster, client)
+	})
+
+	DescribeTable("Server configurations updates", func(testCase string) {
+		cluster = &rabbitmqv1beta1.RabbitmqCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: defaultNamespace,
+				Name:      "rabbitmq-" + testCase,
+			},
+		}
+		Expect(client.Create(ctx, cluster)).To(Succeed())
+		waitForClusterCreation(ctx, cluster, client)
+
+		// ensure that cfm and statefulSet does not have annotations set when cluster just got created
+		cfm := configMap(ctx, cluster, "server-conf")
+		Expect(cfm.Annotations).ShouldNot(HaveKey("rabbitmq.com/serverConfUpdatedAt"))
+		sts := statefulSet(ctx, cluster)
+		Expect(sts.Annotations).ShouldNot(HaveKey("rabbitmq.com/lastRestartAt"))
+
+		// update rabbitmq server configurations
+		Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
+			if testCase == "additional-config" {
+				r.Spec.Rabbitmq.AdditionalConfig = "test_config=0"
 			}
-			Expect(client.Create(ctx, cluster)).To(Succeed())
-			waitForClusterCreation(ctx, cluster, client)
+			if testCase == "advanced-config" {
+				r.Spec.Rabbitmq.AdvancedConfig = "sample-advanced-config."
+			}
+			if testCase == "env-config" {
+				r.Spec.Rabbitmq.EnvConfig = "some-env-variable"
+			}
+		})).To(Succeed())
 
-			// ensure that cfm and statefulSet does not have annotations set when configurations haven't changed
+		By("annotating the server-conf ConfigMap")
+		// ensure annotations from the server-conf ConfigMap
+		var annotations map[string]string
+		Eventually(func() map[string]string {
 			cfm := configMap(ctx, cluster, "server-conf")
-			Expect(cfm.Annotations).ShouldNot(HaveKey("rabbitmq.com/serverConfUpdatedAt"))
+			annotations = cfm.Annotations
+			return annotations
+		}, 5).Should(HaveKey("rabbitmq.com/serverConfUpdatedAt"))
+		_, err := time.Parse(time.RFC3339, annotations["rabbitmq.com/serverConfUpdatedAt"])
+		Expect(err).NotTo(HaveOccurred(), "Annotation rabbitmq.com/serverConfUpdatedAt was not a valid RFC3339 timestamp")
 
+		By("annotating the sts podTemplate")
+		// ensure statefulSet annotations
+		Eventually(func() map[string]string {
 			sts := statefulSet(ctx, cluster)
-			Expect(sts.Annotations).ShouldNot(HaveKey("rabbitmq.com/lastRestartAt"))
-
-			// update rabbitmq server configurations
-			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
-				if testCase == "additional-config" {
-					r.Spec.Rabbitmq.AdditionalConfig = "test_config=0"
-				}
-				if testCase == "advanced-config" {
-					r.Spec.Rabbitmq.AdvancedConfig = "sample-advanced-config."
-				}
-				if testCase == "env-config" {
-					r.Spec.Rabbitmq.EnvConfig = "some-env-variable"
-				}
-			})).To(Succeed())
-
-			By("annotating the server-conf ConfigMap")
-			// ensure annotations from the server-conf ConfigMap
-			var annotations map[string]string
-			Eventually(func() map[string]string {
-				cfm := configMap(ctx, cluster, "server-conf")
-				annotations = cfm.Annotations
-				return annotations
-			}, 5).Should(HaveKey("rabbitmq.com/serverConfUpdatedAt"))
-			_, err := time.Parse(time.RFC3339, annotations["rabbitmq.com/serverConfUpdatedAt"])
-			Expect(err).NotTo(HaveOccurred(), "Annotation rabbitmq.com/serverConfUpdatedAt was not a valid RFC3339 timestamp")
-
-			By("annotating the sts podTemplate")
-			// ensure statefulSet annotations
-			Eventually(func() map[string]string {
-				sts := statefulSet(ctx, cluster)
-				annotations = sts.Spec.Template.Annotations
-				return annotations
-			}, 5).Should(HaveKey("rabbitmq.com/lastRestartAt"))
-			_, err = time.Parse(time.RFC3339, annotations["rabbitmq.com/lastRestartAt"])
-			Expect(err).NotTo(HaveOccurred(), "Annotation rabbitmq.com/lastRestartAt was not a valid RFC3339 timestamp")
-
-			// delete rmq cluster
-			Expect(client.Delete(ctx, cluster)).To(Succeed())
-			waitForClusterDeletion(ctx, cluster, client)
-		},
+			annotations = sts.Spec.Template.Annotations
+			return annotations
+		}, 5).Should(HaveKey("rabbitmq.com/lastRestartAt"))
+		_, err = time.Parse(time.RFC3339, annotations["rabbitmq.com/lastRestartAt"])
+		Expect(err).NotTo(HaveOccurred(), "Annotation rabbitmq.com/lastRestartAt was not a valid RFC3339 timestamp")
+	},
 
 		Entry("spec.rabbitmq.additionalConfig is updated", "additional-config"),
 		Entry("spec.rabbitmq.advancedConfig is updated", "advanced-config"),
 		Entry("spec.rabbitmq.envConfig is updated", "env-config"),
 	)
+
+	Context("scale out", func() {
+		It("does not restart StatefulSet", func() {
+			cluster = &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: defaultNamespace,
+					Name:      "rabbitmq-scale-out",
+				},
+			}
+			Expect(client.Create(ctx, cluster)).To(Succeed())
+			waitForClusterCreation(ctx, cluster, client)
+
+			cfm := configMap(ctx, cluster, "server-conf")
+			Expect(cfm.Annotations).ShouldNot(HaveKey("rabbitmq.com/serverConfUpdatedAt"))
+			sts := statefulSet(ctx, cluster)
+			Expect(sts.Annotations).ShouldNot(HaveKey("rabbitmq.com/lastRestartAt"))
+
+			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
+				r.Spec.Replicas = pointer.Int32Ptr(5)
+			})).To(Succeed())
+
+			Consistently(func() map[string]string {
+				return configMap(ctx, cluster, "server-conf").Annotations
+			}, 3, 0.3).ShouldNot(HaveKey("rabbitmq.com/serverConfUpdatedAt"))
+
+			Consistently(func() map[string]string {
+				sts := statefulSet(ctx, cluster)
+				return sts.Spec.Template.Annotations
+			}, 3, 0.3).ShouldNot(HaveKey("rabbitmq.com/lastRestartAt"))
+		})
+	})
 })

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -148,7 +148,7 @@ RabbitMQ-related configuration.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`additionalPlugins`* __xref:{anchor_prefix}-github-com-rabbitmq-cluster-operator-api-v1beta1-plugin[$$Plugin$$] array__ | List of plugins to enable in addition to essential plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s.
+| *`additionalPlugins`* __xref:{anchor_prefix}-github-com-rabbitmq-cluster-operator-api-v1beta1-plugin[$$Plugin$$] array__ | List of plugins to enable in addition to essential plugins: rabbitmq_management, and rabbitmq_prometheus.
 | *`additionalConfig`* __string__ | Modify to add to the rabbitmq.conf file in addition to default configurations set by the operator. Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime. For more information on this config, see https://www.rabbitmq.com/configure.html#config-file
 | *`advancedConfig`* __string__ | Specify any rabbitmq advanced.config configurations to apply to the cluster. For more information on advanced config, see https://www.rabbitmq.com/configure.html#advanced-config-file
 | *`envConfig`* __string__ | Modify to add to the rabbitmq-env.conf file. Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime. For more information on env config, see https://www.rabbitmq.com/man/rabbitmq-env.conf.5.html
@@ -298,7 +298,7 @@ Spec is the desired state of the RabbitmqCluster Custom Resource.
 | Field | Description
 | *`replicas`* __integer__ | Replicas is the number of nodes in the RabbitMQ cluster. Each node is deployed as a Replica in a StatefulSet. Only 1, 3, 5 replicas clusters are tested. This value should be an odd number to ensure the resultant cluster can establish exactly one quorum of nodes in the event of a fragmenting network partition.
 | *`image`* __string__ | Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster. Must be provided together with ImagePullSecrets in order to use an image in a private registry.
-| *`imagePullSecrets`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#localobjectreference-v1-core[$$LocalObjectReference$$] array__ | List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
+| *`imagePullSecrets`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
 | *`service`* __xref:{anchor_prefix}-github-com-rabbitmq-cluster-operator-api-v1beta1-rabbitmqclusterservicespec[$$RabbitmqClusterServiceSpec$$]__ | The desired state of the Kubernetes Service to create for the cluster.
 | *`persistence`* __xref:{anchor_prefix}-github-com-rabbitmq-cluster-operator-api-v1beta1-rabbitmqclusterpersistencespec[$$RabbitmqClusterPersistenceSpec$$]__ | The desired persistent storage configuration for each Pod in the cluster.
 | *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | The desired compute resource requirements of Pods in the cluster.

--- a/internal/resource/headless_service.go
+++ b/internal/resource/headless_service.go
@@ -21,9 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	headlessServiceSuffix = "nodes"
-)
+const headlessServiceSuffix = "nodes"
 
 type HeadlessServiceBuilder struct {
 	*RabbitmqResourceBuilder

--- a/internal/resource/rabbitmq_plugins.go
+++ b/internal/resource/rabbitmq_plugins.go
@@ -15,8 +15,7 @@ import (
 )
 
 var requiredPlugins = []string{
-	"rabbitmq_peer_discovery_k8s", // required for clustering
-	"rabbitmq_prometheus",         // enforce prometheus metrics
+	"rabbitmq_prometheus", // enforce prometheus metrics
 	"rabbitmq_management",
 }
 

--- a/internal/resource/rabbitmq_plugins_test.go
+++ b/internal/resource/rabbitmq_plugins_test.go
@@ -28,7 +28,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 		When("AdditionalPlugins is empty", func() {
 			It("returns list of required plugins", func() {
 				plugins := NewRabbitmqPlugins(nil)
-				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s", "rabbitmq_prometheus", "rabbitmq_management"}))
+				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_prometheus", "rabbitmq_management"}))
 			})
 		})
 
@@ -37,7 +37,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 				morePlugins := []rabbitmqv1beta1.Plugin{"rabbitmq_shovel", "my_great_plugin"}
 				plugins := NewRabbitmqPlugins(morePlugins)
 
-				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s",
+				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{
 					"rabbitmq_prometheus",
 					"rabbitmq_management",
 					"my_great_plugin",
@@ -51,7 +51,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 				morePlugins := []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_shovel", "my_great_plugin", "rabbitmq_shovel"}
 				plugins := NewRabbitmqPlugins(morePlugins)
 
-				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s",
+				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{
 					"rabbitmq_prometheus",
 					"rabbitmq_management",
 					"my_great_plugin",
@@ -117,10 +117,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 			})
 
 			It("adds list of default plugins", func() {
-				expectedEnabledPlugins := "[" +
-					"rabbitmq_peer_discovery_k8s," +
-					"rabbitmq_prometheus," +
-					"rabbitmq_management]."
+				expectedEnabledPlugins := "[rabbitmq_prometheus,rabbitmq_management]."
 
 				obj, err := configMapBuilder.Build()
 				Expect(err).NotTo(HaveOccurred())
@@ -184,7 +181,6 @@ var _ = Describe("RabbitMQPlugins", func() {
 						builder.Instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_management", "rabbitmq_shovel", "my_great_plugin"}
 
 						expectedEnabledPlugins := "[" +
-							"rabbitmq_peer_discovery_k8s," +
 							"rabbitmq_prometheus," +
 							"rabbitmq_management," +
 							"rabbitmq_shovel," +
@@ -199,7 +195,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 				When("previous data is present", func() {
 					BeforeEach(func() {
 						configMap.Data = map[string]string{
-							"enabled_plugins": "[rabbitmq_peer_discovery_k8s,rabbitmq_shovel]",
+							"enabled_plugins": "[rabbitmq_prometheus,rabbitmq_shovel]",
 						}
 					})
 
@@ -207,7 +203,6 @@ var _ = Describe("RabbitMQPlugins", func() {
 						builder.Instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_management", "rabbitmq_shovel", "my_great_plugin"}
 
 						expectedEnabledPlugins := "[" +
-							"rabbitmq_peer_discovery_k8s," +
 							"rabbitmq_prometheus," +
 							"rabbitmq_management," +
 							"rabbitmq_shovel," +

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -31,6 +31,7 @@ import (
 )
 
 const (
+	stsSuffix           string = "server"
 	initContainerCPU    string = "100m"
 	initContainerMemory string = "500Mi"
 	defaultPVCName      string = "persistence"
@@ -54,7 +55,7 @@ func (builder *StatefulSetBuilder) Build() (client.Object, error) {
 
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      builder.Instance.ChildResourceName("server"),
+			Name:      builder.Instance.ChildResourceName(stsSuffix),
 			Namespace: builder.Instance.Namespace,
 		},
 		Spec: appsv1.StatefulSetSpec{

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -78,7 +78,6 @@ var _ = Describe("Operator", func() {
 					"rabbitmq-plugins",
 					"is_enabled",
 					"rabbitmq_management",
-					"rabbitmq_peer_discovery_k8s",
 					"rabbitmq_prometheus",
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -174,7 +173,6 @@ var _ = Describe("Operator", func() {
 					"rabbitmq-plugins",
 					"is_enabled",
 					"rabbitmq_management",
-					"rabbitmq_peer_discovery_k8s",
 					"rabbitmq_prometheus",
 					"rabbitmq_top",
 				)


### PR DESCRIPTION
Relates #662.

Dynamic peer discovery is not needed for RabbitMQ Clusters deployed by the Cluster Operator. All nodes are known at deploy time. The Cluster Operator knows the number of replicas and their host names.

This PR uses classic peer discovery with a static list of nodes instead of the dynamic `rabbitmq_peer_discovery_k8s` plugin.
In the case of a scale out (i.e. more RabbitMQ nodes added to the RabbitMQ cluster), existing nodes do not get restarted.

**Pros:**
* Nodes can join other nodes that are `running` but not yet `ready` increasing the likelihood of discovering peers
* no sophisticated locking mechanism

**Cons:**
* There might still be cases where clusters do not get formed correctly since this approach still relies on randomised startup delays. @mkuratczyk and I are doing some more testing with different parameters.

**Alternatives:**
* Enforce dedicated node to form the cluster: #689 
* Use a lock in `rabbitmq_peer_discovery_k8s` (e.g. as done in controller-runtime leader election)