### PR TITLE
Add YTT overlay to automate removing default operator securityContext

### DIFF
--- a/hack/remove-operator-securityContext.yml
+++ b/hack/remove-operator-securityContext.yml
@@ -1,0 +1,8 @@
+#@ load("@ytt:overlay", "overlay")
+#@overlay/match by=overlay.subset({"kind": "Deployment"}), expects="1+"
+---
+spec:
+  template:
+    spec:
+      #@overlay/remove
+      securityContext:


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
Adds a YTT overlay in the `hack/` directory to remove the securityContext on the operator Deployments (both `cluster-operator` and `messaging-topology-operator`).

This allows you to simply use the overlay to remove this field, rather than having to manually download the manifest, edit it then kubectl apply it.

## Additional Context

Docs PR is here: https://github.com/rabbitmq/rabbitmq-website/pull/1220

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
