### PR TITLE
feat(docs): add stream ports to inter-node-traffic network-policy

### DIFF
--- a/docs/examples/network-policies/allow-inter-node-traffic.yaml
+++ b/docs/examples/network-policies/allow-inter-node-traffic.yaml
@@ -18,6 +18,8 @@ spec:
           app.kubernetes.io/name: network-policies
     ports:
     - port: 4369  # epmd
+    - port: 6000  # stream replication, if streams are being used
+      endPort: 6500 # if your cluster version is below 1.22 (see below) you should use a helm loop or something similar
     - port: 25672 # clustering
     - port: 35672 # CLI tooling
     - port: 35673 # CLI tooling
@@ -41,6 +43,8 @@ spec:
           app.kubernetes.io/name: network-policies
     ports:
     - port: 4369  # epmd
+    - port: 6000  # stream replication, if streams are being used
+      endPort: 6500 # if your cluster version is below 1.22 (see below) you should use a helm loop or something similar
     - port: 25672 # clustering
     - port: 35672 # CLI tooling
     - port: 35673 # CLI tooling


### PR DESCRIPTION
This closes https://github.com/rabbitmq/cluster-operator/issues/1457

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
Add missing ports for stream replication to networkpolicies example.



