### PR TITLE
change way to get client config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,12 +77,12 @@ destroy: ## Cleanup all controller artefacts
 run: generate manifests fmt vet install deploy-namespace-rbac just-run ## Run operator binary locally against the configured Kubernetes cluster in ~/.kube/config
 
 just-run: ## Just runs 'go run main.go' without regenerating any manifests or deploying RBACs
-	KUBE_CONFIG=${HOME}/.kube/config OPERATOR_NAMESPACE=rabbitmq-system go run ./main.go -metrics-bind-address 127.0.0.1:9782 --zap-devel $(OPERATOR_ARGS)
+	KUBECONFIG=${HOME}/.kube/config OPERATOR_NAMESPACE=rabbitmq-system go run ./main.go -metrics-bind-address 127.0.0.1:9782 --zap-devel $(OPERATOR_ARGS)
 
 delve: generate install deploy-namespace-rbac just-delve ## Deploys CRD, Namespace, RBACs and starts Delve debugger
 
 just-delve: install-tools ## Just starts Delve debugger
-	KUBE_CONFIG=${HOME}/.kube/config OPERATOR_NAMESPACE=rabbitmq-system dlv debug
+	KUBECONFIG=${HOME}/.kube/config OPERATOR_NAMESPACE=rabbitmq-system dlv debug
 
 # Install CRDs into a cluster
 install: manifests

--- a/main.go
+++ b/main.go
@@ -13,16 +13,14 @@ import (
 	"fmt"
 	"k8s.io/klog/v2"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"strconv"
 	"time"
-
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/controllers"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -114,17 +112,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	var clusterConfig *rest.Config
-	if kubeConfigPath := os.Getenv("KUBE_CONFIG"); kubeConfigPath != "" {
-		clusterConfig, err = clientcmd.BuildConfigFromFlags("", kubeConfigPath)
-	} else {
-		clusterConfig, err = rest.InClusterConfig()
-	}
-
-	if err != nil {
-		log.Error(err, "unable to get kubernetes cluster config")
-		os.Exit(1)
-	}
+	clusterConfig := config.GetConfigOrDie()
 
 	err = (&controllers.RabbitmqClusterReconciler{
 		Client:                  mgr.GetClient(),


### PR DESCRIPTION
easy way to get client config

This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
