### PR TITLE
Update default user updater image to latest patch

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 	var (
 		metricsAddr             string
 		defaultRabbitmqImage    = "rabbitmq:3.9.13-management"
-		defaultUserUpdaterImage = "rabbitmqoperator/default-user-credential-updater:1.0.0"
+		defaultUserUpdaterImage = "rabbitmqoperator/default-user-credential-updater:1.0.2"
 		defaultImagePullSecrets = ""
 	)
 


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Bump user default updater image to latest patch.

## Additional Context

The latest user updater image is built with Golang 1.17.7 and latest dependency bumps.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

