### PR TITLE
fixed paths and env variable name for plugings

### DIFF
--- a/docs/examples/community-plugins/rabbitmq.yaml
+++ b/docs/examples/community-plugins/rabbitmq.yaml
@@ -40,4 +40,4 @@ spec:
     additionalPlugins:
       - rabbitmq_message_timestamp
     envConfig: |
-      PLUGINS_DIR=/opt/rabbitmq/plugins:/opt/rabbitmq/community-plugins
+      RABBITMQ_PLUGINS_DIR=/opt/rabbitmq/plugins:/opt/rabbitmq/community-plugins:/opt/bitnami/rabbitmq/plugins


### PR DESCRIPTION
This may fix #1352

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Tried to fix enabling community plugins, downloaded via init-containers. 

Changed `PLUGIN_DIR` to `RABBITMQ_PLUGIN_DIR` and added the default path of shipped plugins to its value. 

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
[~]$ kubectl exec -ti rabbitmq-server-0 -- bash
Defaulted container "rabbitmq" out of: rabbitmq, copy-community-plugins (init), setup-container (init)
I have no name!@rabbitmq-server-0:/$ rabbitmq-plugins directories
Listing plugin directories used by node rabbit@rabbitmq-server-0.rabbitmq-nodes.default
Plugin archives directory: /opt/rabbitmq/plugins:/opt/rabbitmq/community-plugins:/opt/bitnami/rabbitmq/plugins
Plugin expansion directory: /bitnami/rabbitmq/mnesia/rabbit@rabbitmq-server-0.rabbitmq-nodes.default-plugins-expand
Enabled plugins file: /operator/enabled_plugins
I have no name!@rabbitmq-server-0:/$ rabbitmq-plugins list
Listing plugins with pattern ".*" ...
 Configured: E = explicitly enabled; e = implicitly enabled
 | Status: * = running on rabbit@rabbitmq-server-0.rabbitmq-nodes.default
 |/
[  ] rabbitmq_amqp1_0                  3.10.11
[  ] rabbitmq_auth_backend_cache       3.10.11
[  ] rabbitmq_auth_backend_http        3.10.11
[  ] rabbitmq_auth_backend_ldap        3.10.11
[  ] rabbitmq_auth_backend_oauth2      3.10.11
[  ] rabbitmq_auth_mechanism_ssl       3.10.11
[  ] rabbitmq_consistent_hash_exchange 3.10.11
[E*] rabbitmq_delayed_message_exchange 3.10.2
[  ] rabbitmq_event_exchange           3.10.11
[  ] rabbitmq_federation               3.10.11
[  ] rabbitmq_federation_management    3.10.11
[  ] rabbitmq_jms_topic_exchange       3.10.11
[E*] rabbitmq_management               3.10.11
[e*] rabbitmq_management_agent         3.10.11
[  ] rabbitmq_mqtt                     3.10.11
[  ] rabbitmq_peer_discovery_aws       3.10.11
[e*] rabbitmq_peer_discovery_common    3.10.11
[  ] rabbitmq_peer_discovery_consul    3.10.11
[  ] rabbitmq_peer_discovery_etcd      3.10.11
[E*] rabbitmq_peer_discovery_k8s       3.10.11
[E*] rabbitmq_prometheus               3.10.11
[  ] rabbitmq_random_exchange          3.10.11
[  ] rabbitmq_recent_history_exchange  3.10.11
[  ] rabbitmq_sharding                 3.10.11
[  ] rabbitmq_shovel                   3.10.11
[  ] rabbitmq_shovel_management        3.10.11
[  ] rabbitmq_stomp                    3.10.11
[  ] rabbitmq_stream                   3.10.11
[  ] rabbitmq_stream_management        3.10.11
[  ] rabbitmq_top                      3.10.11
[  ] rabbitmq_tracing                  3.10.11
[  ] rabbitmq_trust_store              3.10.11
[e*] rabbitmq_web_dispatch             3.10.11
[  ] rabbitmq_web_mqtt                 3.10.11
[  ] rabbitmq_web_mqtt_examples        3.10.11
[  ] rabbitmq_web_stomp                3.10.11
[  ] rabbitmq_web_stomp_examples       3.10.11
I have no name!@rabbitmq-server-0:/$ 
``` 
