### PR TITLE
Move default image from CRD spec to command line flag

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -50,7 +50,6 @@ type RabbitmqClusterSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster.
 	// Must be provided together with ImagePullSecrets in order to use an image in a private registry.
-	// +kubebuilder:default:="rabbitmq:3.8.21-management"
 	Image string `json:"image,omitempty"`
 	// List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -480,7 +480,6 @@ func generateRabbitmqClusterObject(clusterName string) *RabbitmqCluster {
 		},
 		Spec: RabbitmqClusterSpec{
 			Replicas:                      pointer.Int32Ptr(1),
-			Image:                         "rabbitmq:3.8.21-management",
 			TerminationGracePeriodSeconds: pointer.Int64Ptr(604800),
 			Service: RabbitmqClusterServiceSpec{
 				Type: "ClusterIP",

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -514,7 +514,6 @@ spec:
                       type: object
                   type: object
                 image:
-                  default: rabbitmq:3.8.21-management
                   description: Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster. Must be provided together with ImagePullSecrets in order to use an image in a private registry.
                   type: string
                 imagePullSecrets:

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -57,12 +57,13 @@ const (
 // RabbitmqClusterReconciler reconciles a RabbitmqCluster object
 type RabbitmqClusterReconciler struct {
 	client.Client
-	Scheme        *runtime.Scheme
-	Namespace     string
-	Recorder      record.EventRecorder
-	ClusterConfig *rest.Config
-	Clientset     *kubernetes.Clientset
-	PodExecutor   PodExecutor
+	Scheme               *runtime.Scheme
+	Namespace            string
+	Recorder             record.EventRecorder
+	ClusterConfig        *rest.Config
+	Clientset            *kubernetes.Clientset
+	PodExecutor          PodExecutor
+	DefaultRabbitmqImage string
 }
 
 // the rbac rule requires an empty row at the end to render
@@ -111,6 +112,20 @@ func (r *RabbitmqClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			logger.Error(writerErr, "Error trying to Update NoWarnings condition state")
 		}
 		return ctrl.Result{}, nil
+	}
+
+	if rabbitmqCluster.Spec.Image == "" {
+		rabbitmqCluster.Spec.Image = r.DefaultRabbitmqImage
+		if err = r.Update(ctx, rabbitmqCluster); err != nil {
+			if k8serrors.IsConflict(err) {
+				logger.Info("failed to update image because of conflict; requeueing...",
+					"namespace", rabbitmqCluster.Namespace,
+					"name", rabbitmqCluster.Name)
+				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			}
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, err
 	}
 
 	// Ensure the resource have a deletion marker

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -62,13 +62,18 @@ var _ = Describe("RabbitmqClusterController", func() {
 		AfterEach(func() {
 			Expect(client.Delete(ctx, cluster)).To(Succeed())
 			Eventually(func() bool {
-				rmq := &rabbitmqv1beta1.RabbitmqCluster{}
-				err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
+				err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, cluster)
 				return apierrors.IsNotFound(err)
 			}, 5).Should(BeTrue())
 		})
 
 		It("works", func() {
+			By("populating the image spec with the default image", func() {
+				fetchedCluster := &rabbitmqv1beta1.RabbitmqCluster{}
+				Expect(client.Get(ctx, types.NamespacedName{Name: "rabbitmq-one", Namespace: defaultNamespace}, fetchedCluster)).To(Succeed())
+				Expect(fetchedCluster.Spec.Image).To(Equal(defaultRabbitmqImage))
+			})
+
 			By("creating a statefulset with default configurations", func() {
 				sts := statefulSet(ctx, cluster)
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -33,7 +33,10 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-const controllerName = "rabbitmqcluster-controller"
+const (
+	controllerName       = "rabbitmqcluster-controller"
+	defaultRabbitmqImage = "default-rabbit-image:stable"
+)
 
 var (
 	testEnv         *envtest.Environment
@@ -82,12 +85,13 @@ var _ = BeforeSuite(func() {
 
 	fakeExecutor = &fakePodExecutor{}
 	err = (&controllers.RabbitmqClusterReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		Recorder:    mgr.GetEventRecorderFor(controllerName),
-		Namespace:   "rabbitmq-system",
-		Clientset:   clientSet,
-		PodExecutor: fakeExecutor,
+		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		Recorder:             mgr.GetEventRecorderFor(controllerName),
+		Namespace:            "rabbitmq-system",
+		Clientset:            clientSet,
+		PodExecutor:          fakeExecutor,
+		DefaultRabbitmqImage: defaultRabbitmqImage,
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -43,8 +43,13 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
+	var (
+		metricsAddr          string
+		defaultRabbitmqImage string
+	)
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":9782", "The address the metric endpoint binds to.")
+	flag.StringVar(&defaultRabbitmqImage, "default-rabbitmq-image", "rabbitmq:3.8.21-management", "The default image to use in RabbitmqClusters when not specified in the rabbitmqcluster.spec.image")
 
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
@@ -105,13 +110,14 @@ func main() {
 	}
 
 	err = (&controllers.RabbitmqClusterReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		Recorder:      mgr.GetEventRecorderFor(controllerName),
-		Namespace:     operatorNamespace,
-		ClusterConfig: clusterConfig,
-		Clientset:     kubernetes.NewForConfigOrDie(clusterConfig),
-		PodExecutor:   controllers.NewPodExecutor(),
+		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		Recorder:             mgr.GetEventRecorderFor(controllerName),
+		Namespace:            operatorNamespace,
+		ClusterConfig:        clusterConfig,
+		Clientset:            kubernetes.NewForConfigOrDie(clusterConfig),
+		PodExecutor:          controllers.NewPodExecutor(),
+		DefaultRabbitmqImage: defaultRabbitmqImage,
 	}).SetupWithManager(mgr)
 	if err != nil {
 		log.Error(err, "unable to create controller", controllerName)


### PR DESCRIPTION
## Summary Of Changes

Instead of the default image for RabbitmqClusters being hard-coded into
the CRD, it is now available as a command-line flag to the operator's
`manager` binary. Changing the operator's Deployment manifest to call
`/manager --default-rabbitmq-image image:tag` will now cause all
RabbitmqClusters deployed by the operator to use that default image if
one is not specified in `spec.image`.

This closes #856

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Additional Context
This change will make it easier to deploy the operator using helm - the CRD itself will no longer change when bumping the default image, and so the raw CRD manifest can be placed in the `crd/` directory, while still allowing the default image to be configurable on a per-operator-Deployment scope.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
