### PR TITLE
Adapt instance manage to support Linux

### DIFF
--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -10,6 +10,7 @@
 
 set -euo pipefail
 
+PLATFORM="$(uname)"
 NAMESPACE=""
 
 instance=""
@@ -164,9 +165,16 @@ manage() {
 	    MGMT_PORT=15672
 	    MGMT_URL="http://localhost:$MGMT_PORT/"
     fi
+
+    if [[ "${PLATFORM}" == "Darwin" ]]; then
+      OPEN="open"
+    else
+      OPEN="xdg-open"
+    fi
+
     (
         sleep 2
-        open "$MGMT_URL"
+        $OPEN "$MGMT_URL"
     ) &
     kubectl ${NAMESPACE} port-forward "service/${service}" $MGMT_PORT
 }


### PR DESCRIPTION
This closes #801 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
The command `open` is specific to MacOS. Linux desktops use `xdg-open` instead. The rest of the script should be compatible with Linux.

## Additional Context
N/A

## Local Testing
No tests added or modified.