### PR TITLE
Add additional printing columns

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -21,6 +21,8 @@ import (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="AllReplicasReady",type="string",JSONPath=".status.conditions[?(@.type == 'AllReplicasReady')].status"
+// +kubebuilder:printcolumn:name="ReconcileSuccess",type="string",JSONPath=".status.conditions[?(@.type == 'ReconcileSuccess')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:shortName={"rmq"},categories=all
 // RabbitmqCluster is the Schema for the RabbitmqCluster API. Each instance of this object

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -27,6 +27,12 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type == 'AllReplicasReady')].status
+          name: AllReplicasReady
+          type: string
+        - jsonPath: .status.conditions[?(@.type == 'ReconcileSuccess')].status
+          name: ReconcileSuccess
+          type: string
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date


### PR DESCRIPTION
This closes #647 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

This adds two columns to the output of `kubectl get` for `RabbitmqClusters`: 

- AllReplicasReady
- ReconcileSuccess

These correspond to the equivalent fields in the Status of the object in question.

## Additional Context

For example, when creating a 3-node cluster:
![image](https://user-images.githubusercontent.com/23215294/121674513-10cc2f00-caaa-11eb-9b39-0af9662c8fed.png)

Once the deployment is complete:
![image](https://user-images.githubusercontent.com/23215294/121674540-19246a00-caaa-11eb-92e0-14cce9e59715.png)

After applying an update to the cluster:
![image](https://user-images.githubusercontent.com/23215294/121674594-25102c00-caaa-11eb-9e32-68b13e6a8d60.png)

After applying an update that fails to reconcile (in this case, some override config that was incorrect):
![image](https://user-images.githubusercontent.com/23215294/121674614-2ccfd080-caaa-11eb-95e9-f2194fdfb8a1.png)

I considered adding system tests for this feature, however decided against it as I believe these tests would be too brittle to changes to kubectl itself, and feels outside the remit of testing for this repo.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
