### PR TITLE
Remove RabbitMQ 3.8 support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,7 +53,7 @@ jobs:
         k8s:
         - v1.24.1
         rabbitmq-image:
-        - rabbitmq:3.9-management
+        - rabbitmq:3.9.0-management # minimum supported version
         - rabbitmq:3.10-management
         - pivotalrabbitmq/rabbitmq:master-otp-min
         - pivotalrabbitmq/rabbitmq:master-otp-max

--- a/controllers/reconcile_cli.go
+++ b/controllers/reconcile_cli.go
@@ -68,7 +68,7 @@ func (r *RabbitmqClusterReconciler) runRabbitmqCLICommandsIfAnnotated(ctx contex
 func (r *RabbitmqClusterReconciler) runEnableFeatureFlagsCommand(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster, sts *appsv1.StatefulSet) error {
 	logger := ctrl.LoggerFrom(ctx)
 	podName := fmt.Sprintf("%s-0", rmq.ChildResourceName("server"))
-	cmd := "set -eo pipefail; rabbitmqctl -s list_feature_flags name state stability | (grep 'disabled\\sstable$' || true) | cut -f 1 | xargs -r -n1 rabbitmqctl enable_feature_flag"
+	cmd := "rabbitmqctl enable_feature_flag all"
 	stdout, stderr, err := r.exec(rmq.Namespace, podName, "rabbitmq", "bash", "-c", cmd)
 	if err != nil {
 		msg := "failed to enable all feature flags on pod"

--- a/controllers/reconcile_cli_test.go
+++ b/controllers/reconcile_cli_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Reconcile CLI", func() {
 					return sts.ObjectMeta.Annotations
 				}, 5).ShouldNot(HaveKey("rabbitmq.com/createdAt"))
 				Expect(fakeExecutor.ExecutedCommands()).To(ContainElement(command{"bash", "-c",
-					"set -eo pipefail; rabbitmqctl -s list_feature_flags name state stability | (grep 'disabled\\sstable$' || true) | cut -f 1 | xargs -r -n1 rabbitmqctl enable_feature_flag"}))
+					"rabbitmqctl enable_feature_flag all"}))
 			})
 		})
 	})

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -32,9 +32,7 @@ cluster_formation.k8s.host = kubernetes.default
 cluster_formation.k8s.address_type = hostname
 cluster_partition_handling = pause_minority
 queue_master_locator = min-masters
-disk_free_limit.absolute = 2GB
-cluster_formation.randomized_startup_delay_range.min = 0
-cluster_formation.randomized_startup_delay_range.max = 60`
+disk_free_limit.absolute = 2GB`
 
 	defaultTLSConf = `
 ssl_options.certfile = /etc/rabbitmq-tls/tls.crt

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -33,8 +33,6 @@ cluster_formation.k8s.address_type       = hostname
 cluster_partition_handling               = pause_minority
 queue_master_locator                     = min-masters
 disk_free_limit.absolute                 = 2GB
-cluster_formation.randomized_startup_delay_range.min = 0
-cluster_formation.randomized_startup_delay_range.max = 60
 cluster_name                             = ` + instanceName)
 }
 


### PR DESCRIPTION
Since we dropped support for RabbitMQ 3.8 in https://github.com/rabbitmq/cluster-operator/pull/1110, we can now simplify the cluster-operator:
1. Remove deprecated `cluster_formation.randomized_startup_delay_range` configurations such that warning `[warn] <0.130.0> cluster_formation.randomized_startup_delay_range.min and cluster_formation.randomized_startup_delay_range.max are deprecated` won't be output anymore in RabbitMQ logs. See https://github.com/rabbitmq/rabbitmq-server/pull/3075.
2. Use `rabbitmqctl enable_feature_flag all` command introduced by @mkuratczyk and @michaelklishin in https://github.com/rabbitmq/rabbitmq-server/commit/ce655864050a78f46005b8aa5e047394a6178cd6.