### PR TITLE
Ensure consistent log formats

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"k8s.io/klog/v2"
 	"os"
 	"strconv"
 	"time"
@@ -57,7 +58,10 @@ func main() {
 
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	logger := zap.New(zap.UseFlagOptions(&opts))
+	ctrl.SetLogger(logger)
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/1420#issuecomment-794525248
+	klog.SetLogger(logger.WithName("rabbitmq-cluster-operator"))
 
 	operatorNamespace := os.Getenv("OPERATOR_NAMESPACE")
 	if operatorNamespace == "" {


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
Set the LogSink for the klog logger used by client-go to the same as the controller-runtime zap logger

## Additional Context
See https://github.com/rabbitmq/messaging-topology-operator/issues/295#issuecomment-1060631658
