### PR TITLE
Use RabbitMQ user for init container instead of root

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -540,23 +540,8 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 					Name:  "setup-container",
 					Image: builder.Instance.Spec.Image,
 					SecurityContext: &corev1.SecurityContext{
-						RunAsUser: pointer.Int64Ptr(0),
-						Capabilities: &corev1.Capabilities{
-							// drop default set from Docker except for CHOWN, FOWNER, and DAC_OVERRIDE
-							Drop: []corev1.Capability{
-								"FSETID",
-								"KILL",
-								"SETGID",
-								"SETUID",
-								"SETPCAP",
-								"NET_BIND_SERVICE",
-								"NET_RAW",
-								"SYS_CHROOT",
-								"MKNOD",
-								"AUDIT_WRITE",
-								"SETFCAP",
-							},
-						},
+						RunAsGroup: &rabbitmqGID,
+						RunAsUser:  &rabbitmqUID,
 					},
 					Command: []string{
 						"sh", "-c", "cp /tmp/erlang-cookie-secret/.erlang.cookie /var/lib/rabbitmq/.erlang.cookie " +

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1217,26 +1217,13 @@ var _ = Describe("StatefulSet", func() {
 			initContainers := statefulSet.Spec.Template.Spec.InitContainers
 			Expect(initContainers).To(HaveLen(1))
 
+			rmqGID, rmqUID := int64(999), int64(999)
 			initContainer := extractContainer(initContainers, "setup-container")
 			Expect(initContainer).To(MatchFields(IgnoreExtras, Fields{
 				"Image": Equal("rabbitmq-image-from-cr"),
 				"SecurityContext": PointTo(MatchFields(IgnoreExtras, Fields{
-					"Capabilities": PointTo(MatchAllFields(Fields{
-						"Drop": ConsistOf([]corev1.Capability{
-							"FSETID",
-							"KILL",
-							"SETGID",
-							"SETUID",
-							"SETPCAP",
-							"NET_BIND_SERVICE",
-							"NET_RAW",
-							"SYS_CHROOT",
-							"MKNOD",
-							"AUDIT_WRITE",
-							"SETFCAP",
-						}),
-						"Add": BeEmpty(),
-					})),
+					"RunAsUser":  Equal(&rmqUID),
+					"RunAsGroup": Equal(&rmqGID),
 				})),
 				"Command": ConsistOf(
 					"sh", "-c", "cp /tmp/erlang-cookie-secret/.erlang.cookie /var/lib/rabbitmq/.erlang.cookie "+


### PR DESCRIPTION
This closes #357 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
This changes the init container from running as root to running as the same specified RabbitMQ user - 999. This allows RabbitmqClusters to be deployed on environments with restrictive security policies that do not allow for root containers, while still retaining support for Openshift.

## Additional Context
RabbitMQ requires group ownership of the Mnesia database, which is mounted as a persistent volume.

The root init container was added in #303, as a means of changing the GID of this volume on Openshift - in Openshift, we observed that the GID was not being modified by `StatefulSet.Spec.SecurityContext.FSGroup`, and so the volume had the wrong owner. We added the init container to set the GID of this volume correctly on all systems.

The default set of capabilities on Openshift's container runtime, CRI-O, as well as on containerd & Docker, includes `SETGID`, so one shouldn't need to run as root to perform these actions. In testing, the initContainer seems to handle running as the RabbitMQ user `999`, and correctly sets the permissions & owner of the Mnesia volume on all three container runtimes (CRI-O tested on Openshift, containerd & Docker tested on GKE).

I'm not sure if something has changed to make this work, if we falsely assumed we needed root for this in the past, or if CRC (where we previously tested Openshift) uses a different default set of capabilities.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
