### PR TITLE
Allow multi namespace cache scoping

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,11 +13,13 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/rabbitmq/cluster-operator/pkg/profiling"
 
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
@@ -104,6 +106,11 @@ func main() {
 		LeaderElectionNamespace: operatorNamespace,
 		LeaderElectionID:        "rabbitmq-cluster-operator-leader-election",
 		Namespace:               operatorScopeNamespace,
+	}
+
+	if strings.Contains(operatorScopeNamespace, ",") {
+		options.Namespace = ""
+		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(operatorScopeNamespace, ","))
 	}
 
 	if leaseDuration := getEnvInDuration("LEASE_DURATION"); leaseDuration != 0 {


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Allows scoping the cache namespace to more than 1 namespace if `OPERATOR_SCOPE_NAMESPACE` is a comma delimited list.

## Additional Context

If someone needed to configure their RBAC with non-cluster `roles` and `rolebindings` they would be unable to run the operator. This project requires access to a lot of resources and not everyone's security stance allows for using `clusterroles`. 

Without providing `OPERATOR_SCOPE_NAMESPACE` and using `role` instead of `clusterrole` you get errors such as 

```
failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:rabbit:rabbit-cluster-operator" cannot list resource "configmaps" in API group "" at the cluster scope
```

and a similar error if a resource is added in a namespace not covered by `OPERATOR_SCOPE_NAMESPACE`. 

Without this change, it's only possible to scope the cache to a single namespace, and this allows for scoping to a list of namespaces.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
