### PR TITLE
generating single-arch image on main needed for carvel-dev pipeline

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -113,7 +113,7 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
     - name: OCI Metadata for single-arch image
-      if: startsWith(github.ref, 'refs/tags/v')
+      #if: startsWith(github.ref, 'refs/tags/v')
       id: single-arch-meta
       uses: docker/metadata-action@v4
       with:
@@ -124,9 +124,9 @@ jobs:
           latest=false
         # generate Docker tags based on the following events/attributes
         tags: |
-          type=semver,pattern={{version}},suffix=-amd64,latest=false
+          type=semver,pattern={{version}},type=sha,suffix=-amd64,latest=false
     - name: Build and push single-arch image
-      if: startsWith(github.ref, 'refs/tags/v')
+      #if: startsWith(github.ref, 'refs/tags/v')
       uses: docker/build-push-action@v3
       with:
         context: .


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
