### PR TITLE
Add Aggregating ClusterRole for Service Bindings

### DIFF
--- a/config/rbac/service_binding_cluster_role.yaml
+++ b/config/rbac/service_binding_cluster_role.yaml
@@ -5,20 +5,18 @@
 # This product is licensed to you under the Mozilla Public license, Version 2.0 (the "License").  You may not use this product except in compliance with the Mozilla Public License.
 #
 # This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
-#
 
-namespace: rabbitmq-system
-namePrefix: rabbitmq-cluster-
-
-resources:
-- service_account.yaml
-- role.yaml
-- role_binding.yaml
-- leader_election_role.yaml
-- leader_election_role_binding.yaml
-- service_binding_cluster_role.yaml
-
-patches:
-# the following patch file adds labels to the operator ClusterRole definition in role.yaml
-# role.yaml is a generated file, and adding labels directly to the file does not work.
-- role_labels_patch.yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: service-binding-role
+  labels:
+    servicebinding.io/controller: "true"
+    app.kubernetes.io/name: rabbitmq-cluster-operator
+    app.kubernetes.io/component: rabbitmq-operator
+    app.kubernetes.io/part-of: rabbitmq
+rules:
+  - apiGroups: ["rabbitmq.com"]
+    resources: ["rabbitmqclusters"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
This automatically sets up the RBAC required to work with implementors of the Service Binding specification.

As per the spec recommendation:
> Cluster operators and CRD authors SHOULD opt-in resources to expose provisioned services by defining a ClusterRole with a label matching servicebinding.io/controller=true
From https://servicebinding.io/spec/core/1.0.0/#considerations-for-role-based-access-control-rbac

This closes #1149 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Adds a new ClusterRole with the appropriate `servicebinding.io/controller=true` label.  The default `kustomize` configuration appends `rabbitmq-cluster-` to the resource name.
