### PR TITLE
force boot rabbitmq pod because mnesia tables times out

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -67,6 +67,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -91,3 +91,11 @@ func (r *RabbitmqClusterReconciler) configMap(ctx context.Context, rmq *rabbitmq
 	}
 	return configMap, nil
 }
+
+func (r *RabbitmqClusterReconciler) pod(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster, name string) (*corev1.Pod, error) {
+	pod := &corev1.Pod{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: rmq.Namespace, Name: name}, pod); err != nil {
+		return nil, err
+	}
+	return pod, nil
+}


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
