### PR TITLE
Remove securityContext from manager Deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,10 +30,6 @@ spec:
         app.kubernetes.io/part-of: rabbitmq
     spec:
       serviceAccountName: rabbitmq-cluster-operator
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
       containers:
       - command:
         - /manager


### PR DESCRIPTION
## Summary Of Changes
Removing unnecessary securityContext from manager Pod:
- runAsUser & runAsGroup are already enabled by the `USER` line of the
Dockerfile
- fsGroup is unneeded since the manager mounts no volumes.

The securityContext field overrides some of Openshift's arbitrary user
handling, while providing no benefit to the operator. Removing it
provides the same security guarantees as before, while also making
Openshift installation experience the same as any other Kubernetes
distribution.

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
