### PR TITLE
Remove runAsGroup to add compatibility with bitnami/rabbitmq

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -312,7 +312,6 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 	memoryRequest := k8sresource.MustParse(initContainerMemory)
 
 	automountServiceAccountToken := true
-	rabbitmqGID := int64(999)
 	rabbitmqUID := int64(999)
 
 	readinessProbePort := "amqp"
@@ -525,9 +524,8 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 				},
 			},
 			SecurityContext: &corev1.PodSecurityContext{
-				FSGroup:    &rabbitmqGID,
-				RunAsGroup: &rabbitmqGID,
-				RunAsUser:  &rabbitmqUID,
+				FSGroup:   &rabbitmqUID,
+				RunAsUser: &rabbitmqUID,
 			},
 			ImagePullSecrets:              builder.Instance.Spec.ImagePullSecrets,
 			TerminationGracePeriodSeconds: builder.Instance.Spec.TerminationGracePeriodSeconds,

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1189,12 +1189,11 @@ var _ = Describe("StatefulSet", func() {
 			stsBuilder := builder.StatefulSet()
 			Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 
-			rmqGID, rmqUID := int64(999), int64(999)
+			rmqUID := int64(999)
 
 			expectedPodSecurityContext := &corev1.PodSecurityContext{
-				FSGroup:    &rmqGID,
-				RunAsGroup: &rmqGID,
-				RunAsUser:  &rmqUID,
+				FSGroup:   &rmqUID,
+				RunAsUser: &rmqUID,
 			}
 
 			Expect(statefulSet.Spec.Template.Spec.SecurityContext).To(Equal(expectedPodSecurityContext))


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
Currently, the operator was not compatible with the bitnami/rabbitmq container because it requires to run as group `0` (following the Openshift container guidelines https://docs.openshift.com/container-platform/3.3/creating_images/guidelines.html). As the library/rabbitmq container only requires to be run as user `999` to work, the runAsGroup setting does not seem to be necessary. 

The changes were tested in minikube and GKE and no issues appeared.

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
