### PR TITLE
Helper overlay to patch the Operator image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,12 @@ deploy-kind: check-env-docker-repo git-commit-sha manifests deploy-namespace-rba
 	kustomize build config/crd | kubectl apply -f -
 	kustomize build config/default/overlays/kind | sed 's@((operator_docker_image))@"$(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT)"@' | kubectl apply -f -
 
+QUAY_IO_OPERATOR_IMAGE ?= quay.io/rabbitmqoperator/cluster-operator:latest
 # Builds a single-file installation manifest to deploy the Operator
 generate-installation-manifest:
 	mkdir -p releases
 	kustomize build config/installation/ > releases/rabbitmq-cluster-operator.yaml
+	ytt -f releases/rabbitmq-cluster-operator.yaml -f config/ytt/overlay-manager-image.yaml --data-value operator_image=$(QUAY_IO_OPERATOR_IMAGE) > releases/rabbitmq-cluster-operator-quay-io.yaml
 
 # Build the docker image
 docker-build: check-env-docker-repo git-commit-sha

--- a/config/ytt/overlay-manager-image.yaml
+++ b/config/ytt/overlay-manager-image.yaml
@@ -1,7 +1,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 
-#@overlay/match by=overlay.subset({"kind": "Deployment"}), expects="1+"
+#@overlay/match by=overlay.subset({"kind": "Deployment", "metadata":{"name": "rabbitmq-cluster-operator"}}), expects="1+"
 ---
 spec:
   template:

--- a/config/ytt/overlay-manager-image.yaml
+++ b/config/ytt/overlay-manager-image.yaml
@@ -1,0 +1,13 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind": "Deployment"}), expects="1+"
+---
+spec:
+  template:
+    spec:
+      containers:
+        #@overlay/match by="name", expects="1+"
+        - name: operator
+          image: #@ data.values.operator_image
+


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
This will be used in the pipeline to publish to additional registries.

## Additional Context
Related [#869]

## Local Testing

Make sure you have `ytt` installed, then run:

```bash
kustomize build config/installation/ | ytt -f- -f config/ytt/overlay-manager-image.yaml \
  --data-value operator_image=quay.io/bunny:latest
```

Observe the image of the Operator Deployment is set to `quay.io/bunny:latest`.

Edit: tag correct issue 🙈 