### PR TITLE
Add extra logging and event detail when attempting to scale down cluster

### DIFF
--- a/controllers/reconcile_scale_down.go
+++ b/controllers/reconcile_scale_down.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/status"
@@ -18,7 +20,7 @@ func (r *RabbitmqClusterReconciler) scaleDown(ctx context.Context, cluster *v1be
 	currentReplicas := *current.Spec.Replicas
 	desiredReplicas := *sts.Spec.Replicas
 	if currentReplicas > desiredReplicas {
-		msg := "Cluster Scale down not supported"
+		msg := fmt.Sprintf("Cluster Scale down not supported; tried to scale cluster from %d nodes to %d nodes", currentReplicas, desiredReplicas)
 		reason := "UnsupportedOperation"
 		logger.Error(errors.New(reason), msg)
 		r.Recorder.Event(cluster, corev1.EventTypeWarning, reason, msg)

--- a/controllers/reconcile_scale_down_test.go
+++ b/controllers/reconcile_scale_down_test.go
@@ -3,6 +3,7 @@ package controllers_test
 import (
 	"context"
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
@@ -79,7 +80,7 @@ var _ = Describe("Cluster scale down", func() {
 				return "ReconcileSuccess status: condition not present"
 			}, 5).Should(Equal("ReconcileSuccess status: False, " +
 				"with reason: UnsupportedOperation " +
-				"and message: Cluster Scale down not supported"))
+				"and message: Cluster Scale down not supported; tried to scale cluster from 5 nodes to 3 nodes"))
 		})
 	})
 })


### PR DESCRIPTION
This closes #758

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Adds extra detail to the warning generated when attempting to scale down the cluster. The log now states the number of replicas is marked as current, and the desired number of replicas that were used to calculate whether a scale down was occurring. This should help debug other race conditions as demonstrated in #758 .

Example status:
![image](https://user-images.githubusercontent.com/23215294/131846604-750a9227-a03f-4272-b765-d0d4aecca717.png)


## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
