### PR TITLE
Generate arm64 image

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -111,9 +111,9 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-    - name: OCI Metadata for single-arch image
+    - name: OCI Metadata for single-arch amd64 image
       #if: startsWith(github.ref, 'refs/tags/v')
-      id: single-arch-meta
+      id: single-arch-meta-amd64
       uses: docker/metadata-action@v4
       with:
         # list of Docker images to use as base name for tags
@@ -124,15 +124,37 @@ jobs:
         # generate Docker tags based on the following events/attributes
         tags: |
           type=semver,pattern={{version}},type=sha,suffix=-amd64,latest=false
-    - name: Build and push single-arch image
+    - name: Build and push single-arch amd64 image
       #if: startsWith(github.ref, 'refs/tags/v')
       uses: docker/build-push-action@v3
       with:
         context: .
         platforms: linux/amd64
         push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.single-arch-meta.outputs.tags }}
-        labels: ${{ steps.single-arch-meta.outputs.labels }}
+        tags: ${{ steps.single-arch-meta-amd64.outputs.tags }}
+        labels: ${{ steps.single-arch-meta-amd64.outputs.labels }}
+    - name: OCI Metadata for single-arch arm64 image
+      #if: startsWith(github.ref, 'refs/tags/v')
+      id: single-arch-meta-arm64
+      uses: docker/metadata-action@v4
+      with:
+        # list of Docker images to use as base name for tags
+        images: |
+          rabbitmqoperator/cluster-operator
+        flavor: |
+          latest=false
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=semver,pattern={{version}},type=sha,suffix=-arm64,latest=false
+    - name: Build and push single-arch arm64 image
+      #if: startsWith(github.ref, 'refs/tags/v')
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        platforms: linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.single-arch-meta-arm64.outputs.tags }}
+        labels: ${{ steps.single-arch-meta-arm64.outputs.labels }}     
     - name: Build manifest
       if: github.event_name != 'pull_request'
       env:


### PR DESCRIPTION
This contributes to https://github.com/rabbitmq/service-operator-experience/issues/164

Workflow is updated to also build and publish single-arch `arm64` image.
Currently the workflow builds and publishes multi-arch (amd64/arm64) and single-arch (amd64) images.