### PR TITLE
Exclude dependabot from auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,6 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+    authors:
+      - dependabot


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Added dependabot to the list of excluded authors for the sake of generating release notes.

## Additional Context

Once I know this is working, I will add this also to the other operators.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
