### PR TITLE
Document `examples` namespace in examples and small refactors

### DIFF
--- a/controllers/reconcile_persistence.go
+++ b/controllers/reconcile_persistence.go
@@ -18,7 +18,7 @@ func (r *RabbitmqClusterReconciler) reconcilePVC(ctx context.Context, rmq *rabbi
 	err := scaling.NewPersistenceScaler(r.Clientset).Scale(ctx, *rmq, desiredCapacity)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to scale PVCs: %s", err.Error())
-		logger.Error(fmt.Errorf("Hit an error while scaling PVC capacity: %w", err), msg)
+		logger.Error(fmt.Errorf("hit an error while scaling PVC capacity: %w", err), msg)
 		r.Recorder.Event(rmq, corev1.EventTypeWarning, "FailedReconcilePersistence", msg)
 	}
 	return err

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -37,3 +37,12 @@ The test and setup scripts can assume that [Cert Manager](https://cert-manager.i
 There is also a cluster issuer to produce self-signed certificates, named `selfsigned-issuer`. It is also
 acceptable to create local `Issuer`s when needed.
 
+### Namespace
+
+Some examples in this folder default to namespace `examples`, which can be created by:
+
+```shell
+kubectl create ns examples
+```
+
+You can also replace the namespace with any existing namespace in your environment.

--- a/docs/examples/vault-default-user/README.md
+++ b/docs/examples/vault-default-user/README.md
@@ -26,7 +26,15 @@ This example requires:
 4. The RabbitMQ admin credentials were already written to Vault to path `spec.secretBackend.vault.defaultUserPath` with keys `username` and `password` (by some cluster-operator external mechanism. The cluster-operator will never write admin credentials to Vault).
 5. Role `spec.secretBackend.vault.role` is configured in Vault with a policy to read from `defaultUserPath`.
 
-Run script [setup.sh](./setup.sh) to get started with a Vault server in [dev mode](https://www.vaultproject.io/docs/concepts/dev-server) fullfilling above requirements. (This script is not production-ready. It is only meant to get you started experiencing end-to-end how RabbitMQ integrates with Vault.)
+Run script [setup.sh](./setup.sh) to get started with a Vault server in [dev mode](https://www.vaultproject.io/docs/concepts/dev-server) fulfilling above requirements.
+[setup.sh](./setup.sh) assumes you are using namespace `examples`, which can be created by:
+
+```shell
+kubectl create ns examples
+```
+
+If you want to deploy this example in a different existing namespace, you can set environment variable `RABBITMQ_NAMESPACE` when you run the script.
+(This script is not production-ready. It is only meant to get you started experiencing end-to-end how RabbitMQ integrates with Vault.)
 
 You can deploy this example like this:
 

--- a/internal/metadata/annotation_test.go
+++ b/internal/metadata/annotation_test.go
@@ -3,7 +3,7 @@ package metadata_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	internal_metadata "github.com/rabbitmq/cluster-operator/internal/metadata"
+	internalmetadata "github.com/rabbitmq/cluster-operator/internal/metadata"
 )
 
 var _ = Describe("Annotation", func() {
@@ -16,7 +16,7 @@ var _ = Describe("Annotation", func() {
 
 	DescribeTable("Reconcile annotations",
 		func(expectedAnnotations map[string]string, existingAnnotations map[string]string, defaultAnnotations ...map[string]string) {
-			reconciledAnnotations := internal_metadata.ReconcileAnnotations(existingAnnotations, defaultAnnotations...)
+			reconciledAnnotations := internalmetadata.ReconcileAnnotations(existingAnnotations, defaultAnnotations...)
 			Expect(reconciledAnnotations).To(Equal(expectedAnnotations))
 		},
 
@@ -55,7 +55,7 @@ var _ = Describe("Annotation", func() {
 
 	DescribeTable("Reconcile and filter annotations",
 		func(expectedAnnotations map[string]string, existingAnnotations map[string]string, defaultAnnotations ...map[string]string) {
-			reconciledAnnotations := internal_metadata.ReconcileAndFilterAnnotations(existingAnnotations, defaultAnnotations...)
+			reconciledAnnotations := internalmetadata.ReconcileAndFilterAnnotations(existingAnnotations, defaultAnnotations...)
 			Expect(reconciledAnnotations).To(Equal(expectedAnnotations))
 		},
 

--- a/internal/scaling/scaling.go
+++ b/internal/scaling/scaling.go
@@ -34,7 +34,7 @@ func (p PersistenceScaler) Scale(ctx context.Context, rmq rabbitmqv1beta1.Rabbit
 
 	existingCapacity, err := p.existingCapacity(ctx, rmq)
 	if client.IgnoreNotFound(err) != nil {
-		logErr := fmt.Errorf("Failed to determine existing STS capactiy: %w", err)
+		logErr := fmt.Errorf("failed to determine existing STS capactiy: %w", err)
 		logger.Error(logErr, "Could not read sts")
 		return logErr
 	}
@@ -65,7 +65,7 @@ func (p PersistenceScaler) Scale(ctx context.Context, rmq rabbitmqv1beta1.Rabbit
 	logger.Info("Scaling up PVCs", "RabbitmqCluster", rmq.Name, "pvcsToBeScaled", pvcsToBeScaled)
 
 	if err := p.deleteSts(ctx, rmq); err != nil {
-		logErr := fmt.Errorf("Failed to delete Statefulset from Kubernetes API: %w", err)
+		logErr := fmt.Errorf("failed to delete Statefulset from Kubernetes API: %w", err)
 		logger.Error(logErr, "Could not delete existing sts")
 		return logErr
 	}
@@ -82,7 +82,7 @@ func (p PersistenceScaler) getClusterPVCs(ctx context.Context, rmq rabbitmqv1bet
 	for i = 0; i < pointer.Int32Deref(rmq.Spec.Replicas, 1); i++ {
 		pvc, err := p.Client.CoreV1().PersistentVolumeClaims(rmq.Namespace).Get(ctx, rmq.PVCName(int(i)), metav1.GetOptions{})
 		if client.IgnoreNotFound(err) != nil {
-			logErr := fmt.Errorf("Failed to get PVC from Kubernetes API: %w", err)
+			logErr := fmt.Errorf("failed to get PVC from Kubernetes API: %w", err)
 			logger.Error(logErr, "Could not read existing PVC")
 			return nil, logErr
 		}
@@ -137,7 +137,7 @@ func (p PersistenceScaler) deleteSts(ctx context.Context, rmq rabbitmqv1beta1.Ra
 
 	sts, err := p.getSts(ctx, rmq)
 	if client.IgnoreNotFound(err) != nil {
-		logErr := fmt.Errorf("Failed to get statefulset from Kubernetes API: %w", err)
+		logErr := fmt.Errorf("failed to get statefulset from Kubernetes API: %w", err)
 		logger.Error(logErr, "Could not read existing statefulset")
 		return logErr
 	}
@@ -174,7 +174,7 @@ func (p PersistenceScaler) scaleUpPVCs(ctx context.Context, rmq rabbitmqv1beta1.
 		// To minimise any timing windows, retrieve the latest version of this PVC before updating
 		pvc, err := p.Client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		if err != nil {
-			logErr := fmt.Errorf("Failed to get PVC from Kubernetes API: %w", err)
+			logErr := fmt.Errorf("failed to get PVC from Kubernetes API: %w", err)
 			logger.Error(logErr, "Could not read existing PVC")
 			return logErr
 		}

--- a/internal/scaling/scaling_suite_test.go
+++ b/internal/scaling/scaling_suite_test.go
@@ -41,7 +41,7 @@ var (
 	ephemeralStorage  = k8sresource.MustParse("0")
 )
 
-func generatePVCTemplate(rmq rabbitmqv1beta1.RabbitmqCluster, size k8sresource.Quantity) corev1.PersistentVolumeClaim {
+func generatePVCTemplate(size k8sresource.Quantity) corev1.PersistentVolumeClaim {
 	return corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "persistence",

--- a/internal/scaling/scaling_suite_test.go
+++ b/internal/scaling/scaling_suite_test.go
@@ -201,7 +201,7 @@ func (matcher *UpdateActionMatcher) Match(actual interface{}) (bool, error) {
 	updatedObject := reflect.ValueOf(action.GetObject()).Elem()
 	objMeta, ok := updatedObject.FieldByName("ObjectMeta").Interface().(metav1.ObjectMeta)
 	if !ok {
-		return false, fmt.Errorf("Object of action was not an object with ObjectMeta")
+		return false, fmt.Errorf("object of action was not an object with ObjectMeta")
 	}
 
 	// Check the object's Name, Namespace, resource type and the verb of the action first. If this fails, there's

--- a/internal/scaling/scaling_test.go
+++ b/internal/scaling/scaling_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Scaling", func() {
 				Namespace: namespace,
 			},
 			Spec: appsv1.StatefulSetSpec{
-				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{generatePVCTemplate(rmq, tenG)},
+				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{generatePVCTemplate(tenG)},
 			},
 		}
 	})


### PR DESCRIPTION
This closes #1025 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

[Error string shouldn't be capitalized](https://github.com/rabbitmq/cluster-operator/commit/96b476249013beb0fc0be05721ed719aed70a986)
 
[Remove unused param from generatePVCTemplate](https://github.com/rabbitmq/cluster-operator/commit/89d90cc8d4438298745f2f6ecddbf75219202cfa)
 
[Document examples namespace in vault example and examples README](https://github.com/rabbitmq/cluster-operator/commit/8b3b56e05d87ccc451dc936980db423d5022fadd)

