### PR TITLE
Make GiB global

### DIFF
--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -56,6 +56,7 @@ prometheus.ssl.port      = 15691
 	tlsCertPath     = tlsCertDir + tlsCertFilename
 	tlsKeyFilename  = "tls.key"
 	tlsKeyPath      = tlsCertDir + tlsKeyFilename
+        GiB             = int64(1073741824)
 )
 
 type ServerConfigMapBuilder struct {
@@ -254,7 +255,6 @@ func updateProperty(configMapData map[string]string, key string, value string) {
 	}
 }
 
-const GiB int64 = 1073741824
 // The Erlang VM needs headroom above Rabbit to avoid being OOM killed
 // We set the headroom to be the smaller amount of 20% memory or 2GiB
 func removeHeadroom(memLimit int64) int64 {


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
It seems better.