### PR TITLE
Bump system tests timeouts and remove k8s 1.18 from PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,7 +52,6 @@ jobs:
     strategy:
       matrix:
         k8s:
-        - v1.18.19
         - v1.19.11
         - v1.20.7
         - v1.21.1

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -165,14 +165,14 @@ var _ = Describe("Operator", func() {
 				}
 				Eventually(getConfigMapAnnotations, 30, 1).Should(
 					HaveKey("rabbitmq.com/pluginsUpdatedAt"), "plugins ConfigMap should have been annotated")
-				Eventually(getConfigMapAnnotations, 60, 1).Should(
+				Eventually(getConfigMapAnnotations, 120, 1).Should(
 					Not(HaveKey("rabbitmq.com/pluginsUpdatedAt")), "plugins ConfigMap annotation should have been removed")
 
 				Eventually(func() map[string][]byte {
 					secret, err := clientSet.CoreV1().Secrets(cluster.Namespace).Get(ctx, cluster.ChildResourceName("default-user"), metav1.GetOptions{})
 					Expect(err).NotTo(HaveOccurred())
 					return secret.Data
-				}).Should(HaveKeyWithValue("mqtt-port", []byte("1883")))
+				}, 30).Should(HaveKeyWithValue("mqtt-port", []byte("1883")))
 
 				_, err := kubectlExec(namespace,
 					statefulSetPodName(cluster, 0),

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -859,16 +859,16 @@ func publishAndConsumeMQTTMsg(hostname, port, username, password string, overWeb
 	}
 
 	token = c.Subscribe(topic, 0, handler)
-	ExpectWithOffset(1, token.Wait()).To(BeTrue())
-	ExpectWithOffset(1, token.Error()).ToNot(HaveOccurred())
+	ExpectWithOffset(1, token.Wait()).To(BeTrue(), "Subscribe token should return true")
+	ExpectWithOffset(1, token.Error()).ToNot(HaveOccurred(), "Subscribe token received error")
 
 	token = c.Publish(topic, 0, false, "test message MQTT")
-	ExpectWithOffset(1, token.Wait()).To(BeTrue())
-	ExpectWithOffset(1, token.Error()).ToNot(HaveOccurred())
+	ExpectWithOffset(1, token.Wait()).To(BeTrue(), "Publish token should return true")
+	ExpectWithOffset(1, token.Error()).ToNot(HaveOccurred(), "Publish token received error")
 
 	EventuallyWithOffset(1, func() bool {
 		return msgReceived
-	}, 5*time.Second).Should(BeTrue())
+	}, 5*time.Second).Should(BeTrue(), "Expect to receive message")
 
 	token = c.Unsubscribe(topic)
 	ExpectWithOffset(1, token.Wait()).To(BeTrue())


### PR DESCRIPTION
This closes #767

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

1. remove k8s `1.18` from PR system tests workflow (1.18 has reached end of life 3 months ago)
2.  bump timeouts for rabbitmq configurations system tests for two different timeout related flakes that we have been seeing:

1)`pluginsUpdatedAt` annotation should be removed after updates (timeout bumped from 60s to 120s)
```
    Timed out after 60.003s.
    plugins ConfigMap annotation should have been removed
    Expected
        <map[string]string | len:1>: {
            "rabbitmq.com/pluginsUpdatedAt": "2021-07-19T09:00:20Z",
        }
    not to have key
        <string>: rabbitmq.com/pluginsUpdatedAt
```

2)`mqtt` port should be added to default user secret after `rabbitmq_mqtt` plugin is enabled (timeout bumped from 1s to 30s)
```
    Timed out after 1.001s.
    Expected
        <map[string][]uint8 | len:5>: {
            "type": "rabbitmq",
            "username": "_lVAKXsy08F0LU9SF2dgHUShWjR3c3Mt",
            "default_user.conf": [100, 101, 102, 97, 117, 108, 116, 95, 117, 115, 101, 114, 32, 61, 32, 95, 108, 86, 65, 75, 88, 115, 121, 48, 56, 70, 48, 76, 85, 57, 83, 70, 50, 100, 103, 72, 85, 83, 104, 87, 106, 82, 51, 99, 51, 77, 116, 10, 100, 101, 102, 97, 117, 108, 116, 95, 112, 97, 115, 115, 32, 61, 32, 85, 75, 104, 85, 78, 104, 105, 100, 109, 65, 102, 45, 114, 79, 110, 109, 111, 101, 102, 116, 68, 80, 70, 80, 109, 119, 45, 70, 98, 50, 120, 79, 10],
            "password": "UKhUNhidmAf-rOnmoeftDPFPmw-Fb2xO",
            "provider": "rabbitmq",
        }
    to have {key: value}
        <map[interface {}]interface {} | len:1>: {
            <string>"mqtt-port": <[]uint8 | len:4, cap:4>"1883",
        }

    /Users/clyu/workspace/cluster-operator/system_tests/system_test.go:175
```

3. add error descriptions to mqtt connection system tests. Because all assertions are in the helper function, without adding descriptions, it's hard to tell which line had failed (See below for an example test failure):
```
Operator
/Users/clyu/workspace/cluster-operator/system_tests/system_test.go:35
  when (web) MQTT, STOMP, and stream plugins are enabled
  /Users/clyu/workspace/cluster-operator/system_tests/system_test.go:544
    publishes and consumes a message [It]
    /Users/clyu/workspace/cluster-operator/system_tests/system_test.go:575

    Unexpected error:
        <*errors.errorString | 0xc00007b770>: {s: "not Connected"}
        not Connected
    occurred

    /Users/clyu/workspace/cluster-operator/system_tests/system_test.go:577
``` 

