### PR TITLE
Fix missing definition in failing unit tests

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -538,8 +538,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 					Name:  "setup-container",
 					Image: builder.Instance.Spec.Image,
 					SecurityContext: &corev1.SecurityContext{
-						RunAsGroup: &rabbitmqGID,
-						RunAsUser:  &rabbitmqUID,
+						RunAsUser: &rabbitmqUID,
 					},
 					Command: []string{
 						"sh", "-c", "cp /tmp/erlang-cookie-secret/.erlang.cookie /var/lib/rabbitmq/.erlang.cookie " +

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1216,13 +1216,12 @@ var _ = Describe("StatefulSet", func() {
 			initContainers := statefulSet.Spec.Template.Spec.InitContainers
 			Expect(initContainers).To(HaveLen(1))
 
-			rmqGID, rmqUID := int64(999), int64(999)
+			rmqUID := int64(999)
 			initContainer := extractContainer(initContainers, "setup-container")
 			Expect(initContainer).To(MatchFields(IgnoreExtras, Fields{
 				"Image": Equal("rabbitmq-image-from-cr"),
 				"SecurityContext": PointTo(MatchFields(IgnoreExtras, Fields{
-					"RunAsUser":  Equal(&rmqUID),
-					"RunAsGroup": Equal(&rmqGID),
+					"RunAsUser": Equal(&rmqUID),
 				})),
 				"Command": ConsistOf(
 					"sh", "-c", "cp /tmp/erlang-cookie-secret/.erlang.cookie /var/lib/rabbitmq/.erlang.cookie "+


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Removes the undefined variable from the unit tests, and removes the RunAsGroup from the initContainer. Not sure how it made it through #724 without failing there.

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
