### PR TITLE
More reliable system tests

### DIFF
--- a/system_tests/system_tests_suite_test.go
+++ b/system_tests/system_tests_suite_test.go
@@ -11,17 +11,14 @@ package system_tests
 
 import (
 	"context"
-	"k8s.io/utils/pointer"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"testing"
 
-	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/client-go/kubernetes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
@@ -56,21 +53,7 @@ var _ = BeforeSuite(func() {
 
 	namespace = MustHaveEnv("NAMESPACE")
 
-	// Create or update the StorageClass used in persistence expansion test spec
-	storageClass := &storagev1.StorageClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: storageClassName,
-		},
-		Provisioner:          "kubernetes.io/gce-pd",
-		AllowVolumeExpansion: pointer.BoolPtr(true),
-	}
 	ctx := context.Background()
-	err = rmqClusterClient.Create(ctx, storageClass)
-	if apierrors.IsAlreadyExists(err) {
-		Expect(rmqClusterClient.Update(ctx, storageClass)).To(Succeed())
-	} else {
-		Expect(err).NotTo(HaveOccurred())
-	}
 
 	Eventually(func() int32 {
 		operatorDeployment, err := clientSet.AppsV1().Deployments(namespace).Get(ctx, "rabbitmq-cluster-operator", metav1.GetOptions{})

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	storagev1 "k8s.io/api/storage/v1"
 	"log"
 	"net/http"
 	"os"
@@ -434,7 +435,6 @@ func newRabbitmqCluster(namespace, instanceName string) *rabbitmqv1beta1.Rabbitm
 }
 
 func overrideSecurityContextForOpenshift(cluster *rabbitmqv1beta1.RabbitmqCluster) {
-
 	cluster.Spec.Override = rabbitmqv1beta1.RabbitmqClusterOverrideSpec{
 		StatefulSet: &rabbitmqv1beta1.StatefulSet{
 			Spec: &rabbitmqv1beta1.StatefulSetSpec{
@@ -451,7 +451,6 @@ func overrideSecurityContextForOpenshift(cluster *rabbitmqv1beta1.RabbitmqCluste
 			},
 		},
 	}
-
 }
 
 //the updateFn can change properties of the RabbitmqCluster CR
@@ -1068,4 +1067,32 @@ func pod(ctx context.Context, clientSet *kubernetes.Clientset, r *rabbitmqv1beta
 		return err
 	}, 10).Should(Succeed())
 	return pod
+}
+
+func defaultStorageClass(ctx context.Context, clientSet *kubernetes.Clientset) *storagev1.StorageClass {
+	var storageClasses *storagev1.StorageClassList
+	defaultClassAnnotation := "storageclass.kubernetes.io/is-default-class"
+	var err error
+	storageClasses, err = clientSet.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(storageClasses.Items).NotTo(BeEmpty(), "expected at least 1 storageClass, but found 0")
+	for _, storageClass := range storageClasses.Items {
+		defaultClassAnnotationValue, ok := storageClass.ObjectMeta.Annotations[defaultClassAnnotation]
+		if !ok {
+			// StorageClass is not the default
+			continue
+		}
+		isDefaultClass, err := strconv.ParseBool(defaultClassAnnotationValue)
+		if err == nil && isDefaultClass {
+			return &storageClass
+		}
+	}
+	return nil
+}
+
+func volumeExpansionSupported(ctx context.Context, clientSet *kubernetes.Clientset) bool {
+	clusterDefaultStorageClass := defaultStorageClass(ctx, clientSet)
+	Expect(clusterDefaultStorageClass).NotTo(BeNil(), "expected to find a default storageClass, but failed to find one")
+	return clusterDefaultStorageClass.AllowVolumeExpansion != nil &&
+		*clusterDefaultStorageClass.AllowVolumeExpansion == true
 }


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Dynamically check for PVC expansion support in tests

## Additional Context

Previously, it was the responsibility of whoever was running the system tests to decide if PVC expansion was supported or not.
In addition, the tests created a storageClass with the gce-pd Provider, in order to ensure there was a storageClass available that supported expansion. This Provider is deprecated, and in modern gke versions supports expansion anyway, removing the need for a bespoke class.

This change now dynamically queries the k8s API for the default storage class, and checks if it supports expansion or not. If it does not, the expansion test is skipped as before (e.g. in kind). If it does, the test proceeds, using this default class.
This also means the tests should now be able to be run in non-GKE environments with storage drivers that support PVC expansion.

This should hopefully alleviate some race conditions we see in our CI where a storageClass is not yet available before a PVC is provisioned using that Class.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
