### PR TITLE
Update Ginkgo to V2

### DIFF
--- a/api/v1beta1/rabbitmqcluster_status_test.go
+++ b/api/v1beta1/rabbitmqcluster_status_test.go
@@ -1,7 +1,7 @@
 package v1beta1
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rabbitmq/cluster-operator/internal/status"
 	appsv1 "k8s.io/api/apps/v1"

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -9,7 +9,7 @@
 package v1beta1
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rabbitmq/cluster-operator/internal/status"
 	appsv1 "k8s.io/api/apps/v1"

--- a/api/v1beta1/suite_test.go
+++ b/api/v1beta1/suite_test.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -19,7 +19,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/controllers/reconcile_cli_test.go
+++ b/controllers/reconcile_cli_test.go
@@ -9,7 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 )

--- a/controllers/reconcile_finalizer_test.go
+++ b/controllers/reconcile_finalizer_test.go
@@ -3,7 +3,7 @@ package controllers_test
 import (
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/reconcile_no_persistence_test.go
+++ b/controllers/reconcile_no_persistence_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/status"

--- a/controllers/reconcile_persistence_test.go
+++ b/controllers/reconcile_persistence_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/status"

--- a/controllers/reconcile_rabbitmq_configurations_test.go
+++ b/controllers/reconcile_rabbitmq_configurations_test.go
@@ -4,8 +4,7 @@ import (
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/reconcile_scale_down_test.go
+++ b/controllers/reconcile_scale_down_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/status"

--- a/controllers/reconcile_status_test.go
+++ b/controllers/reconcile_status_test.go
@@ -6,7 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/reconcile_tls_test.go
+++ b/controllers/reconcile_tls_test.go
@@ -9,7 +9,7 @@ import (
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,7 +17,7 @@ import (
 
 	"k8s.io/client-go/util/retry"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/controllers"
@@ -81,7 +81,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-stomp/stomp v2.1.4+incompatible
 	github.com/michaelklishin/rabbit-hole/v2 v2.12.0
 	github.com/mikefarah/yq/v4 v4.24.5
-	github.com/onsi/ginkgo v1.16.5
+	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.19.0
 	github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210811090309-627299932bac
 	github.com/sclevine/yj v0.0.0-20200815061347-554173e71934
@@ -84,6 +84,7 @@ require (
 	github.com/google/certificate-transparency-go v1.1.2 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/trillian v1.4.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect
@@ -115,7 +116,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -185,7 +185,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.23.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -555,6 +555,7 @@ github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/rpmpack v0.0.0-20191226140753-aa36bfddb3a0/go.mod h1:RaTPr0KUf2K7fnZYLNDrr8rxAamWs3iNywJLtQ2AzBg=

--- a/internal/metadata/annotation_test.go
+++ b/internal/metadata/annotation_test.go
@@ -1,11 +1,9 @@
 package metadata_test
 
 import (
-	. "github.com/onsi/ginkgo/extensions/table"
-
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/rabbitmq/cluster-operator/internal/metadata"
+	internal_metadata "github.com/rabbitmq/cluster-operator/internal/metadata"
 )
 
 var _ = Describe("Annotation", func() {
@@ -18,7 +16,7 @@ var _ = Describe("Annotation", func() {
 
 	DescribeTable("Reconcile annotations",
 		func(expectedAnnotations map[string]string, existingAnnotations map[string]string, defaultAnnotations ...map[string]string) {
-			reconciledAnnotations := ReconcileAnnotations(existingAnnotations, defaultAnnotations...)
+			reconciledAnnotations := internal_metadata.ReconcileAnnotations(existingAnnotations, defaultAnnotations...)
 			Expect(reconciledAnnotations).To(Equal(expectedAnnotations))
 		},
 
@@ -57,7 +55,7 @@ var _ = Describe("Annotation", func() {
 
 	DescribeTable("Reconcile and filter annotations",
 		func(expectedAnnotations map[string]string, existingAnnotations map[string]string, defaultAnnotations ...map[string]string) {
-			reconciledAnnotations := ReconcileAndFilterAnnotations(existingAnnotations, defaultAnnotations...)
+			reconciledAnnotations := internal_metadata.ReconcileAndFilterAnnotations(existingAnnotations, defaultAnnotations...)
 			Expect(reconciledAnnotations).To(Equal(expectedAnnotations))
 		},
 

--- a/internal/metadata/metadata_suite_test.go
+++ b/internal/metadata/metadata_suite_test.go
@@ -12,7 +12,7 @@ package metadata_test
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -13,7 +13,7 @@ import (
 	"bytes"
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"

--- a/internal/resource/default_user_secret_test.go
+++ b/internal/resource/default_user_secret_test.go
@@ -11,7 +11,7 @@ package resource_test
 
 import (
 	b64 "encoding/base64"
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"

--- a/internal/resource/erlang_cookie_test.go
+++ b/internal/resource/erlang_cookie_test.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"

--- a/internal/resource/headless_service_test.go
+++ b/internal/resource/headless_service_test.go
@@ -10,7 +10,7 @@
 package resource_test
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"

--- a/internal/resource/rabbitmq_plugins_test.go
+++ b/internal/resource/rabbitmq_plugins_test.go
@@ -10,7 +10,7 @@
 package resource_test
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"

--- a/internal/resource/rabbitmq_resource_builder_test.go
+++ b/internal/resource/rabbitmq_resource_builder_test.go
@@ -10,7 +10,7 @@
 package resource_test
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"

--- a/internal/resource/resource_suite_test.go
+++ b/internal/resource/resource_suite_test.go
@@ -12,7 +12,7 @@ package resource_test
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/internal/resource/role_binding_test.go
+++ b/internal/resource/role_binding_test.go
@@ -10,7 +10,7 @@
 package resource_test
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"

--- a/internal/resource/role_test.go
+++ b/internal/resource/role_test.go
@@ -10,7 +10,7 @@
 package resource_test
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"

--- a/internal/resource/service_account_test.go
+++ b/internal/resource/service_account_test.go
@@ -10,7 +10,7 @@
 package resource_test
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -10,8 +10,7 @@
 package resource_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -10,8 +10,7 @@
 package resource_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"

--- a/internal/scaling/scaling_suite_test.go
+++ b/internal/scaling/scaling_suite_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"

--- a/internal/scaling/scaling_test.go
+++ b/internal/scaling/scaling_test.go
@@ -3,7 +3,7 @@ package scaling_test
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"

--- a/internal/status/all_replicas_ready_test.go
+++ b/internal/status/all_replicas_ready_test.go
@@ -12,7 +12,7 @@ package status_test
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqstatus "github.com/rabbitmq/cluster-operator/internal/status"
 	appsv1 "k8s.io/api/apps/v1"

--- a/internal/status/cluster_available_test.go
+++ b/internal/status/cluster_available_test.go
@@ -12,7 +12,7 @@ package status_test
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqstatus "github.com/rabbitmq/cluster-operator/internal/status"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/status/no_warnings_test.go
+++ b/internal/status/no_warnings_test.go
@@ -12,7 +12,7 @@ package status_test
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqstatus "github.com/rabbitmq/cluster-operator/internal/status"
 	appsv1 "k8s.io/api/apps/v1"

--- a/internal/status/reconcile_success_test.go
+++ b/internal/status/reconcile_success_test.go
@@ -1,7 +1,7 @@
 package status_test
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/status/status_suite_test.go
+++ b/internal/status/status_suite_test.go
@@ -12,7 +12,7 @@ package status_test
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1,7 +1,7 @@
 package status_test
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
@@ -309,7 +309,7 @@ CONSOLE_LOG=new`
 		})
 	})
 
-	Context("Persistence expansion", func() {
+	Context("Persistence expansion", Label("persistence_expansion"), func() {
 		var cluster *rabbitmqv1beta1.RabbitmqCluster
 
 		AfterEach(func() {

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -50,11 +51,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
@@ -76,7 +75,7 @@ func MustHaveEnv(name string) string {
 }
 
 func createClientSet() (*kubernetes.Clientset, error) {
-	config, err := createRestConfig()
+	config, err := controllerruntime.GetConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -87,23 +86,6 @@ func createClientSet() (*kubernetes.Clientset, error) {
 	}
 
 	return clientset, err
-}
-
-func createRestConfig() (*rest.Config, error) {
-	var config *rest.Config
-	var err error
-	var kubeconfig string
-
-	if len(os.Getenv("KUBECONFIG")) > 0 {
-		kubeconfig = os.Getenv("KUBECONFIG")
-	} else {
-		kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube/config")
-	}
-	config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		return nil, err
-	}
-	return config, nil
 }
 
 func kubectlExec(namespace, podname, containerName string, args ...string) ([]byte, error) {

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -5,7 +5,7 @@ package tools
 import (
 	_ "github.com/elastic/crd-ref-docs"
 	_ "github.com/mikefarah/yq/v4"
-	_ "github.com/onsi/ginkgo/ginkgo"
+	_ "github.com/onsi/ginkgo/v2/ginkgo"
 	_ "github.com/sclevine/yj"
 	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"


### PR DESCRIPTION
## Summary Of Changes

Two significant changes affected our code base:

1. The table DSL i.e. `DescribeTable` and `Entry` have been moved to
   top-level. It was not required to import `extensions/table` anymore
1. Changes to CLI flag arguments to randomise all specs

There was a function name conflict because our code base and Ginkgo
define the function `Label()`. Due to the dot-import, it caused a name
conflict. This was resolved by aliasing our module.

Disabled metrics in integration tests to avoid MacOS firewall popup
everytime we run integration tests. We do not observe or scrape metrics
in the integration tests at the moment. In the future, we could bind to
localhost if needed.

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Additional Context

Unit and integration tests are green.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
```

