### PR TITLE
Open stream port when stream management plugin is on

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -441,9 +441,11 @@ func (cluster *RabbitmqCluster) AdditionalPluginEnabled(plugin Plugin) bool {
 	return false
 }
 
-// the OSR plugin `rabbitmq_multi_dc_replication` enables `rabbitmq_stream` as a dependency
+// StreamNeeded returns true when stream or plugins that auto enable stream are turned on
 func (cluster *RabbitmqCluster) StreamNeeded() bool {
-	return cluster.AdditionalPluginEnabled("rabbitmq_stream") || cluster.AdditionalPluginEnabled("rabbitmq_multi_dc_replication")
+	return cluster.AdditionalPluginEnabled("rabbitmq_stream") ||
+		cluster.AdditionalPluginEnabled("rabbitmq_stream_management") ||
+		cluster.AdditionalPluginEnabled("rabbitmq_multi_dc_replication")
 }
 
 func (cluster *RabbitmqCluster) VaultEnabled() bool {

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -194,6 +194,22 @@ var _ = Context("Services", func() {
 				})
 			})
 
+			When("stream_management is enabled", func() {
+				It("opens port for streams", func() {
+					instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_stream_management"}
+					Expect(serviceBuilder.Update(svc)).To(Succeed())
+					Expect(svc.Spec.Ports).To(ContainElements([]corev1.ServicePort{
+						{
+							Name:        "streams",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        5551,
+							TargetPort:  intstr.FromInt(5551),
+							AppProtocol: pointer.String("rabbitmq.com/stream-tls"),
+						},
+					}))
+				})
+			})
+
 			When("DisableNonTLSListeners is set to true", func() {
 				It("only exposes tls ports in the service", func() {
 					instance.Spec.TLS.DisableNonTLSListeners = true
@@ -267,6 +283,7 @@ var _ = Context("Services", func() {
 					Entry(nil, "rabbitmq_web_stomp", "web-stomp-tls", 15673, pointer.String("https")),
 					Entry(nil, "rabbitmq_stream", "streams", 5551, pointer.String("rabbitmq.com/stream-tls")),
 					Entry(nil, "rabbitmq_multi_dc_replication", "streams", 5551, pointer.String("rabbitmq.com/stream-tls")),
+					Entry(nil, "rabbitmq_stream_management", "streams", 5551, pointer.String("rabbitmq.com/stream-tls")),
 				)
 			})
 
@@ -553,6 +570,7 @@ var _ = Context("Services", func() {
 				Entry(nil, "rabbitmq_web_stomp", "web-stomp", 15674, pointer.String("http")),
 				Entry(nil, "rabbitmq_stream", "stream", 5552, pointer.String("rabbitmq.com/stream")),
 				Entry(nil, "rabbitmq_multi_dc_replication", "stream", 5552, pointer.String("rabbitmq.com/stream")),
+				Entry(nil, "rabbitmq_stream_management", "stream", 5552, pointer.String("rabbitmq.com/stream")),
 			)
 
 			It("updates the service type from ClusterIP to NodePort", func() {

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 		defaultUserUpdaterImage = configuredDefaultUserUpdaterImage
 	}
 
-	// EXPERIMENTAL: If the environment variable CONTROL_RABBITMQ_IMAGE is set to `true`, the operator will 
+	// EXPERIMENTAL: If the environment variable CONTROL_RABBITMQ_IMAGE is set to `true`, the operator will
 	// automatically set the default image tags. (DEFAULT_RABBITMQ_IMAGE and DEFAULT_USER_UPDATER_IMAGE)
 	// No safety checks!
 	if configuredControlRabbitmqImage, ok := os.LookupEnv("CONTROL_RABBITMQ_IMAGE"); ok {


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Open stream port when stream management plugin is on because `rabbitmq_stream_management` turns on `rabbitmq_stream` automatically.

## Additional Context

## Local Testing
