### PR TITLE
Add documented examples for NetworkPolicies

### DIFF
--- a/docs/examples/network-policies/README.md
+++ b/docs/examples/network-policies/README.md
@@ -8,8 +8,20 @@ By defining NetworkPolicies, you can restrict the network entities with which yo
 from reaching the cluster. It is important to note that once a RabbitmqCluster Pod, or any other Pod for that matter, is the target of any
 NetworkPolicy, it becomes isolated to all traffic except that permitted by a NetworkPolicy.
 
-The first policy in this example, [allow-inter-node-traffic.yaml](./allow-inter-node-traffic.yaml) ensures that the only nodes in the RabbitmqCluster
-send or receive traffic with each other on the ports used for inter-node communication.
+The following example policies all target (and therefore, affect the Pods of) the specific RabbitmqCluster deployed by [rabbitmq.yaml](./rabbitmq.yaml).
+This is done by targetting the RabbitmqCluster Pods using podSelector label matching:
+```yaml
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: rabbitmq
+      app.kubernetes.io/name: network-policies
+```
+To create policies that match any RabbitmqCluster, you can remove the `app.kubernetes.io/name` labelSelector. Bear in mind this might not always
+be appropriate for all NetworkPolicies; for example, inter-node traffic should be restricted on a per-RabbitmqCluster scope.
+
+The first policy in this example, [allow-inter-node-traffic.yaml](./allow-inter-node-traffic.yaml) ensures that only the Pods in the RabbitmqCluster
+can send or receive traffic with each other on the ports used for inter-node communication.
 
 The second policy, [allow-operator-traffic.yaml](./allow-operator-traffic.yaml), allows the cluster-operator and the messaging-topology-operator to
 communicate with the cluster Pods over HTTP, which is necessary for some reconciliation operations.

--- a/docs/examples/network-policies/README.md
+++ b/docs/examples/network-policies/README.md
@@ -8,13 +8,13 @@ By defining NetworkPolicies, you can restrict the network entities with which yo
 from reaching the cluster. It is important to note that once a RabbitmqCluster Pod, or any other Pod for that matter, is the target of any
 NetworkPolicy, it becomes isolated to all traffic except that permitted by a NetworkPolicy.
 
-The first policy in this example, [allow-inter-node-traffic.yaml](/allow-inter-node-traffic.yaml) ensures that the only nodes in the RabbitmqCluster
+The first policy in this example, [allow-inter-node-traffic.yaml](./allow-inter-node-traffic.yaml) ensures that the only nodes in the RabbitmqCluster
 send or receive traffic with each other on the ports used for inter-node communication.
 
-The second policy, [allow-operator-traffic.yaml](/allow-operator-traffic.yaml), allows the cluster-operator and the messaging-topology-operator to
+The second policy, [allow-operator-traffic.yaml](./allow-operator-traffic.yaml), allows the cluster-operator and the messaging-topology-operator to
 communicate with the cluster Pods over HTTP, which is necessary for some reconciliation operations.
 
-The third policy, [allow-rabbitmq-traffic.yaml](/allow-rabbitmq-traffic.yaml), allows all ingress traffic to external-facing ports on the cluster,
+The third policy, [allow-rabbitmq-traffic.yaml](./allow-rabbitmq-traffic.yaml), allows all ingress traffic to external-facing ports on the cluster,
 such as for AMQP messaging, Prometheus scraping, etc. In practice you may wish to add a selector to this policy to only allow traffic to these
 ports from your known client application Pods, or Prometheus servers, etc., depending on your network topology.
 

--- a/docs/examples/network-policies/README.md
+++ b/docs/examples/network-policies/README.md
@@ -1,0 +1,23 @@
+# Network Policy Example
+
+Kubernetes allows you to restrict the source/destination of traffic to & from your Pods at an IP / port level, by defining NetworkPolicies for your cluster, provided your
+cluster has the [network plugin](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/) enabled. For more
+information on NetworkPolicies, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/network-policies/).
+
+By defining NetworkPolicies, you can restrict the network entities with which your RabbitmqCluster can communicate, and prevent unrecognised traffic
+from reaching the cluster. It is important to note that once a RabbitmqCluster Pod, or any other Pod for that matter, is the target of any
+NetworkPolicy, it becomes isolated to all traffic except that permitted by a NetworkPolicy.
+
+The first policy in this example, [allow-inter-node-traffic.yaml](/allow-inter-node-traffic.yaml) ensures that the only nodes in the RabbitmqCluster
+send or receive traffic with each other on the ports used for inter-node communication.
+
+The second policy, [allow-operator-traffic.yaml](/allow-operator-traffic.yaml), allows the cluster-operator and the messaging-topology-operator to
+communicate with the cluster Pods over HTTP, which is necessary for some reconciliation operations.
+
+The third policy, [allow-rabbitmq-traffic.yaml](/allow-rabbitmq-traffic.yaml), allows all ingress traffic to external-facing ports on the cluster,
+such as for AMQP messaging, Prometheus scraping, etc. In practice you may wish to add a selector to this policy to only allow traffic to these
+ports from your known client application Pods, or Prometheus servers, etc., depending on your network topology.
+
+The ports exposed in these examples are taken from [the RabbitMQ documentation](https://www.rabbitmq.com/networking.html#ports), and represent
+the default ports used by RabbitMQ. It is possible to configure different ports to be used; if you have applied such configuration in your cluster,
+take care to ensure the ports in your NetworkPolicies match this configuration.

--- a/docs/examples/network-policies/allow-inter-node-traffic.yaml
+++ b/docs/examples/network-policies/allow-inter-node-traffic.yaml
@@ -1,0 +1,58 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-inter-node-traffic
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: rabbitmq
+      app.kubernetes.io/name: network-policies
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/component: rabbitmq
+          app.kubernetes.io/name: network-policies
+    ports:
+    - port: 4369  # epmd
+    - port: 25672 # clustering
+    - port: 35672 # CLI tooling
+    - port: 35673 # CLI tooling
+    - port: 35674 # CLI tooling
+    - port: 35675 # CLI tooling
+    - port: 35676 # CLI tooling
+    - port: 35677 # CLI tooling
+    - port: 35678 # CLI tooling
+    - port: 35679 # CLI tooling
+    - port: 35680 # CLI tooling
+    - port: 35681 # CLI tooling
+    - port: 35682 # CLI tooling
+  # If using the k8s feature gate NetworkPolicyEndPort (enabled by default 1.22+), the last 11 entries can be simplified to:
+  # - port: 35672 # CLI tooling
+  #   endPort: 35682
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/component: rabbitmq
+          app.kubernetes.io/name: network-policies
+    ports:
+    - port: 4369  # epmd
+    - port: 25672 # clustering
+    - port: 35672 # CLI tooling
+    - port: 35673 # CLI tooling
+    - port: 35674 # CLI tooling
+    - port: 35675 # CLI tooling
+    - port: 35676 # CLI tooling
+    - port: 35677 # CLI tooling
+    - port: 35678 # CLI tooling
+    - port: 35679 # CLI tooling
+    - port: 35680 # CLI tooling
+    - port: 35681 # CLI tooling
+    - port: 35682 # CLI tooling
+  # If using the k8s feature gate NetworkPolicyEndPort (enabled by default 1.22+), the last 11 entries can be simplified to:
+  # - port: 35672 # CLI tooling
+  #   endPort: 35682

--- a/docs/examples/network-policies/allow-operator-traffic.yaml
+++ b/docs/examples/network-policies/allow-operator-traffic.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-operator-traffic
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: rabbitmq
+      app.kubernetes.io/name: network-policies
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/component: rabbitmq-operator
+    ports:
+    - port: 15672 # HTTP API
+    - port: 15671 # HTTP API + TLS

--- a/docs/examples/network-policies/allow-rabbitmq-traffic.yaml
+++ b/docs/examples/network-policies/allow-rabbitmq-traffic.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-rabbitmq-traffic
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: rabbitmq
+      app.kubernetes.io/name: network-policies
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - port: 5672  # AMQP
+    - port: 5671  # AMQP + TLS
+    - port: 5552  # Streams
+    - port: 5551  # Streams + TLS
+    - port: 15672 # HTTP API
+    - port: 15672 # HTTP API + TLS
+    - port: 61613 # STOMP
+    - port: 61614 # STOMP + TLS
+    - port: 1883  # MQTT
+    - port: 8883  # MQTT + TLS
+    - port: 15674 # STOMP-over-WebSockets
+    - port: 15675 # MQTT-over-WebSockets
+    - port: 15692 # Prometheus endpoint
+    - port: 15691 # Prometheus endpoint + TLS
+

--- a/docs/examples/network-policies/allow-rabbitmq-traffic.yaml
+++ b/docs/examples/network-policies/allow-rabbitmq-traffic.yaml
@@ -16,7 +16,7 @@ spec:
     - port: 5552  # Streams
     - port: 5551  # Streams + TLS
     - port: 15672 # HTTP API
-    - port: 15672 # HTTP API + TLS
+    - port: 15671 # HTTP API + TLS
     - port: 61613 # STOMP
     - port: 61614 # STOMP + TLS
     - port: 1883  # MQTT

--- a/docs/examples/network-policies/rabbitmq.yaml
+++ b/docs/examples/network-policies/rabbitmq.yaml
@@ -1,0 +1,14 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: network-policies
+spec:
+  image: rabbitmq:3.9.7-management
+  replicas: 3
+  rabbitmq:
+    additionalPlugins:
+    - rabbitmq_mqtt
+    - rabbitmq_stomp
+    - rabbitmq_stream
+    - rabbitmq_web_mqtt
+    - rabbitmq_web_stomp


### PR DESCRIPTION
This closes #835 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
[NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) allow users to restrict the source/destination of ingress/egress traffic of their Pods. This documented example demonstrates the kinds of traffic a user may wish to restrict/allow on their cluster.

## Additional Context
You can enable the network plugin on GKE for testing with:
```
gcloud container clusters create CLUSTER_NAME --enable-network-policy
```

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
