### PR TITLE
Fix port exposure in MQTT/STOMP and WS variants

### DIFF
--- a/internal/resource/service.go
+++ b/internal/resource/service.go
@@ -12,6 +12,7 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
+
 	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -246,7 +247,7 @@ func (builder *ServiceBuilder) generateServicePortsMap() map[string]corev1.Servi
 
 	if builder.Instance.MutualTLSEnabled() {
 		if builder.Instance.AdditionalPluginEnabled("rabbitmq_web_stomp") {
-			servicePortsMap["stomps"] = corev1.ServicePort{
+			servicePortsMap["web-stomp-tls"] = corev1.ServicePort{
 				Protocol:    corev1.ProtocolTCP,
 				Port:        15673,
 				Name:        "web-stomp-tls",
@@ -255,7 +256,7 @@ func (builder *ServiceBuilder) generateServicePortsMap() map[string]corev1.Servi
 			}
 		}
 		if builder.Instance.AdditionalPluginEnabled("rabbitmq_web_mqtt") {
-			servicePortsMap["mqtts"] = corev1.ServicePort{
+			servicePortsMap["web-mqtt-tls"] = corev1.ServicePort{
 				Protocol:    corev1.ProtocolTCP,
 				Port:        15676,
 				Name:        "web-mqtt-tls",

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -270,6 +270,54 @@ var _ = Context("Services", func() {
 					Entry("OSR", "rabbitmq_multi_dc_replication", "streams", 5551, pointer.String("rabbitmq.com/stream-tls")),
 				)
 			})
+
+			When("MQTT and Web-MQTT are enabled", func() {
+				It("exposes ports for both protocols", func() {
+					instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_mqtt", "rabbitmq_web_mqtt"}
+					instance.Spec.TLS.CaSecretName = "my-ca"
+					Expect(serviceBuilder.Update(svc)).To(Succeed())
+					Expect(svc.Spec.Ports).To(ContainElements([]corev1.ServicePort{
+						{
+							Name:        "web-mqtt-tls",
+							Protocol:    corev1.ProtocolTCP,
+							AppProtocol: pointer.String("https"),
+							Port:        15676,
+							TargetPort:  intstr.FromInt(15676),
+						},
+						{
+							Name:        "mqtts",
+							Protocol:    corev1.ProtocolTCP,
+							AppProtocol: pointer.String("mqtts"),
+							Port:        8883,
+							TargetPort:  intstr.FromInt(8883),
+						},
+					}))
+				})
+			})
+
+			When("STOMP and Web-STOMP are enabled", func() {
+				It("exposes ports for both protocols", func() {
+					instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_stomp", "rabbitmq_web_stomp"}
+					instance.Spec.TLS.CaSecretName = "my-ca"
+					Expect(serviceBuilder.Update(svc)).To(Succeed())
+					Expect(svc.Spec.Ports).To(ContainElements([]corev1.ServicePort{
+						{
+							Name:        "web-stomp-tls",
+							Protocol:    corev1.ProtocolTCP,
+							AppProtocol: pointer.String("https"),
+							Port:        15673,
+							TargetPort:  intstr.FromInt(15673),
+						},
+						{
+							Name:        "stomps",
+							Protocol:    corev1.ProtocolTCP,
+							AppProtocol: pointer.String("stomp.github.io/stomp-tls"),
+							Port:        61614,
+							TargetPort:  intstr.FromInt(61614),
+						},
+					}))
+				})
+			})
 		})
 
 		Context("Annotations", func() {


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

MQTT/STOMP over TLS, and its web socket variants, can be exposed together over TLS, they are not mutually exclusive. Previously, we were not exposing MQTT/STOMP over TLS, if mTLS was enabled, but replacing them with the web socket variants.

## Additional Context

Integration test `the service annotations are updated` may flake. This flake will be improved by #888 

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
