### PR TITLE
Bump github action dependencies

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/operatorhub.yml
+++ b/.github/workflows/operatorhub.yml
@@ -21,7 +21,7 @@ jobs:
 
   
       # Initialize environment and install Carvel toolsuite
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Initialize
         run: |
           RELEASE_VERSION=${GITHUB_REF#refs/*/} 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,11 +16,11 @@ jobs:
     container: us.gcr.io/cf-rabbitmq-for-k8s-bunny/rabbitmq-for-kubernetes-ci
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Unit tests
       run: make unit-tests
     - name: Integration tests
@@ -31,11 +31,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Dry run examples
       run: |
         export GOPATH=$HOME/go
@@ -63,11 +63,11 @@ jobs:
         - pivotalrabbitmq/rabbitmq:main-otp-max-bazel
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: System tests
       env:
         K8S_VERSION: ${{ matrix.k8s }}
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Install Bats
@@ -94,7 +94,7 @@ jobs:
         cd "$HOME"/bats-core
         sudo ./install.sh /usr/local
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: kubectl rabbitmq tests
       run: |
         export GOPATH=$HOME/go

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: 1.19.2
+  GO_VERSION: ~1.19.3
   K8S_VERSION: v1.24.1
 
 jobs:

--- a/.github/workflows/prometheus-rules.yml
+++ b/.github/workflows/prometheus-rules.yml
@@ -7,7 +7,7 @@ on:
     - observability/prometheus/rules/**/*.y*ml
 
 env:
-  GO_VERSION: 1.19.2
+  GO_VERSION: ~1.19.2
 
 jobs:
   rules:

--- a/.github/workflows/prometheus-rules.yml
+++ b/.github/workflows/prometheus-rules.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Create Prometheus rule file
         run: |
           make install-tools

--- a/.github/workflows/publish-versioned-api-ref.yml
+++ b/.github/workflows/publish-versioned-api-ref.yml
@@ -12,14 +12,14 @@ jobs:
 
     steps:
       - name: Checkout operator codebase
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: cluster-operator
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
       - name: Checkout wiki codebase
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki


### PR DESCRIPTION
v2 actions are deprecated and produce warnings due to outdated nodeJS version.