### PR TITLE
Remove chmod operations from init Container

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -543,14 +543,10 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 					},
 					Command: []string{
 						"sh", "-c", "cp /tmp/erlang-cookie-secret/.erlang.cookie /var/lib/rabbitmq/.erlang.cookie " +
-							"&& chown 999:999 /var/lib/rabbitmq/.erlang.cookie " +
 							"&& chmod 600 /var/lib/rabbitmq/.erlang.cookie ; " +
-							"cp /tmp/rabbitmq-plugins/enabled_plugins /operator/enabled_plugins " +
-							"&& chown 999:999 /operator/enabled_plugins ; " +
-							"chown 999:999 /var/lib/rabbitmq/mnesia/ ; " +
+							"cp /tmp/rabbitmq-plugins/enabled_plugins /operator/enabled_plugins ; " +
 							"echo '[default]' > /var/lib/rabbitmq/.rabbitmqadmin.conf " +
 							"&& sed -e 's/default_user/username/' -e 's/default_pass/password/' /tmp/default_user.conf >> /var/lib/rabbitmq/.rabbitmqadmin.conf " +
-							"&& chown 999:999 /var/lib/rabbitmq/.rabbitmqadmin.conf " +
 							"&& chmod 600 /var/lib/rabbitmq/.rabbitmqadmin.conf",
 					},
 					Resources: corev1.ResourceRequirements{

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1226,14 +1226,10 @@ var _ = Describe("StatefulSet", func() {
 				})),
 				"Command": ConsistOf(
 					"sh", "-c", "cp /tmp/erlang-cookie-secret/.erlang.cookie /var/lib/rabbitmq/.erlang.cookie "+
-						"&& chown 999:999 /var/lib/rabbitmq/.erlang.cookie "+
 						"&& chmod 600 /var/lib/rabbitmq/.erlang.cookie ; "+
-						"cp /tmp/rabbitmq-plugins/enabled_plugins /operator/enabled_plugins "+
-						"&& chown 999:999 /operator/enabled_plugins ; "+
-						"chown 999:999 /var/lib/rabbitmq/mnesia/ ; "+
+						"cp /tmp/rabbitmq-plugins/enabled_plugins /operator/enabled_plugins ; "+
 						"echo '[default]' > /var/lib/rabbitmq/.rabbitmqadmin.conf "+
 						"&& sed -e 's/default_user/username/' -e 's/default_pass/password/' /tmp/default_user.conf >> /var/lib/rabbitmq/.rabbitmqadmin.conf "+
-						"&& chown 999:999 /var/lib/rabbitmq/.rabbitmqadmin.conf "+
 						"&& chmod 600 /var/lib/rabbitmq/.rabbitmqadmin.conf",
 				),
 				"VolumeMounts": ConsistOf([]corev1.VolumeMount{


### PR DESCRIPTION
This is no longer needed as fsGroup modifies this for us.

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

`fsGroup`, set in the securityContext of mounted volumes, already sets the ownership of files within the volumes, so explicitly setting them in the initContainer is unnecessary. We also no longer run as GID 999, so part of the chown operation is actively doing the wrong thing now.

## Additional Context
This brings the operator closer to supporting Openshift's arbitrary user flow. 

Following this PR will be updates to the docs around installing on Openshift.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
