### PR TITLE
Bump default rmq image to 3.8.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.8.19` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.18` or newer.
+The operator deploys RabbitMQ `3.8.21` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.18` or newer.
 
 ## Versioning
 

--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -50,7 +50,7 @@ type RabbitmqClusterSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster.
 	// Must be provided together with ImagePullSecrets in order to use an image in a private registry.
-	// +kubebuilder:default:="rabbitmq:3.8.19-management"
+	// +kubebuilder:default:="rabbitmq:3.8.21-management"
 	Image string `json:"image,omitempty"`
 	// List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -480,7 +480,7 @@ func generateRabbitmqClusterObject(clusterName string) *RabbitmqCluster {
 		},
 		Spec: RabbitmqClusterSpec{
 			Replicas:                      pointer.Int32Ptr(1),
-			Image:                         "rabbitmq:3.8.19-management",
+			Image:                         "rabbitmq:3.8.21-management",
 			TerminationGracePeriodSeconds: pointer.Int64Ptr(604800),
 			Service: RabbitmqClusterServiceSpec{
 				Type: "ClusterIP",

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -10,7 +10,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: rabbitmqclusters.rabbitmq.com
 spec:
@@ -514,7 +514,7 @@ spec:
                       type: object
                   type: object
                 image:
-                  default: rabbitmq:3.8.19-management
+                  default: rabbitmq:3.8.21-management
                   description: Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster. Must be provided together with ImagePullSecrets in order to use an image in a private registry.
                   type: string
                 imagePullSecrets:

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Operator", func() {
 				}
 				Eventually(getConfigMapAnnotations, 30, 1).Should(
 					HaveKey("rabbitmq.com/pluginsUpdatedAt"), "plugins ConfigMap should have been annotated")
-				Eventually(getConfigMapAnnotations, 4 * time.Minute, 1).Should(
+				Eventually(getConfigMapAnnotations, 4*time.Minute, 1).Should(
 					Not(HaveKey("rabbitmq.com/pluginsUpdatedAt")), "plugins ConfigMap annotation should have been removed")
 
 				Eventually(func() map[string][]byte {

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -868,7 +868,7 @@ func publishAndConsumeMQTTMsg(hostname, port, username, password string, overWeb
 
 	EventuallyWithOffset(1, func() bool {
 		return msgReceived
-	}, 10 * time.Second).Should(BeTrue(), "Expect to receive message")
+	}, 10*time.Second).Should(BeTrue(), "Expect to receive message")
 
 	token = c.Unsubscribe(topic)
 	ExpectWithOffset(1, token.Wait()).To(BeTrue(), "Unsubscribe token should return true")


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Bump default RMQ image to `3.8.21`. Will squash before merging.

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
