### PR TITLE
Fixing .yaml to .yml bug on operatorhub pipeline

### DIFF
--- a/.github/workflows/operatorhub.yml
+++ b/.github/workflows/operatorhub.yml
@@ -39,9 +39,9 @@ jobs:
           cp ./cluster-operator.yml ./OLM-Package-Repo/generate_OLM/generate_OLM_cluster_operator/manifests_crds
           cp ./config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml ./OLM-Package-Repo/generate_OLM/generate_OLM_cluster_operator/manifests_crds/crds.yaml
           cd ./OLM-Package-Repo/generate_OLM/generate_OLM_cluster_operator/
-          python3 generate-olm-package.py ./manifests_crds/cluster-operator.yaml ${{ env.RELEASE_VERSION }} ./../../OLM2/rabbitmq-cluster-operator
+          python3 generate-olm-package.py ./manifests_crds/cluster-operator.yml ${{ env.RELEASE_VERSION }} ./../../OLM2/rabbitmq-cluster-operator
           cp ./generators/cluster-service-version-generator-openshift.yml ./generators/cluster-service-version-generator.yml
-          python3 generate-olm-package.py ./manifests_crds/cluster-operator.yaml ${{ env.RELEASE_VERSION }} ./../../OLM2/rabbitmq-cluster-operator-openshift
+          python3 generate-olm-package.py ./manifests_crds/cluster-operator.yml ${{ env.RELEASE_VERSION }} ./../../OLM2/rabbitmq-cluster-operator-openshift
 
       # Create the PR to OperatorHUB
       - name: CreateOperatorHubPR


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
