### PR TITLE
Renamed patches -> patchesStrategicMerge

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 - bases/rabbitmq.com_rabbitmqclusters.yaml
 # +kubebuilder:scaffold:kustomizeresource
 
-patches:
+patchesStrategicMerge:
 - patches/crd_labels_patch.yaml
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/default/overlays/dev/kustomization.yaml
+++ b/config/default/overlays/dev/kustomization.yaml
@@ -10,5 +10,5 @@ namespace: rabbitmq-system
 resources:
 - ../../base
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml

--- a/config/default/overlays/kind/kustomization.yaml
+++ b/config/default/overlays/kind/kustomization.yaml
@@ -10,5 +10,5 @@ namespace: rabbitmq-system
 resources:
 - ../../base
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -18,7 +18,7 @@ resources:
 - leader_election_role_binding.yaml
 - service_binding_cluster_role.yaml
 
-patches:
+patchesStrategicMerge:
 # the following patch file adds labels to the operator ClusterRole definition in role.yaml
 # role.yaml is a generated file, and adding labels directly to the file does not work.
 - role_labels_patch.yaml


### PR DESCRIPTION
Hello. I can't use this repo kustomize templates, because "patches:" notation was obsolete. I get errors, when try to execute kustomize:
```
error: invalid Kustomization: json: cannot unmarshal string into Go struct field Kustomization.patches of type types.Patch
```
Could you merge this little PR to fix it?