### PR TITLE
support k8s 1.25.3

### DIFF
--- a/docs/examples/production-ready/README.md
+++ b/docs/examples/production-ready/README.md
@@ -11,7 +11,10 @@ To deploy this RabbitMQ cluster, run the following:
 
 ```shell
 kubectl apply -f rabbitmq.yaml
+#k8s Version:<v1.25.3
 kubectl apply -f pod-disruption-budget.yaml
+#k8s Version:>=1.25.3
+kubectl apply -f pod-disruption-budget-1.25.3.yaml
 ```
 
 This example is a good starting point for a production RabbitMQ deployment and it may not be suitable for **your use-case**.

--- a/docs/examples/production-ready/pod-disruption-budget-1.25.3.yaml
+++ b/docs/examples/production-ready/pod-disruption-budget-1.25.3.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: production-ready-rabbitmq
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: production-ready


### PR DESCRIPTION
This closes #
K8S latest version don't support `policy/v1beta1` any more.
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
```shell
[root@m-master1 ~]# kubectl version --short | grep Server
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
Server Version: v1.25.3
[root@m-master1 ~]# kubectl api-versions | grep policy
policy/v1
[root@m-master1 ~]# 
```

```shell
[root@m-master1 ~]# kubectl version --short | grep Server
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
Server Version: v1.23.0
[root@m-master1 ~]# kubectl api-versions | grep policy
policy/v1
policy/v1beta1
[root@m-master1 ~]# 
```
## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
