### PR TITLE
Remove `.cluster.local` from host in default-user secret.

### DIFF
--- a/internal/resource/default_user_secret.go
+++ b/internal/resource/default_user_secret.go
@@ -55,7 +55,7 @@ func (builder *DefaultUserSecretBuilder) Build() (client.Object, error) {
 		return nil, err
 	}
 
-	host := fmt.Sprintf("%s.%s.svc.cluster.local", builder.Instance.Name, builder.Instance.Namespace)
+	host := fmt.Sprintf("%s.%s.svc", builder.Instance.Name, builder.Instance.Namespace)
 
 	// Default user secret implements the service binding Provisioned Service
 	// See: https://k8s-service-bindings.github.io/spec/#provisioned-service

--- a/internal/resource/default_user_secret_test.go
+++ b/internal/resource/default_user_secret_test.go
@@ -91,7 +91,7 @@ var _ = Describe("DefaultUserSecret", func() {
 			By("Setting a host that corresponds to the service address", func() {
 				host, ok = secret.Data["host"]
 				Expect(ok).NotTo(BeFalse(), "Failed to find a key \"host\" in the generated Secret")
-				expectedHost := "a name.a namespace.svc.cluster.local"
+				expectedHost := "a name.a namespace.svc"
 				Expect(host).To(BeEquivalentTo(expectedHost))
 			})
 


### PR DESCRIPTION
Cluster name is configurable and not fixed.

This is related to #75 and [Messaging Topology Operator issue 186](https://github.com/rabbitmq/messaging-topology-operator/issues/186)

## Summary Of Changes

Removes hardcoded `.cluster.local` suffix from the service address in the `host` field of the default-user secret.

