### PR TITLE
Prefix generated username with 'default_user_'

### DIFF
--- a/internal/resource/default_user_secret.go
+++ b/internal/resource/default_user_secret.go
@@ -29,6 +29,7 @@ const (
 	DefaultUserSecretName = "default-user"
 	bindingProvider       = "rabbitmq"
 	bindingType           = "rabbitmq"
+	usernamePrefix        = "default_user_"
 )
 
 type DefaultUserSecretBuilder struct {
@@ -40,7 +41,7 @@ func (builder *RabbitmqResourceBuilder) DefaultUserSecret() *DefaultUserSecretBu
 }
 
 func (builder *DefaultUserSecretBuilder) Build() (client.Object, error) {
-	username, err := randomEncodedString(24)
+	username, err := generateUsername(24)
 	if err != nil {
 		return nil, err
 	}
@@ -144,6 +145,18 @@ func (builder *DefaultUserSecretBuilder) updatePorts(secret *corev1.Secret) {
 			}
 		}
 	}
+}
+
+// generateUsername returns a base64 string that has "default_user_" as prefix
+// returned string has length 'l' when base64 decoded
+func generateUsername(l int) (string, error) {
+	encodedStr, err := randomEncodedString(l)
+	if err != nil {
+		return "", err
+	}
+
+	encodedStrSlice := []byte(encodedStr)
+	return string(append([]byte(usernamePrefix), encodedStrSlice[0:len(encodedStrSlice)-len(usernamePrefix)]...)), nil
 }
 
 func (builder *DefaultUserSecretBuilder) pluginEnabled(plugin v1beta1.Plugin) bool {

--- a/internal/resource/default_user_secret.go
+++ b/internal/resource/default_user_secret.go
@@ -150,13 +150,13 @@ func (builder *DefaultUserSecretBuilder) updatePorts(secret *corev1.Secret) {
 // generateUsername returns a base64 string that has "default_user_" as prefix
 // returned string has length 'l' when base64 decoded
 func generateUsername(l int) (string, error) {
-	encodedStr, err := randomEncodedString(l)
+	encoded, err := randomEncodedString(l)
 	if err != nil {
 		return "", err
 	}
 
-	encodedStrSlice := []byte(encodedStr)
-	return string(append([]byte(usernamePrefix), encodedStrSlice[0:len(encodedStrSlice)-len(usernamePrefix)]...)), nil
+	encodedSlice := []byte(encoded)
+	return string(append([]byte(usernamePrefix), encodedSlice[0:len(encodedSlice)-len(usernamePrefix)]...)), nil
 }
 
 func (builder *DefaultUserSecretBuilder) pluginEnabled(plugin v1beta1.Plugin) bool {

--- a/internal/resource/default_user_secret_test.go
+++ b/internal/resource/default_user_secret_test.go
@@ -76,7 +76,7 @@ var _ = Describe("DefaultUserSecret", func() {
 				Expect(string(username)).To(HavePrefix("default_user_"))
 				decoded, err := b64.URLEncoding.DecodeString(string(username))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(len(decoded)).To(Equal(24))
+				Expect(decoded).To(HaveLen(24))
 			})
 
 			By("creating a rabbitmq password that is base64 encoded and 24 characters in length when decoded", func() {
@@ -84,7 +84,7 @@ var _ = Describe("DefaultUserSecret", func() {
 				Expect(ok).To(BeTrue(), "Failed to find a key \"password\" in the generated Secret")
 				decodedPassword, err := b64.URLEncoding.DecodeString(string(password))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(len(decodedPassword)).To(Equal(24))
+				Expect(decodedPassword).To(HaveLen(24))
 			})
 
 			By("Setting a host that corresponds to the service address", func() {

--- a/internal/resource/default_user_secret_test.go
+++ b/internal/resource/default_user_secret_test.go
@@ -72,9 +72,8 @@ var _ = Describe("DefaultUserSecret", func() {
 
 			By("creating a rabbitmq username that has a prefix 'default_user_', base64 encoded, and 24 characters in length when decoded", func() {
 				username, ok = secret.Data["username"]
-				Expect(ok).NotTo(BeFalse(), "Failed to find a key \"username\" in the generated Secret")
+				Expect(ok).To(BeTrue(), "Failed to find a key \"username\" in the generated Secret")
 				Expect(string(username)).To(HavePrefix("default_user_"))
-				//strList := strings.SplitAfter(string(username), "default_user_")
 				decoded, err := b64.URLEncoding.DecodeString(string(username))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(decoded)).To(Equal(24))
@@ -82,7 +81,7 @@ var _ = Describe("DefaultUserSecret", func() {
 
 			By("creating a rabbitmq password that is base64 encoded and 24 characters in length when decoded", func() {
 				password, ok = secret.Data["password"]
-				Expect(ok).NotTo(BeFalse(), "Failed to find a key \"password\" in the generated Secret")
+				Expect(ok).To(BeTrue(), "Failed to find a key \"password\" in the generated Secret")
 				decodedPassword, err := b64.URLEncoding.DecodeString(string(password))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(decodedPassword)).To(Equal(24))
@@ -90,20 +89,20 @@ var _ = Describe("DefaultUserSecret", func() {
 
 			By("Setting a host that corresponds to the service address", func() {
 				host, ok = secret.Data["host"]
-				Expect(ok).NotTo(BeFalse(), "Failed to find a key \"host\" in the generated Secret")
+				Expect(ok).To(BeTrue(), "Failed to find a key \"host\" in the generated Secret")
 				expectedHost := "a name.a namespace.svc"
 				Expect(host).To(BeEquivalentTo(expectedHost))
 			})
 
 			By("Setting a port that corresponds to the amqp port", func() {
 				port, ok = secret.Data["port"]
-				Expect(ok).NotTo(BeFalse(), "Failed to find a key \"port\" in the generated Secret")
+				Expect(ok).To(BeTrue(), "Failed to find a key \"port\" in the generated Secret")
 				Expect(port).To(BeEquivalentTo("5672"))
 			})
 
 			By("creating a default_user.conf file that contains the correct sysctl config format to be parsed by RabbitMQ", func() {
 				defaultUserConf, ok := secret.Data["default_user.conf"]
-				Expect(ok).NotTo(BeFalse(), "Failed to find a key \"default_user.conf\" in the generated Secret")
+				Expect(ok).To(BeTrue(), "Failed to find a key \"default_user.conf\" in the generated Secret")
 
 				cfg, err := ini.Load(defaultUserConf)
 				Expect(err).NotTo(HaveOccurred())
@@ -117,13 +116,13 @@ var _ = Describe("DefaultUserSecret", func() {
 
 			By("setting 'data.provider' to 'rabbitmq' ", func() {
 				provider, ok := secret.Data["provider"]
-				Expect(ok).NotTo(BeFalse(), "Failed to find key 'provider' ")
+				Expect(ok).To(BeTrue(), "Failed to find key 'provider' ")
 				Expect(string(provider)).To(Equal("rabbitmq"))
 			})
 
 			By("setting 'data.type' to 'rabbitmq' ", func() {
 				t, ok := secret.Data["type"]
-				Expect(ok).NotTo(BeFalse(), "Failed to find key 'type' ")
+				Expect(ok).To(BeTrue(), "Failed to find key 'type' ")
 				Expect(string(t)).To(Equal("rabbitmq"))
 			})
 		})
@@ -146,23 +145,23 @@ var _ = Describe("DefaultUserSecret", func() {
 			secret = obj.(*corev1.Secret)
 
 			port, ok := secret.Data["mqtt-port"]
-			Expect(ok).NotTo(BeFalse(), "Failed to find key \"mqtt-port\" in the generated Secret")
+			Expect(ok).To(BeTrue(), "Failed to find key \"mqtt-port\" in the generated Secret")
 			Expect(port).To(BeEquivalentTo("1883"))
 
 			port, ok = secret.Data["stomp-port"]
-			Expect(ok).NotTo(BeFalse(), "Failed to find key \"stomp-port\" in the generated Secret")
+			Expect(ok).To(BeTrue(), "Failed to find key \"stomp-port\" in the generated Secret")
 			Expect(port).To(BeEquivalentTo("61613"))
 
 			port, ok = secret.Data["stream-port"]
-			Expect(ok).NotTo(BeFalse(), "Failed to find key \"stream-port\" in the generated Secret")
+			Expect(ok).To(BeTrue(), "Failed to find key \"stream-port\" in the generated Secret")
 			Expect(port).To(BeEquivalentTo("5552"))
 
 			port, ok = secret.Data["web-mqtt-port"]
-			Expect(ok).NotTo(BeFalse(), "Failed to find key \"web-mqtt-port\" in the generated Secret")
+			Expect(ok).To(BeTrue(), "Failed to find key \"web-mqtt-port\" in the generated Secret")
 			Expect(port).To(BeEquivalentTo("15675"))
 
 			port, ok = secret.Data["web-stomp-port"]
-			Expect(ok).NotTo(BeFalse(), "Failed to find key \"web-stomp-port\" in the generated Secret")
+			Expect(ok).To(BeTrue(), "Failed to find key \"web-stomp-port\" in the generated Secret")
 			Expect(port).To(BeEquivalentTo("15674"))
 		})
 	})
@@ -178,7 +177,7 @@ var _ = Describe("DefaultUserSecret", func() {
 			secret = obj.(*corev1.Secret)
 
 			port, ok := secret.Data["port"]
-			Expect(ok).NotTo(BeFalse(), "Failed to find key \"port\" in the generated Secret")
+			Expect(ok).To(BeTrue(), "Failed to find key \"port\" in the generated Secret")
 			Expect(port).To(BeEquivalentTo("5671"))
 		})
 
@@ -200,23 +199,23 @@ var _ = Describe("DefaultUserSecret", func() {
 				secret = obj.(*corev1.Secret)
 
 				port, ok := secret.Data["mqtt-port"]
-				Expect(ok).NotTo(BeFalse(), "Failed to find key \"mqtt-port\" in the generated Secret")
+				Expect(ok).To(BeTrue(), "Failed to find key \"mqtt-port\" in the generated Secret")
 				Expect(port).To(BeEquivalentTo("8883"))
 
 				port, ok = secret.Data["stomp-port"]
-				Expect(ok).NotTo(BeFalse(), "Failed to find key \"stomp-port\" in the generated Secret")
+				Expect(ok).To(BeTrue(), "Failed to find key \"stomp-port\" in the generated Secret")
 				Expect(port).To(BeEquivalentTo("61614"))
 
 				port, ok = secret.Data["stream-port"]
-				Expect(ok).NotTo(BeFalse(), "Failed to find key \"stream-port\" in the generated Secret")
+				Expect(ok).To(BeTrue(), "Failed to find key \"stream-port\" in the generated Secret")
 				Expect(port).To(BeEquivalentTo("5551"))
 
 				port, ok = secret.Data["web-mqtt-port"]
-				Expect(ok).NotTo(BeFalse(), "Failed to find key \"web-mqtt-port\" in the generated Secret")
+				Expect(ok).To(BeTrue(), "Failed to find key \"web-mqtt-port\" in the generated Secret")
 				Expect(port).To(BeEquivalentTo("15676"))
 
 				port, ok = secret.Data["web-stomp-port"]
-				Expect(ok).NotTo(BeFalse(), "Failed to find key \"web-stomp-port\" in the generated Secret")
+				Expect(ok).To(BeTrue(), "Failed to find key \"web-stomp-port\" in the generated Secret")
 				Expect(port).To(BeEquivalentTo("15673"))
 			})
 		})
@@ -336,15 +335,15 @@ var _ = Describe("DefaultUserSecret", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			port, ok := secret.Data["port"]
-			Expect(ok).NotTo(BeFalse())
+			Expect(ok).To(BeTrue())
 			Expect(port).To(BeEquivalentTo("5671"))
 
 			port, ok = secret.Data["mqtt-port"]
-			Expect(ok).NotTo(BeFalse())
+			Expect(ok).To(BeTrue())
 			Expect(port).To(BeEquivalentTo("8883"))
 
 			port, ok = secret.Data["stream-port"]
-			Expect(ok).NotTo(BeFalse())
+			Expect(ok).To(BeTrue())
 			Expect(port).To(BeEquivalentTo("5551"))
 
 			_, ok = secret.Data["web-mqtt-port"]

--- a/internal/resource/default_user_secret_test.go
+++ b/internal/resource/default_user_secret_test.go
@@ -11,18 +11,16 @@ package resource_test
 
 import (
 	b64 "encoding/base64"
-
-	"gopkg.in/ini.v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	defaultscheme "k8s.io/client-go/kubernetes/scheme"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"
+	"gopkg.in/ini.v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	defaultscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 var _ = Describe("DefaultUserSecret", func() {
@@ -72,15 +70,17 @@ var _ = Describe("DefaultUserSecret", func() {
 				Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
 			})
 
-			By("creating a rabbitmq username that is base64 encoded and 24 characters in length", func() {
+			By("creating a rabbitmq username that has a prefix 'default_user_', base64 encoded, and 24 characters in length when decoded", func() {
 				username, ok = secret.Data["username"]
 				Expect(ok).NotTo(BeFalse(), "Failed to find a key \"username\" in the generated Secret")
-				decodedUsername, err := b64.URLEncoding.DecodeString(string(username))
+				Expect(string(username)).To(HavePrefix("default_user_"))
+				//strList := strings.SplitAfter(string(username), "default_user_")
+				decoded, err := b64.URLEncoding.DecodeString(string(username))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(len(decodedUsername)).To(Equal(24))
+				Expect(len(decoded)).To(Equal(24))
 			})
 
-			By("creating a rabbitmq password that is base64 encoded and 24 characters in length", func() {
+			By("creating a rabbitmq password that is base64 encoded and 24 characters in length when decoded", func() {
 				password, ok = secret.Data["password"]
 				Expect(ok).NotTo(BeFalse(), "Failed to find a key \"password\" in the generated Secret")
 				decodedPassword, err := b64.URLEncoding.DecodeString(string(password))

--- a/internal/resource/erlang_cookie_test.go
+++ b/internal/resource/erlang_cookie_test.go
@@ -72,7 +72,7 @@ var _ = Describe("ErlangCookie", func() {
 			Expect(ok).NotTo(BeFalse())
 			decodedCookie, err := b64.URLEncoding.DecodeString(string(cookie))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(decodedCookie)).To(Equal(24))
+			Expect(decodedCookie).To(HaveLen(24))
 		})
 	})
 


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- this change will make it easier to specify exclusion rules whenusing schema sync plugin
- After this change, an example username and password could look like:
```
username: default_user_mDj_Yp58qvSynGbUEC3
password: AbdFbGnu2HaVAIkJ1W1AUq42uVglXW1E
```

## Additional Context

Generated username and password logic is tested in unit test level.

## Local Testing

