### PR TITLE
Use latest go patch in github action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: ~1.19.3
+  GO_VERSION: ~1.19
   K8S_VERSION: v1.24.1
 
 jobs:
@@ -19,6 +19,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
+        check-latest: true
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
     - name: Unit tests
@@ -34,6 +35,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
+        check-latest: true
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
     - name: Dry run examples
@@ -66,6 +68,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
+        check-latest: true
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
     - name: System tests
@@ -88,6 +91,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
+        check-latest: true
     - name: Install Bats
       run: |
         git clone https://github.com/bats-core/bats-core.git "$HOME"/bats-core


### PR DESCRIPTION
Same in topology operator https://github.com/rabbitmq/messaging-topology-operator/pull/487

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Use latest go patch in github action. This will make `govulncheck` less likely to fail.

## Additional Context

## Local Testing

