### PR TITLE
Add full URL entry to generated secret resource

### DIFF
--- a/internal/resource/default_user_secret.go
+++ b/internal/resource/default_user_secret.go
@@ -56,6 +56,8 @@ func (builder *DefaultUserSecretBuilder) Build() (client.Object, error) {
 		return nil, err
 	}
 
+	url := fmt.Sprintf("amqp://%s:%s@%s", username, password, builder.Instance.ServiceSubDomain())
+
 	// Default user secret implements the service binding Provisioned Service
 	// See: https://k8s-service-bindings.github.io/spec/#provisioned-service
 	secret := &corev1.Secret{
@@ -71,6 +73,7 @@ func (builder *DefaultUserSecretBuilder) Build() (client.Object, error) {
 			"provider":          []byte(bindingProvider),
 			"type":              []byte(bindingType),
 			"host":              []byte(builder.Instance.ServiceSubDomain()),
+			"url":               []byte(url),
 		},
 	}
 	builder.updatePorts(secret)

--- a/internal/resource/default_user_secret_test.go
+++ b/internal/resource/default_user_secret_test.go
@@ -108,8 +108,9 @@ var _ = Describe("DefaultUserSecret", func() {
 				usernameStr := string(username)
 				passStr := string(password)
 				hostStr := "a name.a namespace.svc"
+				portStr := string(port)
 				Expect(ok).To(BeTrue(), "Failed to find a key \"url\" in the generated Secret")
-				Expect(string(url)).To(BeEquivalentTo(fmt.Sprintf("amqp://%s:%s@%s", usernameStr, passStr, hostStr)))
+				Expect(string(url)).To(BeEquivalentTo(fmt.Sprintf("amqp://%s:%s@%s:%s", usernameStr, passStr, hostStr, portStr)))
 			})
 
 			By("creating a default_user.conf file that contains the correct sysctl config format to be parsed by RabbitMQ", func() {

--- a/internal/resource/default_user_secret_test.go
+++ b/internal/resource/default_user_secret_test.go
@@ -11,6 +11,8 @@ package resource_test
 
 import (
 	b64 "encoding/base64"
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
@@ -55,6 +57,7 @@ var _ = Describe("DefaultUserSecret", func() {
 			var password []byte
 			var host []byte
 			var port []byte
+			var url []byte
 			var ok bool
 
 			obj, err := defaultUserSecretBuilder.Build()
@@ -98,6 +101,15 @@ var _ = Describe("DefaultUserSecret", func() {
 				port, ok = secret.Data["port"]
 				Expect(ok).To(BeTrue(), "Failed to find a key \"port\" in the generated Secret")
 				Expect(port).To(BeEquivalentTo("5672"))
+			})
+
+			By("Checking if the full URL matches", func() {
+				url, ok = secret.Data["url"]
+				usernameStr := string(username)
+				passStr := string(password)
+				hostStr := "a name.a namespace.svc"
+				Expect(ok).To(BeTrue(), "Failed to find a key \"url\" in the generated Secret")
+				Expect(string(url)).To(BeEquivalentTo(fmt.Sprintf("amqp://%s:%s@%s", usernameStr, passStr, hostStr)))
 			})
 
 			By("creating a default_user.conf file that contains the correct sysctl config format to be parsed by RabbitMQ", func() {


### PR DESCRIPTION
This closes #1089 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
- added `url` entry to the generated secret resource (for example, `amqp://username:password@localhost:5672`)
- extended default user unit test to include the `url` field check

## Local Testing
Unit and integration tests pass
