### PR TITLE
Move verbose log lines to debug

### DIFF
--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -10,7 +10,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: rabbitmqclusters.rabbitmq.com
 spec:
@@ -1484,6 +1484,18 @@ spec:
                                             type: object
                                           resources:
                                             properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                  - name
+                                                x-kubernetes-list-type: map
                                               limits:
                                                 additionalProperties:
                                                   anyOf:
@@ -2101,6 +2113,18 @@ spec:
                                             type: object
                                           resources:
                                             properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                  - name
+                                                x-kubernetes-list-type: map
                                               limits:
                                                 additionalProperties:
                                                   anyOf:
@@ -2725,6 +2749,18 @@ spec:
                                             type: object
                                           resources:
                                             properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                  - name
+                                                x-kubernetes-list-type: map
                                               limits:
                                                 additionalProperties:
                                                   anyOf:
@@ -2967,12 +3003,43 @@ spec:
                                           - conditionType
                                         type: object
                                       type: array
+                                    resourceClaims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          source:
+                                            properties:
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
+                                            type: object
+                                        required:
+                                          - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
                                     restartPolicy:
                                       type: string
                                     runtimeClassName:
                                       type: string
                                     schedulerName:
                                       type: string
+                                    schedulingGates:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
                                     securityContext:
                                       properties:
                                         fsGroup:
@@ -3344,13 +3411,26 @@ spec:
                                                             type: string
                                                           name:
                                                             type: string
+                                                          namespace:
+                                                            type: string
                                                         required:
                                                           - kind
                                                           - name
                                                         type: object
-                                                        x-kubernetes-map-type: atomic
                                                       resources:
                                                         properties:
+                                                          claims:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                              required:
+                                                                - name
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-map-keys:
+                                                              - name
+                                                            x-kubernetes-list-type: map
                                                           limits:
                                                             additionalProperties:
                                                               anyOf:
@@ -3889,13 +3969,26 @@ spec:
                                             type: string
                                           name:
                                             type: string
+                                          namespace:
+                                            type: string
                                         required:
                                           - kind
                                           - name
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       resources:
                                         properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           limits:
                                             additionalProperties:
                                               anyOf:
@@ -4007,6 +4100,21 @@ spec:
                       memory: 2Gi
                   description: The desired compute resource requirements of Pods in the cluster.
                   properties:
+                    claims:
+                      description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable."
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        properties:
+                          name:
+                            description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     limits:
                       additionalProperties:
                         anyOf:

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -149,13 +149,13 @@ func (r *RabbitmqClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
+	logger.Info("Start reconciling")
+
 	instanceSpec, err := json.Marshal(rabbitmqCluster.Spec)
 	if err != nil {
 		logger.Error(err, "Failed to marshal cluster spec")
 	}
-
-	logger.Info("Start reconciling",
-		"spec", string(instanceSpec))
+	logger.V(1).Info("RabbitmqCluster", "spec", string(instanceSpec))
 
 	resourceBuilder := resource.RabbitmqResourceBuilder{
 		Instance: rabbitmqCluster,

--- a/controllers/reconcile_cli.go
+++ b/controllers/reconcile_cli.go
@@ -38,7 +38,7 @@ func (r *RabbitmqClusterReconciler) runRabbitmqCLICommandsIfAnnotated(ctx contex
 		// plugins configMap was updated very recently
 		// give StatefulSet controller some time to trigger restart of StatefulSet if necessary
 		// otherwise, there would be race conditions where we exec into containers losing the connection due to pods being terminated
-		logger.Info("requeuing request to set plugins")
+		logger.V(1).Info("requeuing request to set plugins")
 		return 2 * time.Second, nil
 	}
 
@@ -113,6 +113,7 @@ func (r *RabbitmqClusterReconciler) runQueueRebalanceCommand(ctx context.Context
 		r.Recorder.Event(rmq, corev1.EventTypeWarning, "FailedReconcile", fmt.Sprintf("%s %s", msg, podName))
 		return fmt.Errorf("%s %s: %w", msg, podName, err)
 	}
+	logger.Info("successfully rebalanced queues")
 	return r.deleteAnnotation(ctx, rmq, queueRebalanceAnnotation)
 }
 


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Update generated CRD
- log cluster spec at debug instead of info
- log message about requeue request to enable plugin at debug instead of info
- log successfully queue rebalance like other cli command

'Start reconciling' log which used to contain `.spec` now looks like
`2023-02-21T17:35:40Z	INFO	Start reconciling	{"controller": "rabbitmqcluster", "controllerGroup": "rabbitmq.com", "controllerKind": "RabbitmqCluster", "RabbitmqCluster": {"name":"sample","namespace":"rabbitmq-system"}, "namespace": "rabbitmq-system", "name": "sample", "reconcileID": "b8013f6d-40a3-45db-9b57-77e21e56d2a2"}`

## Additional Context

## Local Testing

