### PR TITLE
Update Grafana dashboards

### DIFF
--- a/observability/grafana/dashboards/erlang-distribution.yml
+++ b/observability/grafana/dashboards/erlang-distribution.yml
@@ -7,4 +7,4 @@ metadata:
     grafana_dashboard: "true"
 data:
   # https://grafana.com/grafana/dashboards/11352
-  erlang-distribution-dashboard.json.url: https://grafana.com/api/dashboards/11352/revisions/7/download
+  erlang-distribution-dashboard.json.url: "https://github.com/rabbitmq/rabbitmq-server/raw/e57c579d1a71b283469defdd0d6d45313e6d6daf/deps/rabbitmq_prometheus/docker/grafana/dashboards/Erlang-Distribution.json"

--- a/observability/grafana/dashboards/erlang-distributions-compare.yml
+++ b/observability/grafana/dashboards/erlang-distributions-compare.yml
@@ -7,4 +7,4 @@ metadata:
     grafana_dashboard: "true"
 data:
   # https://grafana.com/grafana/dashboards/10988
-  erlang-distributions-compare-dashboard.json.url: https://grafana.com/api/dashboards/10988/revisions/11/download
+  erlang-distributions-compare-dashboard.json.url: "https://github.com/rabbitmq/rabbitmq-server/raw/e57c579d1a71b283469defdd0d6d45313e6d6daf/deps/rabbitmq_prometheus/docker/grafana/dashboards/Erlang-Distributions-Compare.json"

--- a/observability/grafana/dashboards/erlang-memory-allocators.yml
+++ b/observability/grafana/dashboards/erlang-memory-allocators.yml
@@ -7,4 +7,4 @@ metadata:
     grafana_dashboard: "true"
 data:
   # https://grafana.com/grafana/dashboards/11350
-  erlang-memory-allocators-dashboard.json.url: https://grafana.com/api/dashboards/11350/revisions/5/download
+  erlang-memory-allocators-dashboard.json.url: "https://github.com/rabbitmq/rabbitmq-server/raw/e57c579d1a71b283469defdd0d6d45313e6d6daf/deps/rabbitmq_prometheus/docker/grafana/dashboards/Erlang-Memory-Allocators.json"

--- a/observability/grafana/dashboards/rabbitmq-overview.yml
+++ b/observability/grafana/dashboards/rabbitmq-overview.yml
@@ -7,4 +7,4 @@ metadata:
     grafana_dashboard: "true"
 data:
   # https://grafana.com/grafana/dashboards/10991
-  rabbitmq-overview-dashboard.json.url: https://grafana.com/api/dashboards/10991/revisions/11/download
+  rabbitmq-overview-dashboard.json.url: "https://github.com/rabbitmq/rabbitmq-server/raw/e57c579d1a71b283469defdd0d6d45313e6d6daf/deps/rabbitmq_prometheus/docker/grafana/dashboards/RabbitMQ-Overview.json"

--- a/observability/grafana/dashboards/rabbitmq-queue.yml
+++ b/observability/grafana/dashboards/rabbitmq-queue.yml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: rabbitmq-queue-grafana-dashboard
   labels:
-    grafana_dashboard: "1"
+    grafana_dashboard: "true"
 data:
   rabbitmq-queue-grafana-dashboard.json: |-
     {

--- a/observability/grafana/dashboards/rabbitmq-quorum-queues-raft.yml
+++ b/observability/grafana/dashboards/rabbitmq-quorum-queues-raft.yml
@@ -7,4 +7,4 @@ metadata:
     grafana_dashboard: "true"
 data:
   # https://grafana.com/grafana/dashboards/11340
-  rabbitmq-quorum-queues-raft-dashboard.json.url: https://grafana.com/api/dashboards/11340/revisions/5/download
+  rabbitmq-quorum-queues-raft-dashboard.json.url: "https://github.com/rabbitmq/rabbitmq-server/raw/e57c579d1a71b283469defdd0d6d45313e6d6daf/deps/rabbitmq_prometheus/docker/grafana/dashboards/RabbitMQ-Quorum-Queues-Raft.json"

--- a/observability/grafana/dashboards/rabbitmq-stream.yml
+++ b/observability/grafana/dashboards/rabbitmq-stream.yml
@@ -7,4 +7,4 @@ metadata:
     grafana_dashboard: "true"
 data:
   # https://grafana.com/grafana/dashboards/14798
-  rabbitmq-stream-dashboard.json.url: https://grafana.com/api/dashboards/14798/revisions/9/download
+  rabbitmq-stream-dashboard.json.url: "https://github.com/rabbitmq/rabbitmq-server/raw/e57c579d1a71b283469defdd0d6d45313e6d6daf/deps/rabbitmq_prometheus/docker/grafana/dashboards/RabbitMQ-Stream.json"


### PR DESCRIPTION
This closes #1334

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Use a perma-link to Grafana Dashboards in rabbitmq-server repo.

## Additional Context

`Grafana.com` is rejecting HTTP requests with basic authentication. Earlier, it used to ignore the basic auth, and simply serve the request. This new behaviour in Grafana API breaks the [sidecar import feature of Grafana's Helm Chart](https://artifacthub.io/packages/helm/grafana/grafana#sidecar-for-dashboards). The sidecar from Grafana uses basic authentication in their HTTP request. It then gets a not-authorized response from Grafana API, and dashboard importing fails.

GitHub raw URLs ignore the basic auth and simply serve the file as a static element.

## Local Testing

N/A - no code changes

Edit: formatting