### PR TITLE
Generate `rabbitmq_cluster` label in observability examples

### DIFF
--- a/observability/prometheus/monitors/rabbitmq-servicemonitor.yml
+++ b/observability/prometheus/monitors/rabbitmq-servicemonitor.yml
@@ -10,10 +10,18 @@ spec:
     scheme: http
     interval: 15s
     scrapeTimeout: 14s
+    relabelings:
+    - sourceLabels:
+      - __meta_kubernetes_endpoints_label_app_kubernetes_io_name
+      targetLabel: rabbitmq_cluster
   - port: prometheus-tls
     scheme: https
     interval: 15s
     scrapeTimeout: 14s
+    relabelings:
+    - sourceLabels:
+      - __meta_kubernetes_endpoints_label_app_kubernetes_io_name
+      targetLabel: rabbitmq_cluster
     tlsConfig:
       insecureSkipVerify: true
   - port: prometheus
@@ -25,6 +33,10 @@ spec:
         - queue_metrics
     interval: 15s
     scrapeTimeout: 14s
+    relabelings:
+    - sourceLabels:
+      - __meta_kubernetes_endpoints_label_app_kubernetes_io_name
+      targetLabel: rabbitmq_cluster
   - port: prometheus-tls
     scheme: https
     path: /metrics/detailed
@@ -34,10 +46,16 @@ spec:
         - queue_metrics
     interval: 15s
     scrapeTimeout: 14s
+    relabelings:
+    - sourceLabels:
+      - __meta_kubernetes_endpoints_label_app_kubernetes_io_name
+      targetLabel: rabbitmq_cluster
     tlsConfig:
       insecureSkipVerify: true
   selector:
     matchLabels:
       app.kubernetes.io/component: rabbitmq
+  targetLabels:
+    - app.kubernetes.io/name
   namespaceSelector:
     any: true


### PR DESCRIPTION
## Summary Of Changes

Currently grafana dashboards are always joining on `rabbitmq_identity_info` to be able to filter by cluster. This makes all queries barely readable, and have a performance cost. But we can order prometheus to provide `rabbitmq_cluster` label directly, greatly simplifying everything.

