### PR TITLE
Document lack of 1.18 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.8.21` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.18` or newer.
+The operator deploys RabbitMQ `3.8.21` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.19` or newer.
 
 ## Versioning
 


### PR DESCRIPTION
This closes #930 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
Kubernetes 1.18 is no longer supported by the operator, as of v1.11.0. This is due to the feature gate `ServiceAppProtocol` being disabled by default in 1.18; the feature is needed by the RabbitmqCluster service.

Note: I also edited the v1.11.0 release notes to document the drop of support.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
