### PR TITLE
Add new podAntiAffinity example and modify existing production-ready example

### DIFF
--- a/docs/examples/pod-anti-affinity/README.md
+++ b/docs/examples/pod-anti-affinity/README.md
@@ -1,0 +1,17 @@
+# Pod Anti Affinity Example
+
+This simple pod anti affinity rule will try to assign pods to different nodes according to [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). 
+
+The `preferredDuringSchedulingIgnoredDuringExecution` type can be replaced by `requiredDuringSchedulingIgnoredDuringExecution` to require pod separation as in production-ready example.
+
+You can deploy this example like this:
+
+```shell
+kubectl apply -f rabbitmq.yaml
+```
+
+And once deployed, you can check what defaults were applied like this (`spec` section is the most important):
+
+```shell
+kubectl get -o yaml rabbitmqclusters.rabbitmq.com hello-world
+```

--- a/docs/examples/pod-anti-affinity/rabbitmq.yaml
+++ b/docs/examples/pod-anti-affinity/rabbitmq.yaml
@@ -1,0 +1,18 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: pod-anti-affinity
+spec:
+  replicas: 3
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - pod-anti-affinity
+          topologyKey: kubernetes.io/hostname

--- a/docs/examples/production-ready/README.md
+++ b/docs/examples/production-ready/README.md
@@ -15,6 +15,6 @@ kubectl apply -f rabbitmq.yaml
 kubectl apply -f pod-disruption-budget.yaml
 ```
 
-Please keep in mind that you need a multi-zone Kubernetes cluster with 12 CPUs, 30Gi RAM, 1.5Ti disk space available as well as a `storageClass` called `ssd` to deploy this example as-is. Of course you can adjust these values to your environment if needed.
+Please keep in mind that you need a multi-zone Kubernetes cluster with 3 nodes, 12 CPUs, 30Gi RAM, 1.5Ti disk space available as well as a `storageClass` called `ssd` to deploy this example as-is. Of course you can adjust these values to your environment if needed.
 
 An SSD storage class can be defined using [the example](ssd-gke.yaml) (which is GKE-specific and needs to be adjusted for other environments). Read more about the expected disk performance [in Google Cloud Documentation](https://cloud.google.com/compute/docs/disks/performance#ssd_persistent_disk).

--- a/docs/examples/production-ready/rabbitmq.yaml
+++ b/docs/examples/production-ready/rabbitmq.yaml
@@ -20,6 +20,18 @@ spec:
   persistence:
     storageClassName: ssd
     storage: "500Gi"
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - production-ready
+          topologyKey: kubernetes.io/hostname
   override:
     statefulSet:
       spec:

--- a/docs/examples/production-ready/rabbitmq.yaml
+++ b/docs/examples/production-ready/rabbitmq.yaml
@@ -23,15 +23,13 @@ spec:
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                - production-ready
-          topologyKey: kubernetes.io/hostname
+      - labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - production-ready
+        topologyKey: kubernetes.io/hostname
   override:
     statefulSet:
       spec:


### PR DESCRIPTION
This PR adds `podAntiAffinity` example and modifies the existing procudtion-ready example so that the pods will not be scheduled on the same node. This should ensure higher availability in any Kubernetes cluster.

The pod-anti-affinity example uses `preferredDuringSchedulingIgnoredDuringExecution` type, while production-ready example uses `requiredDuringSchedulingIgnoredDuringExecution` as no production cluster should have potential one point of failure (i.e. one node).