### PR TITLE
Post-2.1.0 pipeline fixes

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -17,7 +17,7 @@ env:
   # Taken from https://github.com/kubernetes-sigs/kind/releases/tag/v0.17.0
   # The image here should be listed under 'Images built for this release' for the version of kind in go.mod
   KIND_NODE_IMAGE: "kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
-  BASELINE_UPGRADE_VERSION: v1.12.0
+  BASELINE_UPGRADE_VERSION: v2.1.0
 
 jobs:
   kubectl_tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
-name: Release
+name: Release Kubectl to Krew
 on:
-  push:
-    tags:
-    - 'v*.*.*'
+  release:
+    types:
+    - published
 
 jobs:
   kubectl_rabbitmq:


### PR DESCRIPTION
## Summary Of Changes

- Sets baseline release to 2.1.0
  -  This is the most recent release that triggered a rolling restart
- Fixes the kubectl rabbitmq release job for krew

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
