### PR TITLE
Update kubectl-bats tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,6 +99,4 @@ jobs:
         export PATH=$PATH:$GOPATH/bin
         make install-tools
         kind create cluster --image kindest/node:"$K8S_VERSION"
-        DOCKER_REGISTRY_SERVER=local-server OPERATOR_IMAGE=local-operator make deploy-kind
-        PATH=$PATH:$(pwd)/bin
-        kubectl-rabbitmq.bats
+        DOCKER_REGISTRY_SERVER=local-server OPERATOR_IMAGE=local-operator make deploy-kind kubectl-plugin-tests

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ system-tests: install-tools ## Run end-to-end tests against Kubernetes cluster d
 
 kubectl-plugin-tests: ## Run kubectl-rabbitmq tests
 	echo "running kubectl plugin tests"
-	./bin/kubectl-rabbitmq.bats
+	PATH=$(PWD)/bin:$$PATH ./bin/kubectl-rabbitmq.bats
 
 tests: unit-tests integration-tests system-tests kubectl-plugin-tests
 

--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -226,7 +226,7 @@ manage() {
 }
 
 list_rabbitmq_clusters() {
-    kubectl get ${NAMESPACE} rabbitmqclusters
+    kubectl get ${NAMESPACE} rabbitmqclusters --sort-by='{.metadata.name}'
 }
 
 create() {

--- a/bin/kubectl-rabbitmq.bats
+++ b/bin/kubectl-rabbitmq.bats
@@ -177,7 +177,7 @@ eventually() {
   kubectl rabbitmq debug bats-default
 
   # '[debug] <pid> Lager installed handler' is logged even without enabling debug logging
-  eventually "kubectl logs bats-default-server-0 | grep -v ' \[debug\] .* Lager installed handler ' | grep ' \[debug\] '" 30
+  eventually "kubectl logs bats-default-server-0 | grep -v ' \[dbug\] .* Lager installed handler ' | grep ' \[dbug\] '" 30
 }
 
 @test "delete deletes RabbitMQ cluster" {


### PR DESCRIPTION

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
The test to set debug logs was broken since the default image became
3.9.x because this commit: https://github.com/rabbitmq/rabbitmq-server/commit/cdcf602749a34674d9eb285df1e31fe9c4aebb89
changed the debug log prefix from `debug` to `dbug`.

There's a small tweak to the make target that runs the kubectl bats
tests locally to include the repo's bin first in the path. This is
important because the version installed by krew will take precedence.

The above also allows us to simplify slightly the PR workflow file and
run everything using `make`.

## Local Testing

```
kind create cluster
kubectl rabbitmq install-cluster-operator
make kubectl-plugin-tests
```

