### PR TITLE
On new release generate -amd64 and -arm64 release versions

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -84,8 +84,6 @@ jobs:
           type=sha
           type=ref,event=pr
           type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
@@ -123,7 +121,8 @@ jobs:
           latest=false
         # generate Docker tags based on the following events/attributes
         tags: |
-          type=semver,pattern={{version}},type=sha,suffix=-amd64,latest=false
+          type=semver,pattern={{version}},suffix=-amd64,latest=false
+          type=sha,suffix=-amd64,latest=false
     - name: Build and push single-arch amd64 image
       #if: startsWith(github.ref, 'refs/tags/v')
       uses: docker/build-push-action@v3
@@ -145,7 +144,8 @@ jobs:
           latest=false
         # generate Docker tags based on the following events/attributes
         tags: |
-          type=semver,pattern={{version}},type=sha,suffix=-arm64,latest=false
+          type=semver,pattern={{version}},suffix=-arm64,latest=false
+          type=sha,suffix=-arm64,latest=false
     - name: Build and push single-arch arm64 image
       #if: startsWith(github.ref, 'refs/tags/v')
       uses: docker/build-push-action@v3


### PR DESCRIPTION
## Summary Of Changes

Previously -amd64 and -arm64 images were created with tags sha-amd64 and sha-arm64.
For our carvel-pipeline to work properly is convinient to have images tagged with version-amd64 and version-arm64 (ex 2.2.0-amd64 and 2.2.0-arm64 when a new release happens).

Also:
type=semver,pattern={{major}}.{{minor}}
type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}

seems not necessary as these created tags of type 2.2 and 2

for example https://hub.docker.com/r/rabbitmqoperator/cluster-operator/tags?page=1&name=2.2 

I have tested these modifications cloning the repo https://github.com/DanielePalaia/cluster-operator/blob/main/.github/workflows/build-test-publish.yml and using my dockerhub account:
https://hub.docker.com/repository/docker/danielepalaia/cluster-operator/general



## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
