### PR TITLE
let rabbitmq operator to control images

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -449,8 +449,8 @@ func (cluster *RabbitmqCluster) ExternalSecretEnabled() bool {
 	return cluster.Spec.SecretBackend.ExternalSecret.Name != ""
 }
 
-func (cluster *RabbitmqCluster) UsesDefaultUserUpdaterImage() bool {
-	return cluster.VaultEnabled() && cluster.Spec.SecretBackend.Vault.DefaultUserUpdaterImage == nil
+func (cluster *RabbitmqCluster) UsesDefaultUserUpdaterImage(controlRabbitmqImage bool) bool {
+	return cluster.VaultEnabled() && (cluster.Spec.SecretBackend.Vault.DefaultUserUpdaterImage == nil || controlRabbitmqImage)
 }
 
 func (cluster *RabbitmqCluster) VaultDefaultUserSecretEnabled() bool {

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -67,6 +67,7 @@ type RabbitmqClusterReconciler struct {
 	DefaultRabbitmqImage    string
 	DefaultUserUpdaterImage string
 	DefaultImagePullSecrets string
+	ControlRabbitmqImage    bool
 }
 
 // the rbac rule requires an empty row at the end to render

--- a/controllers/reconcile_operator_defaults.go
+++ b/controllers/reconcile_operator_defaults.go
@@ -14,7 +14,8 @@ import (
 // reconcileOperatorDefaults updates current rabbitmqCluster with operator defaults from the Reconciler
 // it handles RabbitMQ image, imagePullSecrets, and user updater image
 func (r *RabbitmqClusterReconciler) reconcileOperatorDefaults(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) (time.Duration, error) {
-	if rabbitmqCluster.Spec.Image == "" {
+	// image will be updated image isn't set yet or the image controlled by the operator (experimental).
+	if rabbitmqCluster.Spec.Image == "" || r.ControlRabbitmqImage {
 		rabbitmqCluster.Spec.Image = r.DefaultRabbitmqImage
 		if requeue, err := r.updateRabbitmqCluster(ctx, rabbitmqCluster, "image"); err != nil {
 			return requeue, err
@@ -34,7 +35,7 @@ func (r *RabbitmqClusterReconciler) reconcileOperatorDefaults(ctx context.Contex
 		}
 	}
 
-	if rabbitmqCluster.UsesDefaultUserUpdaterImage() {
+	if rabbitmqCluster.UsesDefaultUserUpdaterImage(r.ControlRabbitmqImage) {
 		rabbitmqCluster.Spec.SecretBackend.Vault.DefaultUserUpdaterImage = &r.DefaultUserUpdaterImage
 		if requeue, err := r.updateRabbitmqCluster(ctx, rabbitmqCluster, "default user image"); err != nil {
 			return requeue, err

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -98,6 +98,7 @@ var _ = BeforeSuite(func() {
 		Clientset:               clientSet,
 		PodExecutor:             fakeExecutor,
 		DefaultRabbitmqImage:    defaultRabbitmqImage,
+		ControlRabbitmqImage:    false,
 		DefaultUserUpdaterImage: defaultUserUpdaterImage,
 		DefaultImagePullSecrets: defaultImagePullSecrets,
 	}).SetupWithManager(mgr)

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 	var (
 		metricsAddr             string
 		defaultRabbitmqImage    = "rabbitmq:3.10.2-management"
+		controlRabbitmqImage    = false
 		defaultUserUpdaterImage = "rabbitmqoperator/default-user-credential-updater:1.0.2"
 		defaultImagePullSecrets = ""
 	)
@@ -78,6 +79,17 @@ func main() {
 
 	if configuredDefaultUserUpdaterImage, ok := os.LookupEnv("DEFAULT_USER_UPDATER_IMAGE"); ok {
 		defaultUserUpdaterImage = configuredDefaultUserUpdaterImage
+	}
+
+	// EXPERIMENTAL: If the environment variable CONTROL_RABBITMQ_IMAGE is set to `true`, the operator will 
+	// automatically set the default image tags. (DEFAULT_RABBITMQ_IMAGE and DEFAULT_USER_UPDATER_IMAGE)
+	// No safety checks!
+	if configuredControlRabbitmqImage, ok := os.LookupEnv("CONTROL_RABBITMQ_IMAGE"); ok {
+		var err error
+		if controlRabbitmqImage, err = strconv.ParseBool(configuredControlRabbitmqImage); err != nil {
+			log.Error(err, "unable to start manager")
+			os.Exit(1)
+		}
 	}
 
 	if configuredDefaultImagePullSecrets, ok := os.LookupEnv("DEFAULT_IMAGE_PULL_SECRETS"); ok {
@@ -138,6 +150,7 @@ func main() {
 		DefaultRabbitmqImage:    defaultRabbitmqImage,
 		DefaultUserUpdaterImage: defaultUserUpdaterImage,
 		DefaultImagePullSecrets: defaultImagePullSecrets,
+		ControlRabbitmqImage:    controlRabbitmqImage,
 	}).SetupWithManager(mgr)
 	if err != nil {
 		log.Error(err, "unable to create controller", controllerName)


### PR DESCRIPTION
Part of #1003 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Add experimental ENV to let rabbitmq operator update images. **No safety checks at the moment.**

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
