### PR TITLE
Explore: classic peer discovery without randomised startup delay

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -280,7 +280,7 @@ type Plugin string
 
 // RabbitMQ-related configuration.
 type RabbitmqClusterConfigurationSpec struct {
-	// List of plugins to enable in addition to essential plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s.
+	// List of plugins to enable in addition to essential plugins: rabbitmq_management, and rabbitmq_prometheus.
 	// +kubebuilder:validation:MaxItems:=100
 	AdditionalPlugins []Plugin `json:"additionalPlugins,omitempty"`
 	// Modify to add to the rabbitmq.conf file in addition to default configurations set by the operator.

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -3496,7 +3496,7 @@ spec:
                       maxLength: 2000
                       type: string
                     additionalPlugins:
-                      description: 'List of plugins to enable in addition to essential plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s.'
+                      description: 'List of plugins to enable in addition to essential plugins: rabbitmq_management, and rabbitmq_prometheus.'
                       items:
                         description: A Plugin to enable on the RabbitmqCluster.
                         maxLength: 100

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -829,8 +829,8 @@ var _ = Describe("RabbitmqClusterController", func() {
 				}))
 
 			Expect(sts.Spec.Template.Spec.HostNetwork).To(BeFalse())
-			Expect(sts.Spec.Template.Spec.Volumes).To(ConsistOf(
-				corev1.Volume{
+			Expect(sts.Spec.Template.Spec.Volumes).To(ConsistOf([]corev1.Volume{
+				{
 					Name: "additional-config",
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -841,7 +841,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 						},
 					},
 				},
-				corev1.Volume{
+				{
 					Name: "rabbitmq-confd",
 					VolumeSource: corev1.VolumeSource{
 						Projected: &corev1.ProjectedVolumeSource{
@@ -881,7 +881,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 						},
 					},
 				},
-				corev1.Volume{
+				{
 					Name: "plugins-conf",
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -893,19 +893,19 @@ var _ = Describe("RabbitmqClusterController", func() {
 					},
 				},
 
-				corev1.Volume{
+				{
 					Name: "rabbitmq-plugins",
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
 				},
-				corev1.Volume{
+				{
 					Name: "rabbitmq-erlang-cookie",
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
 				},
-				corev1.Volume{
+				{
 					Name: "erlang-cookie-secret",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
@@ -914,7 +914,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 						},
 					},
 				},
-				corev1.Volume{
+				{
 					Name: "pod-info",
 					VolumeSource: corev1.VolumeSource{
 						DownwardAPI: &corev1.DownwardAPIVolumeSource{
@@ -930,7 +930,14 @@ var _ = Describe("RabbitmqClusterController", func() {
 							},
 						},
 					},
-				}))
+				},
+				{
+					Name: "rabbitmq-configs",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			}))
 
 			Expect(extractContainer(sts.Spec.Template.Spec.Containers, "additional-container").Image).To(Equal("my-great-image"))
 		})

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -148,7 +148,7 @@ RabbitMQ-related configuration.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`additionalPlugins`* __xref:{anchor_prefix}-github-com-rabbitmq-cluster-operator-api-v1beta1-plugin[$$Plugin$$] array__ | List of plugins to enable in addition to essential plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s.
+| *`additionalPlugins`* __xref:{anchor_prefix}-github-com-rabbitmq-cluster-operator-api-v1beta1-plugin[$$Plugin$$] array__ | List of plugins to enable in addition to essential plugins: rabbitmq_management, and rabbitmq_prometheus.
 | *`additionalConfig`* __string__ | Modify to add to the rabbitmq.conf file in addition to default configurations set by the operator. Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime. For more information on this config, see https://www.rabbitmq.com/configure.html#config-file
 | *`advancedConfig`* __string__ | Specify any rabbitmq advanced.config configurations to apply to the cluster. For more information on advanced config, see https://www.rabbitmq.com/configure.html#advanced-config-file
 | *`envConfig`* __string__ | Modify to add to the rabbitmq-env.conf file. Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime. For more information on env config, see https://www.rabbitmq.com/man/rabbitmq-env.conf.5.html
@@ -298,7 +298,7 @@ Spec is the desired state of the RabbitmqCluster Custom Resource.
 | Field | Description
 | *`replicas`* __integer__ | Replicas is the number of nodes in the RabbitMQ cluster. Each node is deployed as a Replica in a StatefulSet. Only 1, 3, 5 replicas clusters are tested. This value should be an odd number to ensure the resultant cluster can establish exactly one quorum of nodes in the event of a fragmenting network partition.
 | *`image`* __string__ | Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster. Must be provided together with ImagePullSecrets in order to use an image in a private registry.
-| *`imagePullSecrets`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#localobjectreference-v1-core[$$LocalObjectReference$$] array__ | List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
+| *`imagePullSecrets`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
 | *`service`* __xref:{anchor_prefix}-github-com-rabbitmq-cluster-operator-api-v1beta1-rabbitmqclusterservicespec[$$RabbitmqClusterServiceSpec$$]__ | The desired state of the Kubernetes Service to create for the cluster.
 | *`persistence`* __xref:{anchor_prefix}-github-com-rabbitmq-cluster-operator-api-v1beta1-rabbitmqclusterpersistencespec[$$RabbitmqClusterPersistenceSpec$$]__ | The desired persistent storage configuration for each Pod in the cluster.
 | *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | The desired compute resource requirements of Pods in the cluster.

--- a/internal/resource/headless_service.go
+++ b/internal/resource/headless_service.go
@@ -21,9 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	headlessServiceSuffix = "nodes"
-)
+const headlessServiceSuffix = "nodes"
 
 type HeadlessServiceBuilder struct {
 	*RabbitmqResourceBuilder

--- a/internal/resource/rabbitmq_plugins.go
+++ b/internal/resource/rabbitmq_plugins.go
@@ -15,8 +15,7 @@ import (
 )
 
 var requiredPlugins = []string{
-	"rabbitmq_peer_discovery_k8s", // required for clustering
-	"rabbitmq_prometheus",         // enforce prometheus metrics
+	"rabbitmq_prometheus", // enforce prometheus metrics
 	"rabbitmq_management",
 }
 

--- a/internal/resource/rabbitmq_plugins_test.go
+++ b/internal/resource/rabbitmq_plugins_test.go
@@ -28,7 +28,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 		When("AdditionalPlugins is empty", func() {
 			It("returns list of required plugins", func() {
 				plugins := NewRabbitmqPlugins(nil)
-				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s", "rabbitmq_prometheus", "rabbitmq_management"}))
+				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_prometheus", "rabbitmq_management"}))
 			})
 		})
 
@@ -37,7 +37,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 				morePlugins := []rabbitmqv1beta1.Plugin{"rabbitmq_shovel", "my_great_plugin"}
 				plugins := NewRabbitmqPlugins(morePlugins)
 
-				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s",
+				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{
 					"rabbitmq_prometheus",
 					"rabbitmq_management",
 					"my_great_plugin",
@@ -51,7 +51,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 				morePlugins := []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_shovel", "my_great_plugin", "rabbitmq_shovel"}
 				plugins := NewRabbitmqPlugins(morePlugins)
 
-				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s",
+				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{
 					"rabbitmq_prometheus",
 					"rabbitmq_management",
 					"my_great_plugin",
@@ -117,10 +117,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 			})
 
 			It("adds list of default plugins", func() {
-				expectedEnabledPlugins := "[" +
-					"rabbitmq_peer_discovery_k8s," +
-					"rabbitmq_prometheus," +
-					"rabbitmq_management]."
+				expectedEnabledPlugins := "[rabbitmq_prometheus,rabbitmq_management]."
 
 				obj, err := configMapBuilder.Build()
 				Expect(err).NotTo(HaveOccurred())
@@ -184,7 +181,6 @@ var _ = Describe("RabbitMQPlugins", func() {
 						builder.Instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_management", "rabbitmq_shovel", "my_great_plugin"}
 
 						expectedEnabledPlugins := "[" +
-							"rabbitmq_peer_discovery_k8s," +
 							"rabbitmq_prometheus," +
 							"rabbitmq_management," +
 							"rabbitmq_shovel," +
@@ -199,7 +195,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 				When("previous data is present", func() {
 					BeforeEach(func() {
 						configMap.Data = map[string]string{
-							"enabled_plugins": "[rabbitmq_peer_discovery_k8s,rabbitmq_shovel]",
+							"enabled_plugins": "[rabbitmq_prometheus,rabbitmq_shovel]",
 						}
 					})
 
@@ -207,7 +203,6 @@ var _ = Describe("RabbitMQPlugins", func() {
 						builder.Instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_management", "rabbitmq_shovel", "my_great_plugin"}
 
 						expectedEnabledPlugins := "[" +
-							"rabbitmq_peer_discovery_k8s," +
 							"rabbitmq_prometheus," +
 							"rabbitmq_management," +
 							"rabbitmq_shovel," +

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -381,10 +381,10 @@ CONSOLE_LOG=new`
 
 				By("configuring pod 0 to form the RabbitMQ cluster")
 				cfgMap := getConfigFileFromPod(namespace, cluster, 0, "/etc/rabbitmq/conf.d/12-cluster_formation.conf")
-				Expect(cfgMap).To(ConsistOf(HaveKeyWithValue("cluster_formation.discovery_retry_limit", "1")))
+				Expect(cfgMap).To(HaveKeyWithValue("cluster_formation.discovery_retry_limit", "1"))
 				for i := 1; i <= 2; i++ {
 					cfgMap = getConfigFileFromPod(namespace, cluster, i, "/etc/rabbitmq/conf.d/12-cluster_formation.conf")
-					Expect(cfgMap).To(ConsistOf(HaveKeyWithValue("cluster_formation.discovery_retry_limit", "86400")))
+					Expect(cfgMap).To(HaveKeyWithValue("cluster_formation.discovery_retry_limit", "86400"))
 				}
 			})
 		})

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -512,9 +512,9 @@ func kubernetesNodeIp(ctx context.Context, clientSet *kubernetes.Clientset) stri
 	return nodeIp
 }
 
-func getConfigFileFromPod(namespace string, cluster *rabbitmqv1beta1.RabbitmqCluster, path string) map[string]string {
+func getConfigFileFromPod(namespace string, cluster *rabbitmqv1beta1.RabbitmqCluster, podIndex int, path string) map[string]string {
 	output, err := kubectlExec(namespace,
-		statefulSetPodName(cluster, 0),
+		statefulSetPodName(cluster, podIndex),
 		"rabbitmq",
 		"cat",
 		path,


### PR DESCRIPTION
Relates #662.

Enforce pod 0 to form the cluster.

**Pros:**
* no randomised startup delay => always a single node (pod 0) forms the cluster
* no sophisticated locking mechanism

**Cons:**
* If pod 0 never starts, the cluster wont't be created. I think that's okay. For new clusters, all nodes should be up & running.
* Sporadically, there are container restarts since nodes crash with below `schema_integrity_check_failed` error. Eventually the cluster gets created successfully and all pods become `ready`. Solution: have one node initialize itself at a time.
```
2021-05-12 15:34:02.786 [debug] <0.67.0> Supervisor kernel_safe_sup started pg_local:start_link() at pid <0.1065.0>
2021-05-12 15:34:02.876 [info] <0.44.0> Application mnesia exited with reason: stopped

2021-05-12 15:34:02.877 [error] <0.273.0>
2021-05-12 15:34:02.877 [info] <0.44.0> Application mnesia exited with reason: stopped
2021-05-12 15:34:02.877 [error] <0.273.0> BOOT FAILED
2021-05-12 15:34:02.877 [error] <0.273.0> ===========
2021-05-12 15:34:02.877 [error] <0.273.0> Error during startup: {error,
2021-05-12 15:34:02.877 [error] <0.273.0>                           {schema_integrity_check_failed,
BOOT FAILED
===========
Error during startup: {error,
                          {schema_integrity_check_failed,
2021-05-12 15:34:02.877 [error] <0.273.0>                               [{table_attributes_mismatch,rabbit_user,
2021-05-12 15:34:02.878 [error] <0.273.0>                                    [username,password_hash,tags,
                              [{table_attributes_mismatch,rabbit_user,
                                   [username,password_hash,tags,
                                    hashing_algorithm],
                                   [username,password_hash,tags,
                                    hashing_algorithm,limits]},
2021-05-12 15:34:02.878 [error] <0.273.0>                                     hashing_algorithm],
2021-05-12 15:34:02.878 [error] <0.273.0>                                    [username,password_hash,tags,
2021-05-12 15:34:02.878 [error] <0.273.0>                                     hashing_algorithm,limits]},
                               {table_attributes_mismatch,rabbit_vhost,
2021-05-12 15:34:02.878 [error] <0.273.0>                                {table_attributes_mismatch,rabbit_vhost,
2021-05-12 15:34:02.878 [error] <0.273.0>                                    [virtual_host,limits],
2021-05-12 15:34:02.879 [error] <0.273.0>                                    [virtual_host,limits,metadata]}]}}
                                   [virtual_host,limits],
                                   [virtual_host,limits,metadata]}]}}

2021-05-12 15:34:02.879 [error] <0.273.0>
2021-05-12 15:34:03.880 [debug] <0.273.0> Set stop reason to: {error,{schema_integrity_check_failed,[{table_attributes_mismatch,rabbit_user,[username,password_hash,tags,hashing_algorithm],[username,password_hash,tags,hashing_algorithm,limits]},{table_attributes_mismatch,rabbit_vhost,[virtual_host,limits],[virtual_host,limits,metadata]}]}}
2021-05-12 15:34:03.880 [debug] <0.273.0> Change boot state to `stopped`
2021-05-12 15:34:03.881 [debug] <0.44.0> Running rabbit_prelaunch:shutdown_func() as part of `kernel` shutdown
2021-05-12 15:34:03.881 [info] <0.272.0> [{initial_call,{application_master,init,['Argument__1','Argument__2','Argument__3','Argument__4']}},{pid,<0.272.0>},{registered_name,[]},{error_info,{exit,{{schema_integrity_check_failed,[{table_attributes_mismatch,rabbit_user,[username,password_hash,tags,hashing_algorithm],[username,password_hash,tags,hashing_algorithm,limits]},{table_attributes_mismatch,rabbit_vhost,[virtual_host,limits],[virtual_host,limits,metadata]}]},{rabbit,start,[normal,[]]}},[{application_master,init,4,[{file,"application_master.erl"},{line,138}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}},{ancestors,[<0.271.0>]},{message_queue_len,1},{messages,[{'EXIT',<0.273.0>,normal}]},{links,[<0.271.0>,<0.44.0>]},{dictionary,[]},{trap_exit,true},{status,running},{heap_size,376},{stack_size,28},{reductions,620}], []
2021-05-12 15:34:03.881 [debug] <0.44.0> Deleting PID file: /var/lib/rabbitmq/mnesia/rabbit@r1-server-2.r1-nodes.default.pid
2021-05-12 15:34:03.881 [error] <0.272.0> CRASH REPORT Process <0.272.0> with 0 neighbours exited with reason: {{schema_integrity_check_failed,[{table_attributes_mismatch,rabbit_user,[username,password_hash,tags,hashing_algorithm],[username,password_hash,tags,hashing_algorithm,limits]},{table_attributes_mismatch,rabbit_vhost,[virtual_host,limits],[virtual_host,limits,metadata]}]},{rabbit,start,[normal,[]]}} in application_master:init/4 line 138
```