### PR TITLE
This PR override pod security context in system tests in case we are …

### DIFF
--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -23,10 +23,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 	"strconv"
 	"strings"
 	"time"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
 
 	"gopkg.in/ini.v1"
 
@@ -416,6 +417,10 @@ func newRabbitmqCluster(namespace, instanceName string) *rabbitmqv1beta1.Rabbitm
 		},
 	}
 
+	if os.Getenv("ENVIRONMENT") == "openshift" {
+		overrideSecurityContextForOpenshift(cluster)
+	}
+
 	if image := os.Getenv("RABBITMQ_IMAGE"); image != "" {
 		cluster.Spec.Image = image
 	}
@@ -426,6 +431,27 @@ func newRabbitmqCluster(namespace, instanceName string) *rabbitmqv1beta1.Rabbitm
 	}
 
 	return cluster
+}
+
+func overrideSecurityContextForOpenshift(cluster *rabbitmqv1beta1.RabbitmqCluster) {
+
+	cluster.Spec.Override = rabbitmqv1beta1.RabbitmqClusterOverrideSpec{
+		StatefulSet: &rabbitmqv1beta1.StatefulSet{
+			Spec: &rabbitmqv1beta1.StatefulSetSpec{
+				Template: &rabbitmqv1beta1.PodTemplateSpec{
+					Spec: &corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{},
+						Containers: []corev1.Container{
+							{
+								Name: "rabbitmq",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
 }
 
 //the updateFn can change properties of the RabbitmqCluster CR


### PR DESCRIPTION
…running on an openshift environment.

This is due in order to create a pipeline to run our system tests on openshift

This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
