### PR TITLE
Bump to latest k8s patch version for PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
         export GOPATH=$HOME/go
         export PATH=$PATH:$GOPATH/bin
         make install-tools
-        kind create cluster --image kindest/node:v1.20.2
+        kind create cluster --image kindest/node:v1.20.7
         kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.crds.yaml
         # Create CRD PodMonitor without running Prometheus operator
         curl https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml | sed "s/replicas: 1$/replicas: 0/" | kubectl apply -f -
@@ -45,9 +45,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-        - v1.18.15
-        - v1.19.7
-        - v1.20.2
+        - v1.18.19
+        - v1.19.11
+        - v1.20.7
         rabbitmq-image:
         - rabbitmq:3.8.8-management
         - rabbitmq:3.8-management
@@ -80,7 +80,7 @@ jobs:
       uses: actions/checkout@v2
     - name: kubectl rabbitmq tests
       env:
-        K8S_VERSION: v1.20.2
+        K8S_VERSION: v1.20.7
       run: |
         export GOPATH=$HOME/go
         export PATH=$PATH:$GOPATH/bin


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Bump to latest k8s patch versions for PR workflow.

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
