### PR TITLE
Allow a default to be set for imagePullSecrets on operator scope

### DIFF
--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -74,14 +74,30 @@ var _ = Describe("RabbitmqClusterController", func() {
 				Expect(fetchedCluster.Spec.Image).To(Equal(defaultRabbitmqImage))
 			})
 
+			var sts *appsv1.StatefulSet
 			By("creating a statefulset with default configurations", func() {
-				sts := statefulSet(ctx, cluster)
+				sts = statefulSet(ctx, cluster)
 
 				Expect(sts.Name).To(Equal(cluster.ChildResourceName("server")))
-				Expect(sts.Spec.Template.Spec.ImagePullSecrets).To(BeEmpty())
 
 				Expect(len(sts.Spec.VolumeClaimTemplates)).To(Equal(1))
 				Expect(sts.Spec.VolumeClaimTemplates[0].Spec.StorageClassName).To(BeNil())
+			})
+
+			By("setting the default imagePullSecrets", func() {
+				Expect(sts.Spec.Template.Spec.ImagePullSecrets).To(ConsistOf(
+					[]corev1.LocalObjectReference{
+						{
+							Name: "image-secret-1",
+						},
+						{
+							Name: "image-secret-2",
+						},
+						{
+							Name: "image-secret-3",
+						},
+					},
+				))
 			})
 
 			By("creating the server conf configmap", func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -37,6 +37,7 @@ const (
 	controllerName          = "rabbitmqcluster-controller"
 	defaultRabbitmqImage    = "default-rabbit-image:stable"
 	defaultUserUpdaterImage = "default-UU-image:unstable"
+	defaultImagePullSecrets = "image-secret-1,image-secret-2,image-secret-3"
 )
 
 var (
@@ -94,6 +95,7 @@ var _ = BeforeSuite(func() {
 		PodExecutor:             fakeExecutor,
 		DefaultRabbitmqImage:    defaultRabbitmqImage,
 		DefaultUserUpdaterImage: defaultUserUpdaterImage,
+		DefaultImagePullSecrets: defaultImagePullSecrets,
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 		metricsAddr             string
 		defaultRabbitmqImage    = "rabbitmq:3.8.21-management"
 		defaultUserUpdaterImage = "rabbitmqoperator/default-user-credential-updater:1.0.0"
+		defaultImagePullSecrets = ""
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":9782", "The address the metric endpoint binds to.")
@@ -73,6 +74,10 @@ func main() {
 
 	if configuredDefaultUserUpdaterImage, ok := os.LookupEnv("DEFAULT_USER_UPDATER_IMAGE"); ok {
 		defaultUserUpdaterImage = configuredDefaultUserUpdaterImage
+	}
+
+	if configuredDefaultImagePullSecrets, ok := os.LookupEnv("DEFAULT_IMAGE_PULL_SECRETS"); ok {
+		defaultImagePullSecrets = configuredDefaultImagePullSecrets
 	}
 
 	options := ctrl.Options{
@@ -127,6 +132,7 @@ func main() {
 		PodExecutor:             controllers.NewPodExecutor(),
 		DefaultRabbitmqImage:    defaultRabbitmqImage,
 		DefaultUserUpdaterImage: defaultUserUpdaterImage,
+		DefaultImagePullSecrets: defaultImagePullSecrets,
 	}).SetupWithManager(mgr)
 	if err != nil {
 		log.Error(err, "unable to create controller", controllerName)


### PR DESCRIPTION
## Summary Of Changes

This change allows for the operator to set a configurable list of imagePullSecrets
as the default to use on all Pods created in RabbitmqClusters. If a RabbitmqClusterSpec
does not specify imagePullSecrets, the operator will use the value of the environment variable
`DEFAULT_IMAGE_PULL_SECRETS` if set to update the RabbitmqClusterSpec.

This closes #870

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Additional Context

This is a follow-on PR from #858

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
