### PR TITLE
test to let carvel pipeline to work

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -154,7 +154,7 @@ jobs:
         if-no-files-found: error
     - name: Rename manifest for GCS
       if: github.event_name != 'pull_request'
-      run: mv releases/cluster-operator.yml cluster-operator-${{ steps.meta.outputs.version }}.yml
+      run: mv releases/cluster-operator.yml cluster-operator-${{ steps.meta.outputs.version }}.yaml
     - id: 'auth'
       uses: 'google-github-actions/auth@v1'
       with:
@@ -164,7 +164,7 @@ jobs:
       if: github.event_name != 'pull_request'
       uses: 'google-github-actions/upload-cloud-storage@v1'
       with:
-        path: cluster-operator-${{ steps.meta.outputs.version }}.yml
+        path: cluster-operator-${{ steps.meta.outputs.version }}.yaml
         destination: operator-manifests-dev
   system_tests_local:
     name: Local system tests (using KinD)


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
