### PR TITLE
Allow SecurityContext and PodSecurityContext to be reset to default

### DIFF
--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -959,7 +959,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 			}, 3).Should(Equal("my-great-image-2"))
 		})
 
-		It("can reset a controller-set field to default", func() {
+		It("can reset the securityContext of the RabbitMQ container and initContainer to default", func() {
 			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
 				cluster.Spec.Override.StatefulSet.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
 				cluster.Spec.Override.StatefulSet.Spec.Template.Spec.InitContainers = []corev1.Container{

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/status"
 	appsv1 "k8s.io/api/apps/v1"
@@ -957,6 +958,28 @@ var _ = Describe("RabbitmqClusterController", func() {
 				return c.Image
 			}, 3).Should(Equal("my-great-image-2"))
 		})
+
+		It("can reset a controller-set field to default", func() {
+			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
+				cluster.Spec.Override.StatefulSet.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
+				cluster.Spec.Override.StatefulSet.Spec.Template.Spec.InitContainers = []corev1.Container{
+					{
+						Name:            "setup-container",
+						SecurityContext: &corev1.SecurityContext{},
+					},
+				}
+			})).To(Succeed())
+
+			Eventually(func() corev1.PodSecurityContext {
+				sts := statefulSet(ctx, cluster)
+				return *sts.Spec.Template.Spec.SecurityContext
+			}, 3).Should(MatchFields(IgnoreExtras, Fields{
+				"RunAsUser": BeNil(),
+				"FSGroup":   BeNil(),
+			}))
+			Expect(statefulSet(ctx, cluster).Spec.Template.Spec.InitContainers[0].SecurityContext).To(BeNil())
+		})
+
 	})
 
 	Context("Service Override", func() {

--- a/docs/examples/default-security-context/README.md
+++ b/docs/examples/default-security-context/README.md
@@ -1,0 +1,29 @@
+# Setting Pod Security Context to Container Runtime default
+
+By default, the RabbitMQ Cluster Operator applies a [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) in order to run the RabbitMQ container
+and initContainer as a specific non-root user.
+
+In some deployments, you may wish to remove this securityContext so that the containers are run with the default securityContext of the container runtime. For example, in Openshift, in order
+to [run the RabbitMQ containers as an arbitrary user](https://www.openshift.com/blog/a-guide-to-openshift-and-uids), you will need to remove the operator-configured securityContext.
+
+Note that unless your Kubernetes distribution applies a default securityContext to pods, your containers will run as root.
+
+## Example
+
+The example `rabbitmq.yaml` contains an override which will set the securityContext to the default, by specifying it as an empty struct (`{}`).
+
+```shell
+kubectl apply -f rabbitmq.yaml
+```
+
+You can then inspect the container to check that it is running with the default securityContext:
+```shell
+kubectl exec default-security-context-server-0 -- id
+uid=0(root) gid=0(root) groups=0(root)
+```
+
+Or, in an environment where the runtime provides a default securityContext, like Openshift:
+```shell
+kubectl exec default-security-context-server-0 -- id
+uid=1000620000(1000620000) gid=0(root) groups=0(root),1000620000
+```

--- a/docs/examples/default-security-context/rabbitmq.yaml
+++ b/docs/examples/default-security-context/rabbitmq.yaml
@@ -1,0 +1,15 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: default-security-context
+spec:
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            securityContext: {}
+            containers: []
+            initContainers:
+            - name: setup-container
+              securityContext: {}

--- a/docs/examples/default-security-context/test.sh
+++ b/docs/examples/default-security-context/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -x
+
+uid="$(kubectl exec default-security-context-server-0 -- \
+  id -u 2> /dev/null)"
+groups="$(kubectl exec default-security-context-server-0 -- \
+  id -G 2> /dev/null)"
+## kubectl std. error is redirectd to null because the error output of jsonpath
+## is not very helpful to troubleshoot
+
+[[ "$uid" == "0" && "$groups" == "0" ]] || exit 1
+

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -259,10 +259,12 @@ func patchPodSpec(podSpec, podSpecOverride *corev1.PodSpec) (corev1.PodSpec, err
 		sortVolumeMounts(patchedPodSpec.Containers[0].VolumeMounts)
 	}
 
+	// A user may wish to override the controller-set securityContext for the RabbitMQ & init containers so that the
+	// container runtime can override them. If the securityContext has been set to an empty struct, `strategicpatch.StrategicMergePatch`
+	// won't pick this up, so manually override it here.
 	if podSpecOverride.SecurityContext != nil && reflect.DeepEqual(*podSpecOverride.SecurityContext, corev1.PodSecurityContext{}) {
 		patchedPodSpec.SecurityContext = nil
 	}
-
 	for i := range podSpecOverride.InitContainers {
 		if podSpecOverride.InitContainers[i].SecurityContext != nil && reflect.DeepEqual(*podSpecOverride.InitContainers[i].SecurityContext, corev1.SecurityContext{}) {
 			patchedPodSpec.InitContainers[i].SecurityContext = nil

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -12,6 +12,7 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -256,6 +257,16 @@ func patchPodSpec(podSpec, podSpecOverride *corev1.PodSpec) (corev1.PodSpec, err
 	// we need to ensure that '/var/lib/rabbitmq/' always mounts before '/var/lib/rabbitmq/mnesia/' to avoid shadowing
 	if rmqContainer.VolumeMounts != nil {
 		sortVolumeMounts(patchedPodSpec.Containers[0].VolumeMounts)
+	}
+
+	if podSpecOverride.SecurityContext != nil && reflect.DeepEqual(*podSpecOverride.SecurityContext, corev1.PodSecurityContext{}) {
+		patchedPodSpec.SecurityContext = nil
+	}
+
+	for i := range podSpecOverride.InitContainers {
+		if podSpecOverride.InitContainers[i].SecurityContext != nil && reflect.DeepEqual(*podSpecOverride.InitContainers[i].SecurityContext, corev1.SecurityContext{}) {
+			patchedPodSpec.InitContainers[i].SecurityContext = nil
+		}
 	}
 
 	return patchedPodSpec, nil

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1693,6 +1693,34 @@ var _ = Describe("StatefulSet", func() {
 							},
 						}))
 				})
+				It("can reset securityContext to default", func() {
+					instance.Spec.Override.StatefulSet = &rabbitmqv1beta1.StatefulSet{
+						Spec: &rabbitmqv1beta1.StatefulSetSpec{
+							Template: &rabbitmqv1beta1.PodTemplateSpec{
+								Spec: &corev1.PodSpec{
+									SecurityContext: &corev1.PodSecurityContext{},
+									InitContainers: []corev1.Container{
+										{
+											Name:            "setup-container",
+											SecurityContext: &corev1.SecurityContext{},
+										},
+									},
+								},
+							},
+						},
+					}
+
+					builder = &resource.RabbitmqResourceBuilder{
+						Instance: &instance,
+						Scheme:   scheme,
+					}
+					stsBuilder := builder.StatefulSet()
+					Expect(stsBuilder.Update(statefulSet)).To(Succeed())
+
+					Expect(statefulSet.Spec.Template.Spec.SecurityContext).To(BeNil())
+					Expect(statefulSet.Spec.Template.Spec.InitContainers[0].SecurityContext).To(BeNil())
+
+				})
 
 				Context("Rabbitmq Container volume mounts", func() {
 					It("Overrides the volume mounts list while making sure that '/var/lib/rabbitmq/' mounts before '/var/lib/rabbitmq/mnesia/' ", func() {


### PR DESCRIPTION
This closes #741 and closes #746 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
If an override is provided with the SecurityContext of either the rabbitmq container or init container set to `{}`, this ensures the resultant STS uses the default securityContext of the container runtime.

## Additional Context
Unlike #746, this preserves the validation of override types, rather than failing at reconcile time if a user provides an unknown field.

This only works for securityContext right now; the only other fields I think this affects are:
`topologySpreadConstraints`
`resources`

I don't think they're a high priority to make this work for, but I could add them in if needed.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
