### PR TITLE
Dockerfile enable multi-platform compilation(arm64...)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM --platform=$TARGETPLATFORM golang:1.19 as builder
 
 WORKDIR /workspace
 
@@ -16,10 +16,10 @@ COPY internal/ internal/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -tags timetzdata -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -tags timetzdata -o manager main.go
 
 # ---------------------------------------
-FROM alpine:latest as etc-builder
+FROM --platform=$TARGETPLATFORM alpine:latest as etc-builder
 
 RUN echo "rabbitmq-cluster-operator:x:1000:" > /etc/group && \
     echo "rabbitmq-cluster-operator:x:1000:1000::/home/rabbitmq-cluster-operator:/usr/sbin/nologin" > /etc/passwd
@@ -27,7 +27,7 @@ RUN echo "rabbitmq-cluster-operator:x:1000:" > /etc/group && \
 RUN apk add -U --no-cache ca-certificates
 
 # ---------------------------------------
-FROM scratch
+FROM --platform=$TARGETPLATFORM scratch
 
 ARG GIT_COMMIT
 LABEL GitCommit=$GIT_COMMIT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$TARGETPLATFORM golang:1.19 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /workspace
 
@@ -19,7 +19,7 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -tags timetzdata -o manager main.go
 
 # ---------------------------------------
-FROM --platform=$TARGETPLATFORM alpine:latest as etc-builder
+FROM --platform=$BUILDPLATFORM alpine:latest as etc-builder
 
 RUN echo "rabbitmq-cluster-operator:x:1000:" > /etc/group && \
     echo "rabbitmq-cluster-operator:x:1000:1000::/home/rabbitmq-cluster-operator:/usr/sbin/nologin" > /etc/passwd
@@ -27,7 +27,7 @@ RUN echo "rabbitmq-cluster-operator:x:1000:" > /etc/group && \
 RUN apk add -U --no-cache ca-certificates
 
 # ---------------------------------------
-FROM --platform=$TARGETPLATFORM scratch
+FROM --platform=$BUILDPLATFORM scratch
 
 ARG GIT_COMMIT
 LABEL GitCommit=$GIT_COMMIT


### PR DESCRIPTION
This PR is designed to enable multi-platform compilation. It can support arm64 compilation. It is recommended to use 
```shell
docker buildx build -t rabbitmq/cluster-operator:latest --platform=linux/arm64,linux/amd64 -f Dockerfile --push .
```
 to compile the image.
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
