### PR TITLE
Include protocol information in Service ports

### DIFF
--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -421,8 +421,9 @@ var _ = Describe("RabbitmqClusterController", func() {
 			}, 3).Should(HaveKeyWithValue("test-key", "test-value"))
 
 			// verify that SuccessfulUpdate event is recorded for the service
-			Expect(aggregateEventMsgs(ctx, cluster, "SuccessfulUpdate")).To(
-				ContainSubstring("updated resource %s of Type *v1.Service", cluster.ChildResourceName("")))
+			Eventually(func() string {
+				return aggregateEventMsgs(ctx, cluster, "SuccessfulUpdate")
+			}, 5).Should(ContainSubstring("updated resource %s of Type *v1.Service", cluster.ChildResourceName("")))
 		})
 
 		It("the CPU and memory requirements are updated", func() {
@@ -1091,22 +1092,25 @@ var _ = Describe("RabbitmqClusterController", func() {
 			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 			Expect(svc.Spec.Ports).To(ConsistOf(
 				corev1.ServicePort{
-					Name:       "amqp",
-					Port:       5672,
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: amqpTargetPort,
+					Name:        "amqp",
+					Port:        5672,
+					Protocol:    corev1.ProtocolTCP,
+					TargetPort:  amqpTargetPort,
+					AppProtocol: pointer.String("amqp"),
 				},
 				corev1.ServicePort{
-					Name:       "management",
-					Port:       15672,
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: managementTargetPort,
+					Name:        "management",
+					Port:        15672,
+					Protocol:    corev1.ProtocolTCP,
+					TargetPort:  managementTargetPort,
+					AppProtocol: pointer.String("http"),
 				},
 				corev1.ServicePort{
-					Name:       "prometheus",
-					Port:       15692,
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: prometheusTargetPort,
+					Name:        "prometheus",
+					Port:        15692,
+					Protocol:    corev1.ProtocolTCP,
+					TargetPort:  prometheusTargetPort,
+					AppProtocol: pointer.String("prometheus.io/metrics"),
 				},
 				corev1.ServicePort{
 					Protocol:   corev1.ProtocolTCP,

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Context("Services", func() {
@@ -93,29 +94,33 @@ var _ = Context("Services", func() {
 				Expect(serviceBuilder.Update(svc)).To(Succeed())
 				Expect(svc.Spec.Ports).To(ContainElements([]corev1.ServicePort{
 					{
-						Name:       "amqps",
-						Protocol:   corev1.ProtocolTCP,
-						Port:       5671,
-						TargetPort: intstr.FromInt(5671),
+						Name:        "amqps",
+						Protocol:    corev1.ProtocolTCP,
+						Port:        5671,
+						TargetPort:  intstr.FromInt(5671),
+						AppProtocol: pointer.String("amqps"),
 					},
 					{
-						Name:       "management-tls",
-						Protocol:   corev1.ProtocolTCP,
-						Port:       15671,
-						TargetPort: intstr.FromInt(15671),
+						Name:        "management-tls",
+						Protocol:    corev1.ProtocolTCP,
+						Port:        15671,
+						TargetPort:  intstr.FromInt(15671),
+						AppProtocol: pointer.String("https"),
 					},
 					{
-						Name:       "prometheus-tls",
-						Protocol:   corev1.ProtocolTCP,
-						Port:       15691,
-						TargetPort: intstr.FromInt(15691),
+						Name:        "prometheus-tls",
+						Protocol:    corev1.ProtocolTCP,
+						Port:        15691,
+						TargetPort:  intstr.FromInt(15691),
+						AppProtocol: pointer.String("prometheus.io/metric-tls"),
 					},
 				}))
 				Expect(svc.Spec.Ports).ToNot(ContainElement(corev1.ServicePort{
-					Name:       "prometheus",
-					Protocol:   corev1.ProtocolTCP,
-					Port:       15692,
-					TargetPort: intstr.FromInt(15692),
+					Name:        "prometheus",
+					Protocol:    corev1.ProtocolTCP,
+					Port:        15692,
+					TargetPort:  intstr.FromInt(15692),
+					AppProtocol: pointer.String("prometheus.io/metric"),
 				},
 				))
 			})
@@ -126,22 +131,25 @@ var _ = Context("Services", func() {
 					Expect(serviceBuilder.Update(svc)).To(Succeed())
 					Expect(svc.Spec.Ports).To(ContainElements([]corev1.ServicePort{
 						{
-							Name:       "mqtts",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       8883,
-							TargetPort: intstr.FromInt(8883),
+							Name:        "mqtts",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        8883,
+							TargetPort:  intstr.FromInt(8883),
+							AppProtocol: pointer.String("mqtts"),
 						},
 						{
-							Name:       "stomps",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       61614,
-							TargetPort: intstr.FromInt(61614),
+							Name:        "stomps",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        61614,
+							TargetPort:  intstr.FromInt(61614),
+							AppProtocol: pointer.String("stomp.github.io/stomp-tls"),
 						},
 						{
-							Name:       "streams",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       5551,
-							TargetPort: intstr.FromInt(5551),
+							Name:        "streams",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        5551,
+							TargetPort:  intstr.FromInt(5551),
+							AppProtocol: pointer.String("rabbitmq.com/stream-tls"),
 						},
 					}))
 				})
@@ -154,16 +162,18 @@ var _ = Context("Services", func() {
 					Expect(serviceBuilder.Update(svc)).To(Succeed())
 					Expect(svc.Spec.Ports).To(ContainElements([]corev1.ServicePort{
 						{
-							Name:       "web-mqtt-tls",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       15676,
-							TargetPort: intstr.FromInt(15676),
+							Name:        "web-mqtt-tls",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        15676,
+							TargetPort:  intstr.FromInt(15676),
+							AppProtocol: pointer.String("https"),
 						},
 						{
-							Name:       "web-stomp-tls",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       15673,
-							TargetPort: intstr.FromInt(15673),
+							Name:        "web-stomp-tls",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        15673,
+							TargetPort:  intstr.FromInt(15673),
+							AppProtocol: pointer.String("https"),
 						},
 					}))
 				})
@@ -175,10 +185,11 @@ var _ = Context("Services", func() {
 					Expect(serviceBuilder.Update(svc)).To(Succeed())
 					Expect(svc.Spec.Ports).To(ContainElements([]corev1.ServicePort{
 						{
-							Name:       "streams",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       5551,
-							TargetPort: intstr.FromInt(5551),
+							Name:        "streams",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        5551,
+							TargetPort:  intstr.FromInt(5551),
+							AppProtocol: pointer.String("rabbitmq.com/stream-tls"),
 						},
 					}))
 				})
@@ -190,66 +201,73 @@ var _ = Context("Services", func() {
 					Expect(serviceBuilder.Update(svc)).To(Succeed())
 					Expect(svc.Spec.Ports).To(ConsistOf([]corev1.ServicePort{
 						{
-							Name:       "amqps",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       5671,
-							TargetPort: intstr.FromInt(5671),
+							Name:        "amqps",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        5671,
+							TargetPort:  intstr.FromInt(5671),
+							AppProtocol: pointer.String("amqps"),
 						},
 						{
-							Name:       "management-tls",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       15671,
-							TargetPort: intstr.FromInt(15671),
+							Name:        "management-tls",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        15671,
+							TargetPort:  intstr.FromInt(15671),
+							AppProtocol: pointer.String("https"),
 						},
 						{
-							Name:       "prometheus-tls",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       15691,
-							TargetPort: intstr.FromInt(15691),
+							Name:        "prometheus-tls",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        15691,
+							TargetPort:  intstr.FromInt(15691),
+							AppProtocol: pointer.String("prometheus.io/metric-tls"),
 						},
 					}))
 				})
 				DescribeTable("only exposes tls ports in the service for enabled plugins",
-					func(plugin, servicePortName string, port int) {
+					func(plugin, servicePortName string, port int, appProtocol *string) {
 						instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{rabbitmqv1beta1.Plugin(plugin)}
 						instance.Spec.TLS.DisableNonTLSListeners = true
 						instance.Spec.TLS.CaSecretName = "somecacertname"
 						Expect(serviceBuilder.Update(svc)).To(Succeed())
 						amqpsPort := corev1.ServicePort{
 
-							Name:       "amqps",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       5671,
-							TargetPort: intstr.FromInt(5671),
+							Name:        "amqps",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        5671,
+							TargetPort:  intstr.FromInt(5671),
+							AppProtocol: pointer.String("amqps"),
 						}
 						managementTLSPort := corev1.ServicePort{
 
-							Name:       "management-tls",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       15671,
-							TargetPort: intstr.FromInt(15671),
+							Name:        "management-tls",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        15671,
+							TargetPort:  intstr.FromInt(15671),
+							AppProtocol: pointer.String("https"),
 						}
 						prometheusTLSPort := corev1.ServicePort{
 
-							Name:       "prometheus-tls",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       15691,
-							TargetPort: intstr.FromInt(15691),
+							Name:        "prometheus-tls",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        15691,
+							TargetPort:  intstr.FromInt(15691),
+							AppProtocol: pointer.String("prometheus.io/metric-tls"),
 						}
 						expectedPort := corev1.ServicePort{
-							Name:       servicePortName,
-							Port:       int32(port),
-							TargetPort: intstr.FromInt(port),
-							Protocol:   corev1.ProtocolTCP,
+							Name:        servicePortName,
+							Port:        int32(port),
+							TargetPort:  intstr.FromInt(port),
+							Protocol:    corev1.ProtocolTCP,
+							AppProtocol: appProtocol,
 						}
 						Expect(svc.Spec.Ports).To(ConsistOf(amqpsPort, managementTLSPort, prometheusTLSPort, expectedPort))
 					},
-					Entry("MQTT", "rabbitmq_mqtt", "mqtts", 8883),
-					Entry("MQTT-over-WebSockets", "rabbitmq_web_mqtt", "web-mqtt-tls", 15676),
-					Entry("STOMP", "rabbitmq_stomp", "stomps", 61614),
-					Entry("STOMP-over-WebSockets", "rabbitmq_web_stomp", "web-stomp-tls", 15673),
-					Entry("Stream", "rabbitmq_stream", "streams", 5551),
-					Entry("OSR", "rabbitmq_multi_dc_replication", "streams", 5551),
+					Entry("MQTT", "rabbitmq_mqtt", "mqtts", 8883, pointer.String("mqtts")),
+					Entry("MQTT-over-WebSockets", "rabbitmq_web_mqtt", "web-mqtt-tls", 15676, pointer.String("https")),
+					Entry("STOMP", "rabbitmq_stomp", "stomps", 61614, pointer.String("stomp.github.io/stomp-tls")),
+					Entry("STOMP-over-WebSockets", "rabbitmq_web_stomp", "web-stomp-tls", 15673, pointer.String("https")),
+					Entry("Stream", "rabbitmq_stream", "streams", 5551, pointer.String("rabbitmq.com/stream-tls")),
+					Entry("OSR", "rabbitmq_multi_dc_replication", "streams", 5551, pointer.String("rabbitmq.com/stream-tls")),
 				)
 			})
 		})
@@ -444,45 +462,49 @@ var _ = Context("Services", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				amqpPort := corev1.ServicePort{
-					Name:       "amqp",
-					Port:       5672,
-					TargetPort: intstr.FromInt(5672),
-					Protocol:   corev1.ProtocolTCP,
+					Name:        "amqp",
+					Port:        5672,
+					TargetPort:  intstr.FromInt(5672),
+					Protocol:    corev1.ProtocolTCP,
+					AppProtocol: pointer.String("amqp"),
 				}
 				managementPort := corev1.ServicePort{
-					Name:       "management",
-					Port:       15672,
-					TargetPort: intstr.FromInt(15672),
-					Protocol:   corev1.ProtocolTCP,
+					Name:        "management",
+					Port:        15672,
+					TargetPort:  intstr.FromInt(15672),
+					Protocol:    corev1.ProtocolTCP,
+					AppProtocol: pointer.String("http"),
 				}
 				prometheusPort := corev1.ServicePort{
-					Name:       "prometheus",
-					Port:       15692,
-					TargetPort: intstr.FromInt(15692),
-					Protocol:   corev1.ProtocolTCP,
+					Name:        "prometheus",
+					Port:        15692,
+					TargetPort:  intstr.FromInt(15692),
+					Protocol:    corev1.ProtocolTCP,
+					AppProtocol: pointer.String("prometheus.io/metrics"),
 				}
 				Expect(svc.Spec.Ports).To(ConsistOf(amqpPort, managementPort, prometheusPort))
 			})
 
 			DescribeTable("plugins exposing ports",
-				func(plugin, servicePortName string, port int) {
+				func(plugin, servicePortName string, port int, appProtocol *string) {
 					instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{rabbitmqv1beta1.Plugin(plugin)}
 					Expect(serviceBuilder.Update(svc)).To(Succeed())
 
 					expectedPort := corev1.ServicePort{
-						Name:       servicePortName,
-						Port:       int32(port),
-						TargetPort: intstr.FromInt(port),
-						Protocol:   corev1.ProtocolTCP,
+						Name:        servicePortName,
+						Port:        int32(port),
+						TargetPort:  intstr.FromInt(port),
+						Protocol:    corev1.ProtocolTCP,
+						AppProtocol: appProtocol,
 					}
 					Expect(svc.Spec.Ports).To(ContainElement(expectedPort))
 				},
-				Entry("MQTT", "rabbitmq_mqtt", "mqtt", 1883),
-				Entry("MQTT-over-WebSockets", "rabbitmq_web_mqtt", "web-mqtt", 15675),
-				Entry("STOMP", "rabbitmq_stomp", "stomp", 61613),
-				Entry("STOMP-over-WebSockets", "rabbitmq_web_stomp", "web-stomp", 15674),
-				Entry("Stream", "rabbitmq_stream", "stream", 5552),
-				Entry("OSR", "rabbitmq_multi_dc_replication", "stream", 5552),
+				Entry("MQTT", "rabbitmq_mqtt", "mqtt", 1883, pointer.String("mqtt")),
+				Entry("MQTT-over-WebSockets", "rabbitmq_web_mqtt", "web-mqtt", 15675, pointer.String("http")),
+				Entry("STOMP", "rabbitmq_stomp", "stomp", 61613, pointer.String("stomp.github.io/stomp")),
+				Entry("STOMP-over-WebSockets", "rabbitmq_web_stomp", "web-stomp", 15674, pointer.String("http")),
+				Entry("Stream", "rabbitmq_stream", "stream", 5552, pointer.String("rabbitmq.com/stream")),
+				Entry("OSR", "rabbitmq_multi_dc_replication", "stream", 5552, pointer.String("rabbitmq.com/stream")),
 			)
 
 			It("updates the service type from ClusterIP to NodePort", func() {
@@ -499,18 +521,20 @@ var _ = Context("Services", func() {
 				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 				svc.Spec.Ports = []corev1.ServicePort{
 					{
-						Protocol:   corev1.ProtocolTCP,
-						Port:       5672,
-						TargetPort: intstr.FromInt(5672),
-						Name:       "amqp",
-						NodePort:   12345,
+						Protocol:    corev1.ProtocolTCP,
+						Port:        5672,
+						TargetPort:  intstr.FromInt(5672),
+						Name:        "amqp",
+						NodePort:    12345,
+						AppProtocol: pointer.String("amqp"),
 					},
 					{
-						Protocol:   corev1.ProtocolTCP,
-						Port:       15672,
-						Name:       "management",
-						TargetPort: intstr.FromInt(15672),
-						NodePort:   1234,
+						Protocol:    corev1.ProtocolTCP,
+						Port:        15672,
+						Name:        "management",
+						TargetPort:  intstr.FromInt(15672),
+						NodePort:    1234,
+						AppProtocol: nil, // explicitly leaving this nill to test that Update sets the correct value
 					},
 				}
 
@@ -519,78 +543,88 @@ var _ = Context("Services", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedAmqpServicePort := corev1.ServicePort{
-					Name:       "amqp",
-					Protocol:   corev1.ProtocolTCP,
-					Port:       5672,
-					TargetPort: intstr.FromInt(5672),
-					NodePort:   12345,
+					Name:        "amqp",
+					Protocol:    corev1.ProtocolTCP,
+					Port:        5672,
+					TargetPort:  intstr.FromInt(5672),
+					NodePort:    12345,
+					AppProtocol: pointer.String("amqp"),
 				}
 				expectedManagementServicePort := corev1.ServicePort{
-					Protocol:   corev1.ProtocolTCP,
-					Port:       15672,
-					Name:       "management",
-					TargetPort: intstr.FromInt(15672),
-					NodePort:   1234,
+					Protocol:    corev1.ProtocolTCP,
+					Port:        15672,
+					Name:        "management",
+					TargetPort:  intstr.FromInt(15672),
+					NodePort:    1234,
+					AppProtocol: pointer.String("http"),
 				}
 
 				Expect(svc.Spec.Ports).To(ContainElement(expectedAmqpServicePort))
 				Expect(svc.Spec.Ports).To(ContainElement(expectedManagementServicePort))
 			})
 
-			It("unsets nodePort after updating from NodePort to ClusterIP", func() {
-				svc.Spec.Type = corev1.ServiceTypeNodePort
-				svc.Spec.Ports = []corev1.ServicePort{
-					{
-						Protocol:   corev1.ProtocolTCP,
-						Port:       5672,
-						TargetPort: intstr.FromInt(5672),
-						Name:       "amqp",
-						NodePort:   12345,
-					},
-				}
+			When("service type is updated from NodePort to ClusterIP", func() {
+				It("unsets nodePort field", func() {
+					svc.Spec.Type = corev1.ServiceTypeNodePort
+					svc.Spec.Ports = []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       5672,
+							TargetPort: intstr.FromInt(5672),
+							Name:       "amqp",
+							NodePort:   12345,
+						},
+					}
 
-				serviceBuilder.Instance.Spec.Service.Type = "ClusterIP"
-				err := serviceBuilder.Update(svc)
-				Expect(err).NotTo(HaveOccurred())
+					serviceBuilder.Instance.Spec.Service.Type = "ClusterIP"
+					err := serviceBuilder.Update(svc)
+					Expect(err).NotTo(HaveOccurred())
 
-				// We cant set nodePort to nil because its a primitive
-				// For Kubernetes API, setting it to 0 is the same as not setting it at all
-				expectedServicePort := corev1.ServicePort{
-					Name:       "amqp",
-					Protocol:   corev1.ProtocolTCP,
-					Port:       5672,
-					TargetPort: intstr.FromInt(5672),
-					NodePort:   0,
-				}
+					// We cant set nodePort to nil because its a primitive
+					// For Kubernetes API, setting it to 0 is the same as not setting it at all
+					expectedServicePort := corev1.ServicePort{
+						Name:        "amqp",
+						Protocol:    corev1.ProtocolTCP,
+						Port:        5672,
+						TargetPort:  intstr.FromInt(5672),
+						NodePort:    0,
+						AppProtocol: pointer.String("amqp"),
+					}
 
-				Expect(svc.Spec.Ports).To(ContainElement(expectedServicePort))
+					Expect(svc.Spec.Ports).To(ContainElement(expectedServicePort))
+					Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+				})
 			})
 
-			It("unsets the service type and node ports when service type is deleted from CR spec", func() {
-				svc.Spec.Type = corev1.ServiceTypeNodePort
-				svc.Spec.Ports = []corev1.ServicePort{
-					{
-						Protocol:   corev1.ProtocolTCP,
-						Port:       5672,
-						TargetPort: intstr.FromInt(5672),
-						Name:       "amqp",
-						NodePort:   12345,
-					},
-				}
+			When("service type is deleted from the spec", func() {
+				It("unsets the service type and node ports", func() {
+					svc.Spec.Type = corev1.ServiceTypeNodePort
+					svc.Spec.Ports = []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       5672,
+							TargetPort: intstr.FromInt(5672),
+							Name:       "amqp",
+							NodePort:   12345,
+						},
+					}
 
-				serviceBuilder.Instance.Spec.Service.Type = ""
-				err := serviceBuilder.Update(svc)
-				Expect(err).NotTo(HaveOccurred())
+					serviceBuilder.Instance.Spec.Service.Type = ""
+					err := serviceBuilder.Update(svc)
+					Expect(err).NotTo(HaveOccurred())
 
-				expectedServicePort := corev1.ServicePort{
-					Name:       "amqp",
-					Protocol:   corev1.ProtocolTCP,
-					Port:       5672,
-					TargetPort: intstr.FromInt(5672),
-					NodePort:   0,
-				}
+					expectedServicePort := corev1.ServicePort{
+						Name:        "amqp",
+						Protocol:    corev1.ProtocolTCP,
+						Port:        5672,
+						TargetPort:  intstr.FromInt(5672),
+						NodePort:    0,
+						AppProtocol: pointer.String("amqp"),
+					}
 
-				Expect(svc.Spec.Ports).To(ContainElement(expectedServicePort))
+					Expect(svc.Spec.Ports).To(ContainElement(expectedServicePort))
+					Expect(svc.Spec.Type).To(BeEmpty())
+				})
 			})
 		})
 
@@ -642,10 +676,11 @@ var _ = Context("Services", func() {
 					Spec: &corev1.ServiceSpec{
 						Ports: []corev1.ServicePort{
 							{
-								Protocol:   corev1.ProtocolUDP,
-								Port:       12345,
-								TargetPort: intstr.FromInt(12345),
-								Name:       "my-new-port",
+								Protocol:    corev1.ProtocolUDP,
+								Port:        12345,
+								TargetPort:  intstr.FromInt(12345),
+								Name:        "my-new-port",
+								AppProtocol: pointer.String("my.company.com/protocol"),
 							},
 						},
 						Selector: map[string]string{
@@ -672,28 +707,32 @@ var _ = Context("Services", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(svc.Spec.Ports).To(ConsistOf(
 					corev1.ServicePort{
-						Name:       "amqp",
-						Port:       5672,
-						TargetPort: intstr.FromInt(5672),
-						Protocol:   corev1.ProtocolTCP,
+						Name:        "amqp",
+						Port:        5672,
+						TargetPort:  intstr.FromInt(5672),
+						Protocol:    corev1.ProtocolTCP,
+						AppProtocol: pointer.String("amqp"),
 					},
 					corev1.ServicePort{
-						Name:       "management",
-						Port:       15672,
-						TargetPort: intstr.FromInt(15672),
-						Protocol:   corev1.ProtocolTCP,
+						Name:        "management",
+						Port:        15672,
+						TargetPort:  intstr.FromInt(15672),
+						Protocol:    corev1.ProtocolTCP,
+						AppProtocol: pointer.String("http"),
 					},
 					corev1.ServicePort{
-						Name:       "prometheus",
-						Port:       15692,
-						TargetPort: intstr.FromInt(15692),
-						Protocol:   corev1.ProtocolTCP,
+						Name:        "prometheus",
+						Port:        15692,
+						TargetPort:  intstr.FromInt(15692),
+						Protocol:    corev1.ProtocolTCP,
+						AppProtocol: pointer.String("prometheus.io/metrics"),
 					},
 					corev1.ServicePort{
-						Protocol:   corev1.ProtocolUDP,
-						Port:       12345,
-						TargetPort: intstr.FromInt(12345),
-						Name:       "my-new-port",
+						Protocol:    corev1.ProtocolUDP,
+						Port:        12345,
+						TargetPort:  intstr.FromInt(12345),
+						Name:        "my-new-port",
+						AppProtocol: pointer.String("my.company.com/protocol"),
 					},
 				))
 				Expect(svc.Spec.Selector).To(Equal(map[string]string{"a-selector": "a-label", "app.kubernetes.io/name": "foo"}))


### PR DESCRIPTION
This closes #878 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
- Added field `appProtocol` to Service Ports, to enable Istio protocol detection
- FLAKE in integration test

## Additional Context
By setting this field, we are able to take full advantage of all Istio traffic monitoring features and rich metrics, we must hint Istio what's the underlying protocol. [Source
here](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/).

According to Kubernetes docs, protocol that are not registered in IANA registry as well-known ports, must use a suffix, like `my.company.com/my-protocol`. Surprisingly, STOMP does not have a well-known port assigned.

https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml

A system test for MQTT, STOMP and Streams may flake. That flake will be fixed by #872 

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
