### PR TITLE
Bump golang to 1.19

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: 1.17.x
+  GO_VERSION: 1.19.x
   K8S_VERSION: v1.24.1
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rabbitmq/cluster-operator
 
-go 1.17
+go 1.19
 
 require (
 	github.com/cloudflare/cfssl v1.6.2


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Bump golang to 1.19

