### PR TITLE
Adding a workflow to create a PR to k8s-operatorhub/community-operators

### DIFF
--- a/.github/workflows/operatorhub.yml
+++ b/.github/workflows/operatorhub.yml
@@ -1,0 +1,57 @@
+name: operatorhub
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  release:
+    types: [published]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+
+  
+      # Initialize environment and install Carvel toolsuite
+      - uses: actions/checkout@v2
+      - name: Initialize
+        run: |
+          RELEASE_VERSION=${GITHUB_REF#refs/*/} 
+          echo "RELEASE_VERSION=${RELEASE_VERSION:1}" >> $GITHUB_ENV
+          git config --global user.name "DanielePalaia"
+          git config --global user.email "dpalaia@vmware.com"
+          wget -O- https://carvel.dev/install.sh > install.sh
+          sudo bash install.sh
+
+      # Generate the OLM Bundle
+      - name: GenerateOLMBundle
+        run: |
+          git clone https://github.com/rabbitmq/OLM-Package-Repo
+          wget https://github.com/rabbitmq/cluster-operator/releases/latest/download/cluster-operator.yml
+          cp ./cluster-operator.yml ./OLM-Package-Repo/generate_OLM/generate_OLM_cluster_operator/manifests_crds
+          cp ./config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml ./OLM-Package-Repo/generate_OLM/generate_OLM_cluster_operator/manifests_crds/crds.yaml
+          cd ./OLM-Package-Repo/generate_OLM/generate_OLM_cluster_operator/
+          python3 generate-olm-package.py ./manifests_crds/cluster-operator.yaml ${{ env.RELEASE_VERSION }} ./../../OLM2/rabbitmq-cluster-operator
+        
+      # Create the PR to OperatorHUB
+      - name: CreateOperatorHubPR
+        env:
+          TOKEN: ${{ secrets.OPERATORHUB_TOKEN }}
+        run: |
+          git clone https://github.com/rabbitmq/community-operators
+          mkdir -p community-operators/operators/rabbitmq-cluster-operator
+          cd community-operators/operators/rabbitmq-cluster-operator
+          git branch rabbitmq-${{ env.RELEASE_VERSION }}
+          git checkout rabbitmq-${{ env.RELEASE_VERSION }}
+          cp -fR /home/runner/work/cluster-operator/cluster-operator/OLM-Package-Repo/OLM2/rabbitmq-cluster-operator/${{ env.RELEASE_VERSION }} .
+          git add .
+          git commit -s -m "RabbitMQ operator new release"
+          git push https://DanielePalaia:"$TOKEN"@github.com/rabbitmq/community-operators


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
