### PR TITLE
Bump default to `3.8.19`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.8.18` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.18` or newer.
+The operator deploys RabbitMQ `3.8.19` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.18` or newer.
 
 ## Versioning
 

--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -50,7 +50,7 @@ type RabbitmqClusterSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster.
 	// Must be provided together with ImagePullSecrets in order to use an image in a private registry.
-	// +kubebuilder:default:="rabbitmq:3.8.18-management"
+	// +kubebuilder:default:="rabbitmq:3.8.19-management"
 	Image string `json:"image,omitempty"`
 	// List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -480,7 +480,7 @@ func generateRabbitmqClusterObject(clusterName string) *RabbitmqCluster {
 		},
 		Spec: RabbitmqClusterSpec{
 			Replicas:                      pointer.Int32Ptr(1),
-			Image:                         "rabbitmq:3.8.18-management",
+			Image:                         "rabbitmq:3.8.19-management",
 			TerminationGracePeriodSeconds: pointer.Int64Ptr(604800),
 			Service: RabbitmqClusterServiceSpec{
 				Type: "ClusterIP",

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -11,7 +11,7 @@ name: rabbitmq
 description: RabbitMQ Cluster
 apiVersion: v2
 version: 0.9.0
-appVersion: 3.8.18
+appVersion: 3.8.19
 keywords:
   - rabbitmq
   - message queue

--- a/charts/rabbitmq/example-configurations.yaml
+++ b/charts/rabbitmq/example-configurations.yaml
@@ -17,7 +17,7 @@ annotations:
 
 replicas: 3
 
-image: "rabbitmq:3.8.18-management"
+image: "rabbitmq:3.8.19-management"
 
 imagePullSecrets:
   - name: foo

--- a/charts/rabbitmq/expected-template-output
+++ b/charts/rabbitmq/expected-template-output
@@ -20,7 +20,7 @@ metadata:
     annotation2: bar
 
 spec:
-  image: rabbitmq:3.8.18-management
+  image: rabbitmq:3.8.19-management
   imagePullSecrets:
   - name: foo
   replicas: 3

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -514,7 +514,7 @@ spec:
                       type: object
                   type: object
                 image:
-                  default: rabbitmq:3.8.18-management
+                  default: rabbitmq:3.8.19-management
                   description: Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster. Must be provided together with ImagePullSecrets in order to use an image in a private registry.
                   type: string
                 imagePullSecrets:


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Set `3.8.19` as default RMQ image

## Additional Context

## Local Testing

All passing locally
