### PR TITLE
Document how to set up tls verify for prometheus servicemonitor

### DIFF
--- a/observability/prometheus/monitors/README.md
+++ b/observability/prometheus/monitors/README.md
@@ -25,7 +25,7 @@ metadata:
 
 Given the `matchLabels` fields from the Prometheus spec above, you would need to add the label `release: my-prometheus` to the `PodMonitor` and `ServiceMonitor` objects.
 
-File [rabbitmq-servicemonitor.yml](./rabbitmq-servicemonitor.yml) contains scrape targets for RabbitMQ.
+File [rabbitmq-servicemonitor.yml](./rabbitmq-servicemonitor.yml) contains scrape targets for RabbitMQ. TLS verify will be skipped by default. To enable TLS verification for scraping, set `spec.endpoints[port=prometheus-tls].tlsConfig.insecureSkipVerify` to false and provide a Kubernetes Secret containing CA cert used for Prometheus.
 Metrics listed in [RabbitMQ metrics](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_prometheus/metrics.md) will be scraped from all RabbitMQ nodes.
 Note that the ServiceMonitor object works only for RabbitMQ clusters deployed by [cluster-operator](https://github.com/rabbitmq/cluster-operator) `>v1.6.0`. If you run cluster-operator `<=v1.6.0` use a PodMonitor instead:
 

--- a/observability/prometheus/monitors/rabbitmq-servicemonitor.yml
+++ b/observability/prometheus/monitors/rabbitmq-servicemonitor.yml
@@ -15,7 +15,12 @@ spec:
     interval: 15s
     scrapeTimeout: 14s
     tlsConfig:
-      insecureSkipVerify: true
+      insecureSkipVerify: true # set to false and uncomment lines below to enable tls verification
+        # ca:
+        #   secret:
+        #     key: ca.crt
+        #     name: tls-secret # name of the secret containing the CA cert which signed the RabbitMQ Prometheus TLS cert
+        # serverName: '*.RABBITMQ-INSTANCE-NAME.NAMESPACE.svc.cluster.local'
   - port: prometheus
     scheme: http
     path: /metrics/detailed


### PR DESCRIPTION
This closes #1007 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Instead of adding a new example yaml, the tls section is added as comment section since the rest of the configuration is the same.