### PR TITLE
Set podSecurityContext.fsGroup to 0 instead of 999

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -555,7 +555,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 				},
 			},
 			SecurityContext: &corev1.PodSecurityContext{
-				FSGroup:   &rabbitmqUID,
+				FSGroup:   pointer.Int64(0),
 				RunAsUser: &rabbitmqUID,
 			},
 			ImagePullSecrets:              builder.Instance.Spec.ImagePullSecrets,

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -1307,7 +1307,7 @@ default_pass = {{ .Data.data.password }}
 			rmqUID := int64(999)
 
 			expectedPodSecurityContext := &corev1.PodSecurityContext{
-				FSGroup:   &rmqUID,
+				FSGroup:   pointer.Int64(0),
 				RunAsUser: &rmqUID,
 			}
 


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Detailed context in issue: https://github.com/rabbitmq/opportunities/issues/156

Openshift expects containers to be able to run with arbitrary user ids. Their recommendation is for all files that processes need to access during runtime, give permission to the root group and the Openshift random users are all from the root group.

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
