### PR TITLE
Stop testing rmq 3.8

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,7 +53,6 @@ jobs:
         k8s:
         - v1.24.1
         rabbitmq-image:
-        - rabbitmq:3.8.8-management
         - rabbitmq:3.9-management
         - rabbitmq:3.10-management
         - pivotalrabbitmq/rabbitmq:master-otp-min

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.10.2` by default, and supports versions from `3.8.8` upwards. The operator requires Kubernetes `1.19` or newer.
+The operator deploys RabbitMQ `3.10.2` by default, and supports versions from `3.9` upwards. The operator requires Kubernetes `1.19` or newer.
 
 ## Versioning
 


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Stop testing rmq 3.8 as it has reached end of support

- remove 3.8.8 github action tests
- update README to say the Operator supports 3.9 onwards

## Additional Context

