### PR TITLE
Fix system tests

### DIFF
--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Operator", func() {
 			Expect(rmqClusterClient.Delete(context.TODO(), cluster)).To(Succeed())
 		})
 
-		FIt("works", func() {
+		It("works", func() {
 			By("publishing and consuming a message", func() {
 				response := alivenessTest(hostname, port, username, password)
 				Expect(response.Status).To(Equal("ok"))
@@ -347,7 +347,7 @@ CONSOLE_LOG=new`
 				pvc, err := clientSet.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return pvc.Spec.Resources.Requests["storage"]
-			}, "5m", 10).Should(Equal(newCapacity))
+			}, "10m", 10).Should(Equal(newCapacity))
 
 			// storage capacity reflected in the pod
 			Eventually(func() int {

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -623,11 +623,12 @@ CONSOLE_LOG=new`
 			Expect(rmqClusterClient.Delete(context.TODO(), cluster)).To(Succeed())
 		})
 
-		It("publishes and consumes a message", func() {
+		FIt("publishes and consumes a message", func() {
 			if !hasFeatureEnabled(cluster, "stream_queue") {
 				Skip("rabbitmq_stream plugin is not supported by RabbitMQ image " + cluster.Spec.Image)
 			}else {
-				fmt.Printf("Stream feature is enabled ")
+				fmt.Println("Stream feature is enabled ")
+				waitForPortConnectivity(cluster)
 				waitForPortReadiness(cluster, 5552) // stream
 				publishAndConsumeStreamMsg(hostname, rabbitmqNodePort(ctx, clientSet, cluster, "stream"), username, password)
 			}

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -330,7 +330,7 @@ CONSOLE_LOG=new`
 			waitForRabbitmqRunning(cluster)
 		})
 
-		FIt("allows volume expansion", func() {
+		It("allows volume expansion", func() {
 			podUID := pod(ctx, clientSet, cluster, 0).UID
 			output, err := kubectlExec(namespace, statefulSetPodName(cluster, 0), "rabbitmq", "df", "/var/lib/rabbitmq/mnesia")
 			Expect(err).ToNot(HaveOccurred())
@@ -346,6 +346,8 @@ CONSOLE_LOG=new`
 				pvcName := cluster.PVCName(0)
 				pvc, err := clientSet.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
+				fmt.Printf("Retrieved PVC %s with conditions %+v\n", pvcName, pvc.Status.Conditions)
+
 				return pvc.Spec.Resources.Requests["storage"]
 			}, "10m", 10).Should(Equal(newCapacity))
 

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Operator", func() {
 					Expect(err).ToNot(HaveOccurred())
 					return configMap.Annotations
 				}
-				Eventually(getConfigMapAnnotations, 1*time.Minute, 1).Should(
+				Eventually(getConfigMapAnnotations, k8sQueryTimeout, 1).Should(
 					HaveKey("rabbitmq.com/pluginsUpdatedAt"), "plugins ConfigMap should have been annotated")
 				Eventually(getConfigMapAnnotations, 4*time.Minute, 1).Should(
 					Not(HaveKey("rabbitmq.com/pluginsUpdatedAt")), "plugins ConfigMap annotation should have been removed")

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -623,7 +623,7 @@ CONSOLE_LOG=new`
 			Expect(rmqClusterClient.Delete(context.TODO(), cluster)).To(Succeed())
 		})
 
-		FIt("publishes and consumes a message", func() {
+		It("publishes and consumes a message", func() {
 			if !hasFeatureEnabled(cluster, "stream_queue") {
 				Skip("rabbitmq_stream plugin is not supported by RabbitMQ image " + cluster.Spec.Image)
 			}else {

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Operator", func() {
 			Expect(rmqClusterClient.Delete(context.TODO(), cluster)).To(Succeed())
 		})
 
-		It("works", func() {
+		FIt("works", func() {
 			By("publishing and consuming a message", func() {
 				response := alivenessTest(hostname, port, username, password)
 				Expect(response.Status).To(Equal("ok"))
@@ -115,7 +115,8 @@ var _ = Describe("Operator", func() {
 				Eventually(func() bool {
 					Expect(rmqClusterClient.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, fetchedRmq)).To(Succeed())
 					return fetchedRmq.Status.ObservedGeneration == fetchedRmq.Generation
-				}, 30).Should(BeTrue())
+				}, k8sQueryTimeout, 10).Should(BeTrue(), fmt.Sprintf("expected %d (Status.ObservedGeneration) = %d (Generation)",
+					fetchedRmq.Status.ObservedGeneration, fetchedRmq.Generation))
 			})
 
 			By("having all feature flags enabled", func() {
@@ -151,7 +152,7 @@ var _ = Describe("Operator", func() {
 			Expect(rmqClusterClient.Delete(context.TODO(), cluster)).To(Succeed())
 		})
 
-		FIt("keeps rabbitmq server related configurations up-to-date", func() {
+		It("keeps rabbitmq server related configurations up-to-date", func() {
 			By("updating enabled plugins  and the secret ports when additionalPlugins are modified", func() {
 				// modify rabbitmqcluster.spec.rabbitmq.additionalPlugins
 				Expect(updateRabbitmqCluster(ctx, rmqClusterClient, cluster.Name, cluster.Namespace, func(cluster *rabbitmqv1beta1.RabbitmqCluster) {
@@ -329,7 +330,7 @@ CONSOLE_LOG=new`
 			waitForRabbitmqRunning(cluster)
 		})
 
-		It("allows volume expansion", func() {
+		FIt("allows volume expansion", func() {
 			podUID := pod(ctx, clientSet, cluster, 0).UID
 			output, err := kubectlExec(namespace, statefulSetPodName(cluster, 0), "rabbitmq", "df", "/var/lib/rabbitmq/mnesia")
 			Expect(err).ToNot(HaveOccurred())

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -568,7 +568,7 @@ CONSOLE_LOG=new`
 			}
 			Expect(createRabbitmqCluster(ctx, rmqClusterClient, cluster)).To(Succeed())
 			waitForRabbitmqRunning(cluster)
-			waitForPortReadiness(cluster, 1883) // mqtt
+			waitForPortReadiness(cluster, 1883)  // mqtt
 			waitForPortReadiness(cluster, 61613) // stomp
 
 			hostname = kubernetesNodeIp(ctx, clientSet)
@@ -594,13 +594,12 @@ CONSOLE_LOG=new`
 			By("Streams")
 			if !hasFeatureEnabled(cluster, "stream_queue") {
 				Skip("rabbitmq_stream plugin is not supported by RabbitMQ image " + cluster.Spec.Image)
-			}else {
+			} else {
 				waitForPortConnectivity(cluster)
 				waitForPortReadiness(cluster, 5552) // stream
 				publishAndConsumeStreamMsg(hostname, rabbitmqNodePort(ctx, clientSet, cluster, "stream"), username, password)
 			}
 		})
-
 
 	})
 

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Operator", func() {
 			Expect(rmqClusterClient.Delete(context.TODO(), cluster)).To(Succeed())
 		})
 
-		It("keeps rabbitmq server related configurations up-to-date", func() {
+		FIt("keeps rabbitmq server related configurations up-to-date", func() {
 			By("updating enabled plugins  and the secret ports when additionalPlugins are modified", func() {
 				// modify rabbitmqcluster.spec.rabbitmq.additionalPlugins
 				Expect(updateRabbitmqCluster(ctx, rmqClusterClient, cluster.Name, cluster.Namespace, func(cluster *rabbitmqv1beta1.RabbitmqCluster) {
@@ -164,7 +164,7 @@ var _ = Describe("Operator", func() {
 					Expect(err).ToNot(HaveOccurred())
 					return configMap.Annotations
 				}
-				Eventually(getConfigMapAnnotations, 30, 1).Should(
+				Eventually(getConfigMapAnnotations, 1*time.Minute, 1).Should(
 					HaveKey("rabbitmq.com/pluginsUpdatedAt"), "plugins ConfigMap should have been annotated")
 				Eventually(getConfigMapAnnotations, 4*time.Minute, 1).Should(
 					Not(HaveKey("rabbitmq.com/pluginsUpdatedAt")), "plugins ConfigMap annotation should have been removed")
@@ -592,7 +592,7 @@ CONSOLE_LOG=new`
 
 	})
 
-	FWhen("stream plugin is enabled", func() {
+	When("stream plugin is enabled", func() {
 		var (
 			cluster  *rabbitmqv1beta1.RabbitmqCluster
 			hostname string

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -1012,7 +1012,7 @@ func publishAndConsumeStreamMsg(host, port, username, password string) {
 			fmt.Println("connected to stream endpoint")
 			return nil
 		}else {
-			fmt.Errorf("failed to connect to stream endpoint (%s:%d) due to %g\n", host, portInt, err)
+			fmt.Printf("failed to connect to stream endpoint (%s:%d) due to %g\n", host, portInt, err)
 		}
 		return err
 	}, portReadinessTimeout*5, portReadinessTimeout).ShouldNot(HaveOccurred())

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -59,7 +59,8 @@ import (
 )
 
 const podCreationTimeout = 10 * time.Minute
-const portReadinessTimeout = 10 * time.Second
+const portReadinessTimeout = 1 * time.Minute
+const k8sQueryTimeout = 1 * time.Minute
 
 type featureFlag struct {
 	Name  string

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -837,17 +837,21 @@ func publishAndConsumeMQTTMsg(hostname, port, username, password string, overWeb
 
 	var token mqtt.Token
 	EventuallyWithOffset(1, func() bool {
+		fmt.Printf("Attempt to connect using MQTT to url %s ( %+v\n )", url, opts)
+
 		token = c.Connect()
 		// Waits for the network request to reach the destination and receive a response
-		if !token.WaitTimeout(3 * time.Second) {
+		if !token.WaitTimeout(30 * time.Second) {
+			fmt.Printf("Timed out\n")
 			return false
 		}
 
 		if err := token.Error(); err == nil {
+			fmt.Printf("Connected !\n")
 			return true
 		}
 		return false
-	}, 30, 2).Should(BeTrue(), "Expected to be able to connect to MQTT port")
+	}, 30, 20).Should(BeTrue(), "Expected to be able to connect to MQTT port")
 
 	topic := "tests/mqtt"
 	msgReceived := false

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -67,8 +67,6 @@ type featureFlag struct {
 	State string
 }
 
-
-
 func MustHaveEnv(name string) string {
 	value := os.Getenv(name)
 	if value == "" {
@@ -996,8 +994,8 @@ func publishAndConsumeStreamMsg(host, port, username, password string) {
 	portInt, err := strconv.Atoi(port)
 	Expect(err).ToNot(HaveOccurred())
 
-	var env  *stream.Environment
-	Eventually(func() error{
+	var env *stream.Environment
+	Eventually(func() error {
 		fmt.Println("connecting to stream endpoint ...")
 		env, err = stream.NewEnvironment(stream.NewEnvironmentOptions().
 			SetHost(host).
@@ -1011,7 +1009,7 @@ func publishAndConsumeStreamMsg(host, port, username, password string) {
 		if err == nil {
 			fmt.Println("connected to stream endpoint")
 			return nil
-		}else {
+		} else {
 			fmt.Printf("failed to connect to stream endpoint (%s:%d) due to %g\n", host, portInt, err)
 		}
 		return err

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -997,7 +997,7 @@ func publishAndConsumeStreamMsg(host, port, username, password string) {
 	Expect(err).ToNot(HaveOccurred())
 
 	var env  *stream.Environment
-	for retry := 0; retry < 5; retry++ {
+	Eventually(func() error{
 		fmt.Println("connecting to stream endpoint ...")
 		env, err = stream.NewEnvironment(stream.NewEnvironmentOptions().
 			SetHost(host).
@@ -1010,13 +1010,12 @@ func publishAndConsumeStreamMsg(host, port, username, password string) {
 			}))
 		if err == nil {
 			fmt.Println("connected to stream endpoint")
-			break
+			return nil
 		}else {
 			fmt.Errorf("failed to connect to stream endpoint (%s:%d) due to %g\n", host, portInt, err)
 		}
-		time.Sleep(portReadinessTimeout)
-	}
-	Expect(err).ToNot(HaveOccurred())
+		return err
+	}, portReadinessTimeout*5, portReadinessTimeout).ShouldNot(HaveOccurred())
 
 	const streamName = "system-test-stream"
 	Expect(env.DeclareStream(


### PR DESCRIPTION
This fixes #863 (WIP)

## Summary Of Changes

The issues that i identified were mainly these ones:
- Persistent volume operations such as volume expansion take far longer than initially expected. The timeout used is 10m which should be long enough. But the reality is that sometimes it takes longer.  I wonder if it makes sense to get the PVC's events before aborting the test case so that we can know what has happened to the PVC up this point. For the time being, I have added a logging statement that logs the PVC's `status.conditions`. 
- Test cases that checked ConfigMap's annotation `rabbitmq.com/pluginsUpdatedAt` were very time sensitive. I managed to reproduce it a few times so it seemed that 30 seconds timeout was too tight. We could ramp it up to 1 minute without any issues. The next timeout would be 4minutes which is when we check that the annotation should no longer exist.
- The last issue was related to testing protocols such as MQTT, STOMP, and Streams. I observed that even though the stateful set was fully ready , the ports were not fully opened and ready to attend traffic. Therefore, it was required to add an extra function that would wait until the port was ready. 

