### PR TITLE
Vault svc reference

### DIFF
--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -167,7 +167,7 @@ func (r *RabbitmqClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	if requeueAfter, err := r.updateStatus(ctx, rabbitmqCluster); err != nil || requeueAfter > 0 {
+	if requeueAfter, err := r.updateStatusConditions(ctx, rabbitmqCluster); err != nil || requeueAfter > 0 {
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
 
@@ -322,7 +322,7 @@ func (r *RabbitmqClusterReconciler) logAndRecordOperationResult(logger logr.Logg
 	}
 }
 
-func (r *RabbitmqClusterReconciler) updateStatus(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) (time.Duration, error) {
+func (r *RabbitmqClusterReconciler) updateStatusConditions(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) (time.Duration, error) {
 	logger := ctrl.LoggerFrom(ctx)
 	childResources, err := r.getChildResources(ctx, rmq)
 	if err != nil {

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -261,13 +261,8 @@ func (r *RabbitmqClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
 
-	if !rabbitmqCluster.VaultDefaultUserSecretEnabled() {
-		if err := r.setDefaultUserStatus(ctx, rabbitmqCluster); err != nil {
-			return ctrl.Result{}, err
-		}
-		if err := r.setBinding(ctx, rabbitmqCluster); err != nil {
-			return ctrl.Result{}, err
-		}
+	if err := r.reconcileStatus(ctx, rabbitmqCluster); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// By this point the StatefulSet may have finished deploying. Run any

--- a/controllers/reconcile_status.go
+++ b/controllers/reconcile_status.go
@@ -8,49 +8,44 @@ import (
 	"reflect"
 )
 
-func (r *RabbitmqClusterReconciler) setDefaultUserStatus(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) error {
-
-	defaultUserStatus := &rabbitmqv1beta1.RabbitmqClusterDefaultUser{}
-
-	serviceRef := &rabbitmqv1beta1.RabbitmqClusterServiceReference{
-		Name:      rmq.ChildResourceName(""),
-		Namespace: rmq.Namespace,
-	}
-	defaultUserStatus.ServiceReference = serviceRef
-
-	secretRef := &rabbitmqv1beta1.RabbitmqClusterSecretReference{
-		Name:      rmq.ChildResourceName(resource.DefaultUserSecretName),
-		Namespace: rmq.Namespace,
-		Keys: map[string]string{
-			"username": "username",
-			"password": "password",
-		},
-	}
-	defaultUserStatus.SecretReference = secretRef
-
-	if !reflect.DeepEqual(rmq.Status.DefaultUser, defaultUserStatus) {
-		rmq.Status.DefaultUser = defaultUserStatus
-		if err := r.Status().Update(ctx, rmq); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// Status.Binding exposes the default user secret which contains the binding
+// reconcileStatus sets status.defaultUser (secret and service reference) and status.binding.
+// when vault is used as secret backend for default user, no user secret object is created
+// therefore only status.defaultUser.serviceReference is set.
+// status.binding exposes the default user secret which contains the binding
 // information for this RabbitmqCluster.
 // Default user secret implements the service binding Provisioned Service
 // See: https://k8s-service-bindings.github.io/spec/#provisioned-service
-func (r *RabbitmqClusterReconciler) setBinding(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) error {
-	binding := &corev1.LocalObjectReference{
-		Name: rmq.ChildResourceName(resource.DefaultUserSecretName),
+func (r *RabbitmqClusterReconciler) reconcileStatus(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) error {
+	var binding *corev1.LocalObjectReference
+
+	defaultUserStatus := &rabbitmqv1beta1.RabbitmqClusterDefaultUser{
+		ServiceReference: &rabbitmqv1beta1.RabbitmqClusterServiceReference{
+			Name:      rmq.ChildResourceName(""),
+			Namespace: rmq.Namespace,
+		},
 	}
-	if !reflect.DeepEqual(rmq.Status.Binding, binding) {
+
+	if !rmq.VaultDefaultUserSecretEnabled() {
+		defaultUserStatus.SecretReference = &rabbitmqv1beta1.RabbitmqClusterSecretReference{
+			Name:      rmq.ChildResourceName(resource.DefaultUserSecretName),
+			Namespace: rmq.Namespace,
+			Keys: map[string]string{
+				"username": "username",
+				"password": "password",
+			},
+		}
+		binding = &corev1.LocalObjectReference{
+			Name: rmq.ChildResourceName(resource.DefaultUserSecretName),
+		}
+	}
+
+	if !reflect.DeepEqual(rmq.Status.DefaultUser, defaultUserStatus) || !reflect.DeepEqual(rmq.Status.Binding, binding) {
+		rmq.Status.DefaultUser = defaultUserStatus
 		rmq.Status.Binding = binding
 		if err := r.Status().Update(ctx, rmq); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/controllers/reconcile_status_test.go
+++ b/controllers/reconcile_status_test.go
@@ -4,6 +4,7 @@ import (
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/internal/resource"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -18,19 +19,25 @@ var _ = Describe("Reconcile status", func() {
 		defaultNamespace = "default"
 	)
 
-	BeforeEach(func() {
+	AfterEach(func() {
+		Expect(client.Delete(ctx, cluster)).To(Succeed())
+		Eventually(func() bool {
+			rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+			err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
+			return apierrors.IsNotFound(err)
+		}, 5).Should(BeTrue())
+	})
+
+	It("reconciles the custom resource status", func() {
 		cluster = &rabbitmqv1beta1.RabbitmqCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "rabbitmq-status",
 				Namespace: defaultNamespace,
 			},
 		}
-
 		Expect(client.Create(ctx, cluster)).To(Succeed())
 		waitForClusterCreation(ctx, cluster, client)
-	})
 
-	It("reconciles the custom resource status", func() {
 		By("setting the default-user secret details")
 		rmq := &rabbitmqv1beta1.RabbitmqCluster{}
 		secretRef := &rabbitmqv1beta1.RabbitmqClusterSecretReference{}
@@ -87,4 +94,56 @@ var _ = Describe("Reconcile status", func() {
 
 		Expect(binding.Name).To(Equal(rmq.ChildResourceName(resource.DefaultUserSecretName)))
 	})
+
+	When("secret backend vault is enabled", func() {
+		It("sets service reference status correctly", func() {
+			cluster = &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rabbitmq-vault-status",
+					Namespace: defaultNamespace,
+				},
+				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
+					SecretBackend: rabbitmqv1beta1.SecretBackend{
+						Vault: &rabbitmqv1beta1.VaultSpec{
+							Role:            "rabbit",
+							DefaultUserPath: "test-test",
+						},
+					},
+				},
+			}
+			Expect(client.Create(ctx, cluster)).To(Succeed())
+			waitForClusterCreation(ctx, cluster, client)
+
+			By("setting the service details")
+			rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+			serviceRef := &rabbitmqv1beta1.RabbitmqClusterServiceReference{}
+			Eventually(func() *rabbitmqv1beta1.RabbitmqClusterServiceReference {
+				err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
+				if err != nil {
+					return nil
+				}
+				if rmq.Status.DefaultUser != nil && rmq.Status.DefaultUser.ServiceReference != nil {
+					serviceRef = rmq.Status.DefaultUser.ServiceReference
+					return serviceRef
+				}
+				return nil
+			}, 5).ShouldNot(BeNil())
+
+			Expect(serviceRef.Name).To(Equal(rmq.ChildResourceName("")))
+			Expect(serviceRef.Namespace).To(Equal(rmq.Namespace))
+
+			By("leaving status.binding and secret reference empty")
+			rmq = &rabbitmqv1beta1.RabbitmqCluster{}
+			Consistently(func() *corev1.LocalObjectReference {
+				Expect(client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)).To(Succeed())
+				return rmq.Status.Binding
+			}).Should(BeNil())
+
+			Consistently(func() *rabbitmqv1beta1.RabbitmqClusterSecretReference {
+				Expect(client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)).To(Succeed())
+				return rmq.Status.DefaultUser.SecretReference
+			}).Should(BeNil())
+		})
+	})
+
 })


### PR DESCRIPTION
This closes #1030

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Set status.defaultUser.serviceReference when vault default user is used; this is because downstream, topology operator
in this case, may rely on the rabbitmqcluster.status for certain information. topology operator relies on the service
reference to get the name of the ingress service to be able to connect to a given rabbitmqcluster
- Small refactor to move logic that updates status.defaultUser and status.binding into one function so it's cleaner in Reconcile()
- Rename updateStatus() to updateStatusConditions(); the function updates statusConditions instead
of the entire object status

## Additional Context

Status tested in integration test.

## Local Testing
