### PR TITLE
Add label for service discoverability

### DIFF
--- a/config/crd/patches/crd_labels_patch.yaml
+++ b/config/crd/patches/crd_labels_patch.yaml
@@ -15,3 +15,4 @@ metadata:
     app.kubernetes.io/name: rabbitmq-cluster-operator
     app.kubernetes.io/component: rabbitmq-operator
     app.kubernetes.io/part-of: rabbitmq
+    servicebinding.io/provisioned-service: "true"


### PR DESCRIPTION
From the Service Binding Specification for Kubernetes: https://github.com/servicebinding/spec#provisioned-service

  To facilitate discoverability, it is RECOMMENDED that a CustomResourceDefinition
  exposing a Provisioned Service add servicebinding.io/provisioned-service: "true"
  as a label.

Signed-off-by: Baiju Muthukadan <baiju.m.mail@gmail.com>

This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
