### PR TITLE
Bump timeouts for mqtt connection system tests, remove k8s 1.19 and 1.20 tests from PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,8 +52,6 @@ jobs:
     strategy:
       matrix:
         k8s:
-        - v1.19.11
-        - v1.20.7
         - v1.21.1
         rabbitmq-image:
         - rabbitmq:3.8.8-management

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,6 +79,9 @@ jobs:
         kind create cluster --image kindest/node:"$K8S_VERSION"
         DOCKER_REGISTRY_SERVER=local-server OPERATOR_IMAGE=local-operator make deploy-kind
         SUPPORT_VOLUME_EXPANSION=false make system-tests
+    - name: Setup tmate session
+      if: ${{ failure() }} # start a debugging tmate session when system tests fail
+      uses: mxschmitt/action-tmate@v3
 
   kubectl_tests:
     name: kubectl rabbitmq tests

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -165,7 +166,7 @@ var _ = Describe("Operator", func() {
 				}
 				Eventually(getConfigMapAnnotations, 30, 1).Should(
 					HaveKey("rabbitmq.com/pluginsUpdatedAt"), "plugins ConfigMap should have been annotated")
-				Eventually(getConfigMapAnnotations, 120, 1).Should(
+				Eventually(getConfigMapAnnotations, 4 * time.Minute, 1).Should(
 					Not(HaveKey("rabbitmq.com/pluginsUpdatedAt")), "plugins ConfigMap annotation should have been removed")
 
 				Eventually(func() map[string][]byte {

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -846,7 +846,7 @@ func publishAndConsumeMQTTMsg(hostname, port, username, password string, overWeb
 			return true
 		}
 		return false
-	}, 15, 2).Should(BeTrue(), "Expected to be able to connect to MQTT port")
+	}, 30, 2).Should(BeTrue(), "Expected to be able to connect to MQTT port")
 
 	topic := "tests/mqtt"
 	msgReceived := false
@@ -868,7 +868,7 @@ func publishAndConsumeMQTTMsg(hostname, port, username, password string, overWeb
 
 	EventuallyWithOffset(1, func() bool {
 		return msgReceived
-	}, 5*time.Second).Should(BeTrue(), "Expect to receive message")
+	}, 10 * time.Second).Should(BeTrue(), "Expect to receive message")
 
 	token = c.Unsubscribe(topic)
 	ExpectWithOffset(1, token.Wait()).To(BeTrue())

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -871,8 +871,8 @@ func publishAndConsumeMQTTMsg(hostname, port, username, password string, overWeb
 	}, 10 * time.Second).Should(BeTrue(), "Expect to receive message")
 
 	token = c.Unsubscribe(topic)
-	ExpectWithOffset(1, token.Wait()).To(BeTrue())
-	ExpectWithOffset(1, token.Error()).ToNot(HaveOccurred())
+	ExpectWithOffset(1, token.Wait()).To(BeTrue(), "Unsubscribe token should return true")
+	ExpectWithOffset(1, token.Error()).ToNot(HaveOccurred(), "Unsubscribe token received error")
 
 	c.Disconnect(250)
 }


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Another PR to fix system tests timeout issue with PR workflow. Also removes k8s `1.19` and `1.20` from PR workflow. 

The team had a discussion about github action and CI pipeline test coverage, we decided on:
1. only test on k8s 1.21 in github action; remove k8s 1.19 and 1.20 from the system tests matrices (considering 1.21 is not available in GCP yet)
2. test on k8s 1.19 in CI pipeline (no 1.20 coverage considering it’s unlikely to have compatibility issue that only breaks on 1.20 but not 1.19 or 1.21)
3. PR github workflow will run system tests on 5 different rabbitmq versions: 3.8.8, latest 3.8, latest 3.9, rabbitmq-server master with OTP 23 and rabbitmq-server master with OTP 24)
3. CI pipeline will run system tests on 5 different rabbitmq versions: 3.8.8, latest 3.8, latest 3.9, rabbitmq-server master with OTP 23 and rabbitmq-server master with OTP 24)

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
