### PR TITLE
WIP: Explore: Rollout operator upgrades

### DIFF
--- a/internal/upgrade/tracker.go
+++ b/internal/upgrade/tracker.go
@@ -1,0 +1,71 @@
+package upgrade
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+type UpgradeRolloutTracker struct {
+	mu            sync.Mutex
+	rolloutWindow time.Duration
+	plannedTimes  []time.Time
+}
+
+func NewUpgradeRolloutTracker(rolloutWindow time.Duration) UpgradeRolloutTracker {
+	return UpgradeRolloutTracker{
+		rolloutWindow: rolloutWindow,
+	}
+}
+
+func (t *UpgradeRolloutTracker) PlanUpgrade(currentTime time.Time) time.Time {
+	t.cleanupPlannedTimes(currentTime)
+	nextUpgradeTime := t.findNextUpgradeTime(currentTime)
+	t.AddUpgradeTime(nextUpgradeTime)
+	return nextUpgradeTime
+}
+
+func (t *UpgradeRolloutTracker) AddUpgradeTime(upgradeTime time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.plannedTimes = append(t.plannedTimes, upgradeTime)
+}
+
+func (t *UpgradeRolloutTracker) findNextUpgradeTime(currentTime time.Time) time.Time {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if len(t.plannedTimes) == 0 {
+		return currentTime
+	}
+
+	var upgradeTimes = append([]time.Time{currentTime}, t.plannedTimes...)
+	upgradeTimes = append(upgradeTimes, currentTime.Add(t.rolloutWindow))
+
+	var biggestGap time.Duration
+	var previousTime time.Time
+	for i := 0; i < len(upgradeTimes)-1; i++ {
+		timeBetweenUpgrades := upgradeTimes[i+1].Sub(upgradeTimes[i])
+		if timeBetweenUpgrades > biggestGap {
+			biggestGap = timeBetweenUpgrades
+			previousTime = upgradeTimes[i]
+		}
+	}
+	return previousTime.Add(biggestGap / 2)
+}
+
+func (t *UpgradeRolloutTracker) cleanupPlannedTimes(currentTime time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	sort.Slice(t.plannedTimes, func(i, j int) bool {
+		return t.plannedTimes[i].Before(t.plannedTimes[j])
+	})
+
+	for _, upgradeTime := range t.plannedTimes {
+		if upgradeTime.Before(currentTime) {
+			t.plannedTimes = t.plannedTimes[1:]
+		} else {
+			break
+		}
+	}
+}

--- a/internal/upgrade/tracker.go
+++ b/internal/upgrade/tracker.go
@@ -12,13 +12,17 @@ type UpgradeRolloutTracker struct {
 	plannedTimes  []time.Time
 }
 
-func NewUpgradeRolloutTracker(rolloutWindow time.Duration) UpgradeRolloutTracker {
-	return UpgradeRolloutTracker{
+func NewUpgradeRolloutTracker(rolloutWindow time.Duration) *UpgradeRolloutTracker {
+	return &UpgradeRolloutTracker{
 		rolloutWindow: rolloutWindow,
 	}
 }
 
 func (t *UpgradeRolloutTracker) PlanUpgrade(currentTime time.Time) time.Time {
+	if t.rolloutWindow == time.Duration(0) {
+		return currentTime
+	}
+
 	t.cleanupPlannedTimes(currentTime)
 	nextUpgradeTime := t.findNextUpgradeTime(currentTime)
 	t.AddUpgradeTime(nextUpgradeTime)

--- a/internal/upgrade/tracker_test.go
+++ b/internal/upgrade/tracker_test.go
@@ -1,0 +1,46 @@
+package upgrade_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rabbitmq/cluster-operator/internal/upgrade"
+	"time"
+)
+
+var _ = Describe("Tracker", func() {
+	var startTime = time.Now()
+	DescribeTable("picking a time in the middle of the largest gap in the rollout window", func(startTime, expectedTime time.Time, existingTimes []time.Time) {
+		tracker := upgrade.NewUpgradeRolloutTracker(10 * time.Minute)
+		for _, existingTime := range existingTimes {
+			tracker.AddUpgradeTime(existingTime)
+		}
+		Expect(tracker.PlanUpgrade(startTime)).To(Equal(expectedTime))
+	},
+		Entry("there are no upgrades planned in the window", startTime, startTime, []time.Time{}),
+		Entry("an upgrade is already planned", startTime, startTime.Add(5*time.Minute), []time.Time{startTime}),
+		Entry("there are several equal gaps", startTime, startTime.Add(1*time.Minute), []time.Time{
+			startTime,
+			startTime.Add(2 * time.Minute),
+			startTime.Add(4 * time.Minute),
+			startTime.Add(6 * time.Minute),
+			startTime.Add(8 * time.Minute),
+		}),
+		Entry("there are several unequal gaps", startTime, startTime.Add(6*time.Minute+30*time.Second), []time.Time{
+			startTime,
+			startTime.Add(3 * time.Minute),
+			startTime.Add(4 * time.Minute),
+			startTime.Add(9 * time.Minute),
+		}),
+		Entry("there are some times before the current time", startTime, startTime.Add(2*time.Minute+30*time.Second), []time.Time{
+			startTime.Add(-30 * time.Minute),
+			startTime.Add(-20 * time.Minute),
+			startTime,
+			startTime.Add(5 * time.Minute),
+			startTime.Add(7 * time.Minute),
+		}),
+		Entry("there are only times before the current time", startTime, startTime, []time.Time{
+			startTime.Add(-30 * time.Minute),
+			startTime.Add(-20 * time.Minute),
+		}),
+	)
+})

--- a/internal/upgrade/tracker_test.go
+++ b/internal/upgrade/tracker_test.go
@@ -43,4 +43,13 @@ var _ = Describe("Tracker", func() {
 			startTime.Add(-20 * time.Minute),
 		}),
 	)
+	When("the upgrade window is 0 length", func() {
+		It("selects now as the time to upgrade", func() {
+			tracker := upgrade.NewUpgradeRolloutTracker(0 * time.Minute)
+			tracker.AddUpgradeTime(startTime)
+			tracker.AddUpgradeTime(startTime)
+			tracker.AddUpgradeTime(startTime)
+			Expect(tracker.PlanUpgrade(startTime)).To(Equal(startTime))
+		})
+	})
 })

--- a/internal/upgrade/upgrade_suite_test.go
+++ b/internal/upgrade/upgrade_suite_test.go
@@ -1,0 +1,13 @@
+package upgrade_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Upgrade Suite")
+}


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
