### PR TITLE
Avoid MacOS firewall warning on `make run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ destroy: ## Cleanup all controller artefacts
 run: generate manifests fmt vet install deploy-namespace-rbac just-run ## Run operator binary locally against the configured Kubernetes cluster in ~/.kube/config
 
 just-run: ## Just runs 'go run main.go' without regenerating any manifests or deploying RBACs
-	KUBE_CONFIG=${HOME}/.kube/config OPERATOR_NAMESPACE=rabbitmq-system go run ./main.go
+	KUBE_CONFIG=${HOME}/.kube/config OPERATOR_NAMESPACE=rabbitmq-system go run ./main.go -metrics-bind-address 127.0.0.1:9782
 
 delve: generate install deploy-namespace-rbac just-delve ## Deploys CRD, Namespace, RBACs and starts Delve debugger
 


### PR DESCRIPTION
MacOS requires users to allow/deny whenever an unknown process attempts to listen on a TCP port.
Since `make run` always generates a new binary, it is necessary to always accept/deny the attempt.
By only listening on the loopback address, we can avoid the prompt