### PR TITLE
Use EntryDescription for DescribeTable tests

### DIFF
--- a/controllers/reconcile_rabbitmq_configurations_test.go
+++ b/controllers/reconcile_rabbitmq_configurations_test.go
@@ -2,6 +2,7 @@ package controllers_test
 
 import (
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -20,7 +21,7 @@ var _ = Describe("Reconcile rabbitmq Configurations", func() {
 			// create rabbitmqcluster
 			cluster = &rabbitmqv1beta1.RabbitmqCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "rabbitmq-" + testCase,
+					Name:      "rabbitmq-" + strings.ToLower(testCase),
 					Namespace: defaultNamespace,
 				},
 			}
@@ -36,13 +37,13 @@ var _ = Describe("Reconcile rabbitmq Configurations", func() {
 
 			// update rabbitmq server configurations
 			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
-				if testCase == "additional-config" {
+				if testCase == "additionalConfig" {
 					r.Spec.Rabbitmq.AdditionalConfig = "test_config=0"
 				}
-				if testCase == "advanced-config" {
+				if testCase == "advancedConfig" {
 					r.Spec.Rabbitmq.AdvancedConfig = "sample-advanced-config."
 				}
-				if testCase == "env-config" {
+				if testCase == "envConfig" {
 					r.Spec.Rabbitmq.EnvConfig = "some-env-variable"
 				}
 			})).To(Succeed())
@@ -72,9 +73,9 @@ var _ = Describe("Reconcile rabbitmq Configurations", func() {
 			Expect(client.Delete(ctx, cluster)).To(Succeed())
 			waitForClusterDeletion(ctx, cluster, client)
 		},
-
-		Entry("spec.rabbitmq.additionalConfig is updated", "additional-config"),
-		Entry("spec.rabbitmq.advancedConfig is updated", "advanced-config"),
-		Entry("spec.rabbitmq.envConfig is updated", "env-config"),
+		EntryDescription("spec.rabbitmq.%s is updated"),
+		Entry(nil, "additionalConfig"),
+		Entry(nil, "advancedConfig"),
+		Entry(nil, "envConfig"),
 	)
 })

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -229,7 +229,6 @@ var _ = Context("Services", func() {
 						instance.Spec.TLS.CaSecretName = "somecacertname"
 						Expect(serviceBuilder.Update(svc)).To(Succeed())
 						amqpsPort := corev1.ServicePort{
-
 							Name:        "amqps",
 							Protocol:    corev1.ProtocolTCP,
 							Port:        5671,
@@ -261,12 +260,13 @@ var _ = Context("Services", func() {
 						}
 						Expect(svc.Spec.Ports).To(ConsistOf(amqpsPort, managementTLSPort, prometheusTLSPort, expectedPort))
 					},
-					Entry("MQTT", "rabbitmq_mqtt", "mqtts", 8883, pointer.String("mqtts")),
-					Entry("MQTT-over-WebSockets", "rabbitmq_web_mqtt", "web-mqtt-tls", 15676, pointer.String("https")),
-					Entry("STOMP", "rabbitmq_stomp", "stomps", 61614, pointer.String("stomp.github.io/stomp-tls")),
-					Entry("STOMP-over-WebSockets", "rabbitmq_web_stomp", "web-stomp-tls", 15673, pointer.String("https")),
-					Entry("Stream", "rabbitmq_stream", "streams", 5551, pointer.String("rabbitmq.com/stream-tls")),
-					Entry("OSR", "rabbitmq_multi_dc_replication", "streams", 5551, pointer.String("rabbitmq.com/stream-tls")),
+					EntryDescription("%s plugin is enabled"),
+					Entry(nil, "rabbitmq_mqtt", "mqtts", 8883, pointer.String("mqtts")),
+					Entry(nil, "rabbitmq_web_mqtt", "web-mqtt-tls", 15676, pointer.String("https")),
+					Entry(nil, "rabbitmq_stomp", "stomps", 61614, pointer.String("stomp.github.io/stomp-tls")),
+					Entry(nil, "rabbitmq_web_stomp", "web-stomp-tls", 15673, pointer.String("https")),
+					Entry(nil, "rabbitmq_stream", "streams", 5551, pointer.String("rabbitmq.com/stream-tls")),
+					Entry(nil, "rabbitmq_multi_dc_replication", "streams", 5551, pointer.String("rabbitmq.com/stream-tls")),
 				)
 			})
 
@@ -546,12 +546,13 @@ var _ = Context("Services", func() {
 					}
 					Expect(svc.Spec.Ports).To(ContainElement(expectedPort))
 				},
-				Entry("MQTT", "rabbitmq_mqtt", "mqtt", 1883, pointer.String("mqtt")),
-				Entry("MQTT-over-WebSockets", "rabbitmq_web_mqtt", "web-mqtt", 15675, pointer.String("http")),
-				Entry("STOMP", "rabbitmq_stomp", "stomp", 61613, pointer.String("stomp.github.io/stomp")),
-				Entry("STOMP-over-WebSockets", "rabbitmq_web_stomp", "web-stomp", 15674, pointer.String("http")),
-				Entry("Stream", "rabbitmq_stream", "stream", 5552, pointer.String("rabbitmq.com/stream")),
-				Entry("OSR", "rabbitmq_multi_dc_replication", "stream", 5552, pointer.String("rabbitmq.com/stream")),
+				EntryDescription("%s plugin is enabled"),
+				Entry(nil, "rabbitmq_mqtt", "mqtt", 1883, pointer.String("mqtt")),
+				Entry(nil, "rabbitmq_web_mqtt", "web-mqtt", 15675, pointer.String("http")),
+				Entry(nil, "rabbitmq_stomp", "stomp", 61613, pointer.String("stomp.github.io/stomp")),
+				Entry(nil, "rabbitmq_web_stomp", "web-stomp", 15674, pointer.String("http")),
+				Entry(nil, "rabbitmq_stream", "stream", 5552, pointer.String("rabbitmq.com/stream")),
+				Entry(nil, "rabbitmq_multi_dc_replication", "stream", 5552, pointer.String("rabbitmq.com/stream")),
 			)
 
 			It("updates the service type from ClusterIP to NodePort", func() {

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -811,12 +811,13 @@ var _ = Describe("StatefulSet", func() {
 				container := extractContainer(statefulSet.Spec.Template.Spec.Containers, "rabbitmq")
 				Expect(container.Ports).To(ContainElement(expectedPort))
 			},
-			Entry("MQTT", "rabbitmq_mqtt", "mqtt", 1883),
-			Entry("MQTT-over-WebSockets", "rabbitmq_web_mqtt", "web-mqtt", 15675),
-			Entry("STOMP", "rabbitmq_stomp", "stomp", 61613),
-			Entry("STOMP-over-WebSockets", "rabbitmq_web_stomp", "web-stomp", 15674),
-			Entry("Stream", "rabbitmq_stream", "stream", 5552),
-			Entry("OSR", "rabbitmq_multi_dc_replication", "stream", 5552),
+			EntryDescription("%s plugin is enabled"),
+			Entry(nil, "rabbitmq_mqtt", "mqtt", 1883),
+			Entry(nil, "rabbitmq_web_mqtt", "web-mqtt", 15675),
+			Entry(nil, "rabbitmq_stomp", "stomp", 61613),
+			Entry(nil, "rabbitmq_web_stomp", "web-stomp", 15674),
+			Entry(nil, "rabbitmq_stream", "stream", 5552),
+			Entry(nil, "rabbitmq_multi_dc_replication", "stream", 5552),
 		)
 
 		It("uses required Environment Variables", func() {


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- new feature added in ginkgo V2; using entry description for table tests descriptions that can be easily formatted
- some of our table tests descriptions are quite complicated so I didn't replaced those
- see ginkgo doc: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#new-table-level-entry-descriptions

## Additional Context

