### PR TITLE
Bump default RabbitMQ image to v3.10.1

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,8 +53,8 @@ jobs:
         - v1.21.1
         rabbitmq-image:
         - rabbitmq:3.8.8-management
-        - rabbitmq:3.8-management
         - rabbitmq:3.9-management
+        - rabbitmq:3.10-management
         - pivotalrabbitmq/rabbitmq:master-otp-min
         - pivotalrabbitmq/rabbitmq:master-otp-max
     steps:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.9.13` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.19` or newer.
+The operator deploys RabbitMQ `3.10.1` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.19` or newer.
 
 ## Versioning
 

--- a/bin/kubectl-rabbitmq.bats
+++ b/bin/kubectl-rabbitmq.bats
@@ -176,8 +176,7 @@ eventually() {
 @test "debug sets log level to debug" {
   kubectl rabbitmq debug bats-default
 
-  # '[debug] <pid> Lager installed handler' is logged even without enabling debug logging
-  eventually "kubectl logs bats-default-server-0 | grep -v ' \[dbug\] .* Lager installed handler ' | grep ' \[dbug\] '" 30
+  eventually "kubectl logs -c rabbitmq bats-default-server-0 | grep ' \[debug\] '" 30
 }
 
 @test "delete deletes RabbitMQ cluster" {

--- a/main.go
+++ b/main.go
@@ -11,11 +11,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"k8s.io/klog/v2"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"strconv"
 	"time"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/controllers"
@@ -44,7 +45,7 @@ func init() {
 func main() {
 	var (
 		metricsAddr             string
-		defaultRabbitmqImage    = "rabbitmq:3.9.13-management"
+		defaultRabbitmqImage    = "rabbitmq:3.10.1-management"
 		defaultUserUpdaterImage = "rabbitmqoperator/default-user-credential-updater:1.0.2"
 		defaultImagePullSecrets = ""
 	)


### PR DESCRIPTION
Note that the default format of how the log level is printed changed from Docker image 3.9.13 (default image before this PR) to 3.9.14 due to the changes in https://github.com/docker-library/rabbitmq/commit/3e8f0f18ac6a823f2a95d92e67ca88fd95186386

3.9.13:
```
2022-05-11 22:08:22.370896+00:00 [warn] <0.644.0> Message store "628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent": rebuilding indices from scratch
```

3.9.14:
```
2022-05-11 22:09:26.666086+00:00 [warning] <0.644.0> Message store "628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent": rebuilding indices from scratch
```