### PR TITLE
fix: don't set empty image pull secrets

### DIFF
--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -131,8 +131,12 @@ func (r *RabbitmqClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	if rabbitmqCluster.Spec.ImagePullSecrets == nil {
+		// split the comma separated list of default image pull secrets from
+		// the 'DEFAULT_IMAGE_PULL_SECRETS' env var, but ignore empty strings.
 		for _, reference := range strings.Split(r.DefaultImagePullSecrets, ",") {
-			rabbitmqCluster.Spec.ImagePullSecrets = append(rabbitmqCluster.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: reference})
+			if len(reference) > 0 {
+				rabbitmqCluster.Spec.ImagePullSecrets = append(rabbitmqCluster.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: reference})
+			}
 		}
 		if err = r.Update(ctx, rabbitmqCluster); err != nil {
 			if k8serrors.IsConflict(err) {


### PR DESCRIPTION
## Summary Of Changes
commit "5f98b43" added the ability to set image pull secrets from the
DEFAULT_IMAGE_PULL_SECRETS env var. 
https://github.com/rabbitmq/cluster-operator/commit/5f98b4304fbee6153cbf6b4f9ccb9255993f08de

In the case where the `DEFAULT_IMAGE_PULL_SECRETS` env var is unset, `DefaultImagePullSecrets` will be `""`, and `strings.Split(r.DefaultImagePullSecrets, ",")` will return an array of length one containing an empty string and an image pull secret will be created with an empty string. This commit adds check to the output of `strings.Split()` to ensure we don't set an empty strings.

When this empty string is saved and parsed by k8s, resulting operations get this error:
```
$ kubectl rollout restart statefulset/rabbitmq-cluster-server
error: statefulsets.apps "rabbitmq-cluster-server" map: map[] does not contain declared merge key: name
```

you can also see the problem here:
```
$ kubectl get statefulset/rabbitmq-cluster-server -o json | grep -i imagepullsecret -A2
                "imagePullSecrets": [
                    {}
                ],
```

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
