### PR TITLE
Bump vault chart version to fix CI

### DIFF
--- a/docs/examples/vault-default-user/setup.sh
+++ b/docs/examples/vault-default-user/setup.sh
@@ -14,7 +14,7 @@ helm repo update
 # For OpenShift deployments, also set the following:
 # --set "global.openshift=true"
 helm install vault hashicorp/vault \
-    --version 0.16.1 \
+    --version 0.19.0 \
     --set='server.dev.enabled=true' \
     --set='server.logLevel=debug' \
     --set='injector.logLevel=debug' \


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
The older chart is not compatible with K8s 1.21, which is used in our system tests. Tested on the CI cluster and it works now.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
