### PR TITLE
Bump kube-prometheus stack to 31.0.2

### DIFF
--- a/observability/quickstart.sh
+++ b/observability/quickstart.sh
@@ -14,7 +14,7 @@ NO_COLOR='\033[0m'
 
 printf "%bInstalling kube-prometheus-stack...%b\n" "$GREEN" "$NO_COLOR"
 # helm search repo prometheus-community/kube-prometheus-stack
-KUBE_PROMETHEUS_STACK_VERSION='15.2.1'
+KUBE_PROMETHEUS_STACK_VERSION='31.0.2'
 KUBE_PROMETHEUS_STACK_NAME='prom'
 KUBE_PROMETHEUS_STACK_NAMESPACE='kube-prometheus'
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Bump the version of the kube-prometheus helm chart to be compatible with recent Kubernetes versions, when deployed with the quickstart script.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
