### PR TITLE
Fix multiple disks documented example test

### DIFF
--- a/docs/examples/multiple-disks/test.sh
+++ b/docs/examples/multiple-disks/test.sh
@@ -4,5 +4,5 @@ set -ex
 kubectl exec -t multiple-disks-server-0 -c rabbitmq -- rabbitmqctl environment > rabbitmq-environment.out
 
 grep 'data_dir,"/var/lib/rabbitmq/quorum-segments"' rabbitmq-environment.out
-grep "{wal_data_dir,'/var/lib/rabbitmq/quorum-wal'}" rabbitmq-environment.out
+grep 'wal_data_dir,"/var/lib/rabbitmq/quorum-wal"' rabbitmq-environment.out
 


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Additional Context
The 'grep' command in the test had incorrectly escaped quote characters.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
