### PR TITLE
remove prom scrape annotation

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -326,16 +326,8 @@ func sortVolumeMounts(mounts []corev1.VolumeMount) {
 }
 
 func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[string]string) corev1.PodTemplateSpec {
-	// default pod annotations used for prometheus metrics
-	prometheusPort := "15692"
-	if builder.Instance.TLSEnabled() {
-		prometheusPort = "15691"
-	}
-
-	defaultPodAnnotations := map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   prometheusPort,
-	}
+	// default pod annotations
+	defaultPodAnnotations := make(map[string]string, 0)
 
 	if builder.Instance.VaultEnabled() {
 		defaultPodAnnotations = appendVaultAnnotations(defaultPodAnnotations, builder.Instance)

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -405,9 +405,6 @@ var _ = Describe("StatefulSet", func() {
 
 				It("Adds the default annotations to the pod template", func() {
 					Expect(stsBuilder.Update(statefulSet)).To(Succeed())
-
-					Expect(statefulSet.Spec.Template.Annotations).To(HaveKeyWithValue("prometheus.io/scrape", "true"))
-					Expect(statefulSet.Spec.Template.Annotations).To(HaveKeyWithValue("prometheus.io/port", "15692"))
 				})
 			})
 
@@ -415,10 +412,7 @@ var _ = Describe("StatefulSet", func() {
 				It("updates Prometheus port", func() {
 					stsBuilder.Instance.Spec.TLS.SecretName = "tls-secret"
 					Expect(stsBuilder.Update(statefulSet)).To(Succeed())
-					expectedPodAnnotations := map[string]string{
-						"prometheus.io/scrape": "true",
-						"prometheus.io/port":   "15691",
-					}
+					expectedPodAnnotations := make(map[string]string, 0)
 					Expect(statefulSet.Spec.Template.Annotations).To(Equal(expectedPodAnnotations))
 				})
 			})
@@ -1850,9 +1844,7 @@ default_pass = {{ .Data.data.password }}
 						"app.kubernetes.io/name":      "foo",
 					}))
 					Expect(statefulSet.Spec.Template.ObjectMeta.Annotations).To(Equal(map[string]string{
-						"my-key":               "my-value",
-						"prometheus.io/scrape": "true",
-						"prometheus.io/port":   "15692",
+						"my-key": "my-value",
 					}))
 				})
 


### PR DESCRIPTION
This closes #1049 

## Summary Of Changes

Remove legacy prometheus scrape annotations of statefulset / pod

## Local Testing

All tests have passed successfully. 

```
$  make unit-tests integration-tests
go mod download
grep _ tools/tools.go | awk -F '"' '{print $2}' | xargs -t go install
go install github.com/elastic/crd-ref-docs github.com/mikefarah/yq/v4 github.com/onsi/ginkgo/v2/ginkgo github.com/sclevine/yj sigs.k8s.io/controller-runtime/tools/setup-envtest sigs.k8s.io/controller-tools/cmd/controller-gen sigs.k8s.io/kind sigs.k8s.io/kustomize/kustomize/v4
crd-ref-docs \
                --source-path ./api/v1beta1 \
                --config ./docs/api/autogen/config.yaml \
                --templates-dir ./docs/api/autogen/templates \
                --output-path ./docs/api/rabbitmq.com.ref.asciidoc \
                --max-depth 30
2022-06-01T11:08:10.068+0200    INFO    crd-ref-docs    Loading configuration   {"path": "./docs/api/autogen/config.yaml"}
2022-06-01T11:08:10.069+0200    INFO    crd-ref-docs    Processing source directory     {"directory": "./api/v1beta1", "depth": 30}
2022-06-01T11:08:10.778+0200    WARN    crd-ref-docs    Failed to find type     {"name": "Quantity", "package": "k8s.io/apimachinery/pkg/api/resource"}
2022-06-01T11:08:10.779+0200    WARN    crd-ref-docs    Failed to find type     {"name": "IntOrString", "package": "k8s.io/apimachinery/pkg/util/intstr"}
2022-06-01T11:08:10.784+0200    INFO    crd-ref-docs    Rendering output        {"path": "./docs/api/rabbitmq.com.ref.asciidoc"}
2022-06-01T11:08:10.799+0200    INFO    crd-ref-docs    CRD reference documentation generated
2022-06-01T11:08:10.799+0200    INFO    crd-ref-docs    Execution time: 730.012479ms
controller-gen object:headerFile=./hack/NOTICE.go.txt paths=./api/...
controller-gen object:headerFile=./hack/NOTICE.go.txt paths=./internal/status/...
go fmt ./...
go vet ./...
controller-gen crd rbac:roleName=operator-role paths="./api/...;./controllers/..." output:crd:artifacts:config=config/crd/bases
./hack/remove-override-descriptions.sh
./hack/add-notice-to-yaml.sh config/rbac/role.yaml
./hack/add-notice-to-yaml.sh config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
ginkgo -r --randomize-all api/ internal/
[1654074498] v1beta1 Suite - 26/26 specs •••••••••••••••••••••••••• SUCCESS! 8.542292731s PASS
[1654074498] Metadata Suite - 6/6 specs •••••• SUCCESS! 442.097µs PASS
[1654074498] Resource Suite - 221/221 specs ••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 240.71162ms PASS
[1654074498] Scaling Suite - 9/9 specs ••••••••• SUCCESS! 1.225194ms PASS
[1654074498] Status Suite - 49/49 specs ••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 3.384262ms PASS

Ginkgo ran 5 suites in 14.952961218s
Test Suite Passed
ginkgo -r controllers/
Running Suite: Controller Suite - /Users/kilianries/git/github/cluster-operator/controllers
===========================================================================================
Random Seed: 1654074513

Will run 51 of 51 specs
•••
------------------------------
• [SLOW TEST] [12.021 seconds]
Reconcile CLI when the cluster is not configured to run post-deploy steps when the cluster is updated does not trigger the controller to run rabbitmq-queues rebalance all
/Users/kilianries/git/github/cluster-operator/controllers/reconcile_cli_test.go:171
------------------------------
• [SLOW TEST] [12.020 seconds]
Reconcile CLI when the cluster is a single node cluster when the cluster is updated does not trigger the controller to run rabbitmq-queues rebalance all
/Users/kilianries/git/github/cluster-operator/controllers/reconcile_cli_test.go:230
------------------------------
• [SLOW TEST] [11.026 seconds]
Persistence does not allow changing the capcity from zero (no persistence)
/Users/kilianries/git/github/cluster-operator/controllers/reconcile_no_persistence_test.go:54
------------------------------
• [SLOW TEST] [11.026 seconds]
Cluster scale down does not allow cluster scale down
/Users/kilianries/git/github/cluster-operator/controllers/reconcile_scale_down_test.go:34
------------------------------
•••
------------------------------
• [SLOW TEST] [11.026 seconds]
Persistence does not allow PVC shrink
/Users/kilianries/git/github/cluster-operator/controllers/reconcile_persistence_test.go:50
------------------------------
•••••••••••••••••••••••••••••••••••••••
------------------------------
• [SLOW TEST] [11.050 seconds]
RabbitmqClusterController Pause reconciliation works
/Users/kilianries/git/github/cluster-operator/controllers/rabbitmqcluster_controller_test.go:1171
------------------------------

Ran 51 of 51 Specs in 141.763 seconds
SUCCESS! -- 51 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 2m26.29906911s
Test Suite Passed
```

Regards,
Kilian
