### PR TITLE
Add a sidecar example

### DIFF
--- a/docs/examples/sidecar/README.md
+++ b/docs/examples/sidecar/README.md
@@ -1,0 +1,9 @@
+# Sidecar Example
+
+This example adds an additional container in the rabbitmq pod using the StatefulSet override. You can add multiple additional containers and add additional containers to `initContainers` as well.
+
+You can deploy this example:
+
+```shell
+kubectl apply -f rabbitmq.yaml
+```

--- a/docs/examples/sidecar/rabbitmq.yaml
+++ b/docs/examples/sidecar/rabbitmq.yaml
@@ -1,0 +1,15 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: sidecar
+spec:
+  replicas: 1
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: additional-container
+              image: busybox
+              command: ['sh', '-c', 'echo "Hello, Kubernetes!" && sleep 5000']

--- a/docs/examples/sidecar/test.sh
+++ b/docs/examples/sidecar/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+kubectl get pod sidecar-server-0 -o jsonpath="{.spec.containers[*].image}" | grep busybox
+kubectl get pod sidecar-server-0 | grep 2/2
+


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Add a sidecar example with test. Suggestion from @yaronp68  😸 

## Additional Context

Github action has been very flaky these day. Create a github issue to handle that: https://github.com/rabbitmq/cluster-operator/issues/767

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
