### PR TITLE
Set cluster size hint

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,7 +53,7 @@ jobs:
         k8s:
         - v1.24.1
         rabbitmq-image:
-        - rabbitmq:3.9.0-management # minimum supported version
+        - rabbitmq:3.9.9-management # minimum supported version
         - rabbitmq:3.10-management
         - pivotalrabbitmq/rabbitmq:master-otp-min
         - pivotalrabbitmq/rabbitmq:master-otp-max

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.10.2` by default, and supports versions from `3.9` upwards. The operator requires Kubernetes `1.19` or newer.
+The operator deploys RabbitMQ `3.10.2` by default, and supports versions from `3.9.9` upwards. The operator requires Kubernetes `1.19` or newer.
 
 ## Versioning
 


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
 
- set `cluster_formation.target_cluster_size_hint`. The property is currently used in importing definitions: https://github.com/rabbitmq/rabbitmq-server/pull/3981
- update github action to test again `3.9.9` and README

## Additional Context

- There needs to be release notes added when next operator version is cut as this is explicitly changing the minimal support RMQ version (RMQ without this configuration will fail to deploy).

## Local Testing