### PR TITLE
Update PR workflow with latest k8s

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   GO_VERSION: 1.17.x
+  K8S_VERSION: v1.24.1
 
 jobs:
 
@@ -36,7 +37,7 @@ jobs:
         export GOPATH=$HOME/go
         export PATH=$PATH:$GOPATH/bin
         make install-tools
-        kind create cluster --image kindest/node:v1.21.1
+        kind create cluster --image kindest/node:"${{ env.K8S_VERSION }}"
         kubectl create --validate=false -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.crds.yaml
         # Create CRD PodMonitor without running Prometheus operator
         curl https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml | sed "s/replicas: 1$/replicas: 0/" | kubectl create -f -
@@ -50,7 +51,7 @@ jobs:
     strategy:
       matrix:
         k8s:
-        - v1.21.1
+        - ${{ env.K8S_VERSION }}
         rabbitmq-image:
         - rabbitmq:3.8.8-management
         - rabbitmq:3.9-management
@@ -92,8 +93,6 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: kubectl rabbitmq tests
-      env:
-        K8S_VERSION: v1.21.1
       run: |
         export GOPATH=$HOME/go
         export PATH=$PATH:$GOPATH/bin

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         k8s:
-        - ${{ env.K8S_VERSION }}
+        - v1.24.1
         rabbitmq-image:
         - rabbitmq:3.8.8-management
         - rabbitmq:3.9-management
@@ -97,5 +97,5 @@ jobs:
         export GOPATH=$HOME/go
         export PATH=$PATH:$GOPATH/bin
         make install-tools
-        kind create cluster --image kindest/node:"$K8S_VERSION"
+        kind create cluster --image kindest/node:"${{ env.K8S_VERSION }}"
         DOCKER_REGISTRY_SERVER=local-server OPERATOR_IMAGE=local-operator make deploy-kind kubectl-plugin-tests


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Update PR workflow to run on latest available Kubernetes version in KinD.

## Additional Context

Given that we support the latest k8s version since we merged #1044 and Kubernetes 1.21 is out of support since 1.24 became GA, we should update our workflow to test on a newer Kubernetes version.

Edit: 100% I will squash merge

## Local Testing

N/A change to GitHub Actions.