### PR TITLE
Remove version restriction on JSON-log example

### DIFF
--- a/docs/examples/json-log/rabbitmq.yaml
+++ b/docs/examples/json-log/rabbitmq.yaml
@@ -3,8 +3,6 @@ kind: RabbitmqCluster
 metadata:
   name: json
 spec:
-  # JSON logging is supported from RabbitMQ 3.9 onwards
-  image: rabbitmq:3.9.4-management
   rabbitmq:
     # Disable RABBITMQ_LOGS=- which is set in
     # https://github.com/docker-library/rabbitmq/blob/ece63d4534cc44abd6b1ec35bbd9aa0d21e87e1d/3.9/ubuntu/Dockerfile#L211


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Removes the image restriction on the JSON logging example, since all supported versions of RabbitMQ are now valid for this particular documented example.

## Additional Context

The CI testing this example was failing since the image 3.9.4-management is no longer compatible with the operator.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
