### PR TITLE
Update crd after k8s api and controller-gen bump

### DIFF
--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -10,7 +10,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: rabbitmqclusters.rabbitmq.com
 spec:
@@ -110,6 +110,7 @@ spec:
                                       type: object
                                     type: array
                                 type: object
+                                x-kubernetes-map-type: atomic
                               weight:
                                 description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                 format: int32
@@ -170,10 +171,12 @@ spec:
                                       type: object
                                     type: array
                                 type: object
+                                x-kubernetes-map-type: atomic
                               type: array
                           required:
                             - nodeSelectorTerms
                           type: object
+                          x-kubernetes-map-type: atomic
                       type: object
                     podAffinity:
                       description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
@@ -216,6 +219,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                     properties:
@@ -246,6 +250,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
@@ -301,6 +306,7 @@ spec:
                                     description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               namespaceSelector:
                                 description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                 properties:
@@ -331,6 +337,7 @@ spec:
                                     description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               namespaces:
                                 description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                 items:
@@ -385,6 +392,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                     properties:
@@ -415,6 +423,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
@@ -470,6 +479,7 @@ spec:
                                     description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               namespaceSelector:
                                 description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                 properties:
@@ -500,6 +510,7 @@ spec:
                                     description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               namespaces:
                                 description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                 items:
@@ -526,6 +537,7 @@ spec:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 override:
                   properties:
@@ -675,6 +687,7 @@ spec:
                                     type: string
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             serviceName:
                               type: string
                             template:
@@ -741,6 +754,7 @@ spec:
                                                           type: object
                                                         type: array
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                   weight:
                                                     format: int32
                                                     type: integer
@@ -787,10 +801,12 @@ spec:
                                                           type: object
                                                         type: array
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                   type: array
                                               required:
                                                 - nodeSelectorTerms
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                         podAffinity:
                                           properties:
@@ -822,6 +838,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -845,6 +862,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaces:
                                                         items:
                                                           type: string
@@ -888,6 +906,7 @@ spec:
                                                           type: string
                                                         type: object
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                   namespaceSelector:
                                                     properties:
                                                       matchExpressions:
@@ -911,6 +930,7 @@ spec:
                                                           type: string
                                                         type: object
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                   namespaces:
                                                     items:
                                                       type: string
@@ -952,6 +972,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaceSelector:
                                                         properties:
                                                           matchExpressions:
@@ -975,6 +996,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       namespaces:
                                                         items:
                                                           type: string
@@ -1018,6 +1040,7 @@ spec:
                                                           type: string
                                                         type: object
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                   namespaceSelector:
                                                     properties:
                                                       matchExpressions:
@@ -1041,6 +1064,7 @@ spec:
                                                           type: string
                                                         type: object
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                   namespaces:
                                                     items:
                                                       type: string
@@ -1086,6 +1110,7 @@ spec:
                                                       required:
                                                         - key
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     fieldRef:
                                                       properties:
                                                         apiVersion:
@@ -1095,6 +1120,7 @@ spec:
                                                       required:
                                                         - fieldPath
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     resourceFieldRef:
                                                       properties:
                                                         containerName:
@@ -1110,6 +1136,7 @@ spec:
                                                       required:
                                                         - resource
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     secretKeyRef:
                                                       properties:
                                                         key:
@@ -1121,6 +1148,7 @@ spec:
                                                       required:
                                                         - key
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   type: object
                                               required:
                                                 - name
@@ -1136,6 +1164,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 prefix:
                                                   type: string
                                                 secretRef:
@@ -1145,6 +1174,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                               type: object
                                             type: array
                                           image:
@@ -1697,6 +1727,7 @@ spec:
                                                       required:
                                                         - key
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     fieldRef:
                                                       properties:
                                                         apiVersion:
@@ -1706,6 +1737,7 @@ spec:
                                                       required:
                                                         - fieldPath
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     resourceFieldRef:
                                                       properties:
                                                         containerName:
@@ -1721,6 +1753,7 @@ spec:
                                                       required:
                                                         - resource
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     secretKeyRef:
                                                       properties:
                                                         key:
@@ -1732,6 +1765,7 @@ spec:
                                                       required:
                                                         - key
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   type: object
                                               required:
                                                 - name
@@ -1747,6 +1781,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 prefix:
                                                   type: string
                                                 secretRef:
@@ -1756,6 +1791,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                               type: object
                                             type: array
                                           image:
@@ -2280,6 +2316,7 @@ spec:
                                           name:
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       type: array
                                     initContainers:
                                       items:
@@ -2312,6 +2349,7 @@ spec:
                                                       required:
                                                         - key
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     fieldRef:
                                                       properties:
                                                         apiVersion:
@@ -2321,6 +2359,7 @@ spec:
                                                       required:
                                                         - fieldPath
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     resourceFieldRef:
                                                       properties:
                                                         containerName:
@@ -2336,6 +2375,7 @@ spec:
                                                       required:
                                                         - resource
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     secretKeyRef:
                                                       properties:
                                                         key:
@@ -2347,6 +2387,7 @@ spec:
                                                       required:
                                                         - key
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   type: object
                                               required:
                                                 - name
@@ -2362,6 +2403,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 prefix:
                                                   type: string
                                                 secretRef:
@@ -2371,6 +2413,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                               type: object
                                             type: array
                                           image:
@@ -3031,6 +3074,7 @@ spec:
                                                   type: string
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           maxSkew:
                                             format: int32
                                             type: integer
@@ -3115,6 +3159,7 @@ spec:
                                                   name:
                                                     type: string
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               user:
                                                 type: string
                                             required:
@@ -3131,6 +3176,7 @@ spec:
                                                   name:
                                                     type: string
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               volumeID:
                                                 type: string
                                             required:
@@ -3161,6 +3207,7 @@ spec:
                                               optional:
                                                 type: boolean
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           csi:
                                             properties:
                                               driver:
@@ -3172,6 +3219,7 @@ spec:
                                                   name:
                                                     type: string
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               readOnly:
                                                 type: boolean
                                               volumeAttributes:
@@ -3198,6 +3246,7 @@ spec:
                                                       required:
                                                         - fieldPath
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     mode:
                                                       format: int32
                                                       type: integer
@@ -3218,6 +3267,7 @@ spec:
                                                       required:
                                                         - resource
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                   required:
                                                     - path
                                                   type: object
@@ -3258,6 +3308,7 @@ spec:
                                                           - kind
                                                           - name
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       dataSourceRef:
                                                         properties:
                                                           apiGroup:
@@ -3270,6 +3321,7 @@ spec:
                                                           - kind
                                                           - name
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       resources:
                                                         properties:
                                                           limits:
@@ -3312,6 +3364,7 @@ spec:
                                                               type: string
                                                             type: object
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       storageClassName:
                                                         type: string
                                                       volumeMode:
@@ -3358,6 +3411,7 @@ spec:
                                                   name:
                                                     type: string
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                             required:
                                               - driver
                                             type: object
@@ -3442,6 +3496,7 @@ spec:
                                                   name:
                                                     type: string
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               targetPortal:
                                                 type: string
                                             required:
@@ -3522,6 +3577,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     downwardAPI:
                                                       properties:
                                                         items:
@@ -3536,6 +3592,7 @@ spec:
                                                                 required:
                                                                   - fieldPath
                                                                 type: object
+                                                                x-kubernetes-map-type: atomic
                                                               mode:
                                                                 format: int32
                                                                 type: integer
@@ -3556,6 +3613,7 @@ spec:
                                                                 required:
                                                                   - resource
                                                                 type: object
+                                                                x-kubernetes-map-type: atomic
                                                             required:
                                                               - path
                                                             type: object
@@ -3583,6 +3641,7 @@ spec:
                                                         optional:
                                                           type: boolean
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     serviceAccountToken:
                                                       properties:
                                                         audience:
@@ -3637,6 +3696,7 @@ spec:
                                                   name:
                                                     type: string
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               user:
                                                 type: string
                                             required:
@@ -3658,6 +3718,7 @@ spec:
                                                   name:
                                                     type: string
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               sslEnabled:
                                                 type: boolean
                                               storageMode:
@@ -3709,6 +3770,7 @@ spec:
                                                   name:
                                                     type: string
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               volumeName:
                                                 type: string
                                               volumeNamespace:
@@ -3791,6 +3853,7 @@ spec:
                                           - kind
                                           - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       dataSourceRef:
                                         properties:
                                           apiGroup:
@@ -3803,6 +3866,7 @@ spec:
                                           - kind
                                           - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resources:
                                         properties:
                                           limits:
@@ -3845,6 +3909,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       storageClassName:
                                         type: string
                                       volumeMode:
@@ -4046,6 +4111,7 @@ spec:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
+                  x-kubernetes-map-type: atomic
                 conditions:
                   description: Set of Conditions describing the current state of the RabbitmqCluster
                   items:


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Update crd after k8s api and controller-gen bump. We haven't regenerated the CRD after recent k8s api bump to 1.24.

## Additional Context

## Local Testing

