### PR TITLE
Add rmq cluster to 'rabbitmq' category

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -25,7 +25,7 @@ import (
 // +kubebuilder:printcolumn:name="AllReplicasReady",type="string",JSONPath=".status.conditions[?(@.type == 'AllReplicasReady')].status"
 // +kubebuilder:printcolumn:name="ReconcileSuccess",type="string",JSONPath=".status.conditions[?(@.type == 'ReconcileSuccess')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:shortName={"rmq"},categories=all
+// +kubebuilder:resource:shortName={"rmq"},categories=all;rabbitmq
 // RabbitmqCluster is the Schema for the RabbitmqCluster API. Each instance of this object
 // corresponds to a single RabbitMQ cluster.
 type RabbitmqCluster struct {

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -10,7 +10,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: rabbitmqclusters.rabbitmq.com
 spec:
@@ -18,6 +18,7 @@ spec:
   names:
     categories:
       - all
+      - rabbitmq
     kind: RabbitmqCluster
     listKind: RabbitmqClusterList
     plural: rabbitmqclusters

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,7 +6,6 @@
 #
 # This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
 
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

For convenience, this adds `rabbitmqclusters` crd to category `rabbitmq` (PR that does the same to all topology CRDs: ). 

So When you do `kubectl get rabbitmq`, you see:
```
❯ k get rabbitmq
NAME                            AGE
queue.rabbitmq.com/qq-example   8m26s

NAME                                  ALLREPLICASREADY   RECONCILESUCCESS   AGE
rabbitmqcluster.rabbitmq.com/sample   True               True               13m

NAME                            AGE
user.rabbitmq.com/user-sample   5m10s

... and all other rabbitmq resouces
```

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
