### PR TITLE
Don't create PVC if spec.persistence.storage==0

### DIFF
--- a/controllers/reconcile_no_persistence_test.go
+++ b/controllers/reconcile_no_persistence_test.go
@@ -1,0 +1,95 @@
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
+	"github.com/rabbitmq/cluster-operator/internal/status"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Persistence", func() {
+	var (
+		cluster          *rabbitmqv1beta1.RabbitmqCluster
+		defaultNamespace = "default"
+		ctx              = context.Background()
+	)
+
+	BeforeEach(func() {
+		zeroGi := k8sresource.MustParse("0Gi")
+		cluster = &rabbitmqv1beta1.RabbitmqCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rabbitmq-shrink",
+				Namespace: defaultNamespace,
+			},
+			Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
+				Replicas: pointer.Int32Ptr(5),
+				Persistence: rabbitmqv1beta1.RabbitmqClusterPersistenceSpec{
+					Storage: &zeroGi,
+				},
+			},
+		}
+		Expect(client.Create(ctx, cluster)).To(Succeed())
+		waitForClusterCreation(ctx, cluster, client)
+	})
+
+	AfterEach(func() {
+		Expect(client.Delete(ctx, cluster)).To(Succeed())
+		Eventually(func() bool {
+			rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+			err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
+			return apierrors.IsNotFound(err)
+		}, 5).Should(BeTrue())
+	})
+
+	It("does not allow changing the capcity from zero (no persistence)", func() {
+		By("failing a statefulSet update", func() {
+			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
+				storage := k8sresource.MustParse("1Gi")
+				cluster.Spec.Persistence.Storage = &storage
+			})).To(Succeed())
+			Consistently(func() []v1.PersistentVolumeClaim {
+				sts, err := clientSet.AppsV1().StatefulSets(defaultNamespace).Get(ctx, cluster.ChildResourceName("server"), metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return sts.Spec.VolumeClaimTemplates
+			}, 10, 1).Should(BeEmpty())
+		})
+
+		By("setting 'Warning' events", func() {
+			Expect(aggregateEventMsgs(ctx, cluster, "FailedReconcilePersistence")).To(
+				ContainSubstring("changing from ephemeral to persistent storage is not supported"))
+		})
+
+		By("setting ReconcileSuccess to 'false' with failed reason and message", func() {
+			Eventually(func() string {
+				rabbit := &rabbitmqv1beta1.RabbitmqCluster{}
+				Expect(client.Get(ctx, runtimeClient.ObjectKey{
+					Name:      cluster.Name,
+					Namespace: defaultNamespace,
+				}, rabbit)).To(Succeed())
+
+				for i := range rabbit.Status.Conditions {
+					if rabbit.Status.Conditions[i].Type == status.ReconcileSuccess {
+						return fmt.Sprintf(
+							"ReconcileSuccess status: %s, with reason: %s and message: %s",
+							rabbit.Status.Conditions[i].Status,
+							rabbit.Status.Conditions[i].Reason,
+							rabbit.Status.Conditions[i].Message)
+					}
+				}
+				return "ReconcileSuccess status: condition not present"
+			}, 5).Should(Equal("ReconcileSuccess status: False, " +
+				"with reason: FailedReconcilePVC " +
+				"and message: changing from ephemeral to persistent storage is not supported"))
+		})
+	})
+})

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -160,18 +160,27 @@ func applyStsOverride(instance *rabbitmqv1beta1.RabbitmqCluster, scheme *runtime
 	}
 
 	if len(stsOverride.Spec.VolumeClaimTemplates) != 0 {
-		volumeClaimTemplatesOverride := stsOverride.Spec.VolumeClaimTemplates
-		pvcOverride := make([]corev1.PersistentVolumeClaim, len(volumeClaimTemplatesOverride))
-		for i := range volumeClaimTemplatesOverride {
-			copyObjectMeta(&pvcOverride[i].ObjectMeta, volumeClaimTemplatesOverride[i].EmbeddedObjectMeta)
-			pvcOverride[i].Namespace = sts.Namespace // PVC should always be in the same namespace as the Stateful Set
-			pvcOverride[i].Spec = volumeClaimTemplatesOverride[i].Spec
-			if err := controllerutil.SetControllerReference(instance, &pvcOverride[i], scheme); err != nil {
-				return fmt.Errorf("failed setting controller reference: %v", err)
+		// If spec.persistence.storage == 0, ignore PVC overrides.
+		// Main reason for that is that there is no default PVC in such case (emptyDir is used instead)
+		// other PVCs could technically be still overridden/added but we would be entering a very confusing territory
+		// where storage is set to 0 and yet there are PVCs with data
+		if instance.Spec.Persistence.Storage.Cmp(k8sresource.MustParse("0Gi")) == 0 {
+			logger := ctrl.Log.WithName("statefulset").WithName("RabbitmqCluster")
+			logger.Info(fmt.Sprintf("Warning: persistentVolumeClaim overrides are ignored for cluster \"%s\", becasue spec.persistence.storage is set to zero.", sts.GetName()))
+		} else {
+			volumeClaimTemplatesOverride := stsOverride.Spec.VolumeClaimTemplates
+			pvcOverride := make([]corev1.PersistentVolumeClaim, len(volumeClaimTemplatesOverride))
+			for i := range volumeClaimTemplatesOverride {
+				copyObjectMeta(&pvcOverride[i].ObjectMeta, volumeClaimTemplatesOverride[i].EmbeddedObjectMeta)
+				pvcOverride[i].Namespace = sts.Namespace // PVC should always be in the same namespace as the Stateful Set
+				pvcOverride[i].Spec = volumeClaimTemplatesOverride[i].Spec
+				if err := controllerutil.SetControllerReference(instance, &pvcOverride[i], scheme); err != nil {
+					return fmt.Errorf("failed setting controller reference: %v", err)
+				}
+				disableBlockOwnerDeletion(pvcOverride[i])
 			}
-			disableBlockOwnerDeletion(pvcOverride[i])
+			sts.Spec.VolumeClaimTemplates = pvcOverride
 		}
-		sts.Spec.VolumeClaimTemplates = pvcOverride
 	}
 
 	if stsOverride.Spec.Template == nil {


### PR DESCRIPTION
For test environments, especially in CI/CD, it may be beneficial to skip
creating the PVC altogether since the whole cluster is disposable
anyway. With this change, if spec.persistence.storage is set to 0, the
PVC is not created and an `emptyDir` volume is used instead. Changing from
0 to anything else is not supported (and doesn't make much sense
anyway).

This closes #776 