### PR TITLE
Exclude Google Auth in PRs

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -111,6 +111,7 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
     - name: OCI Metadata for single-arch amd64 image
+      if: github.event_name != 'pull_request'
       #if: startsWith(github.ref, 'refs/tags/v')
       id: single-arch-meta-amd64
       uses: docker/metadata-action@v5
@@ -125,6 +126,7 @@ jobs:
           type=semver,pattern={{version}},suffix=-amd64,latest=false
           type=sha,suffix=-amd64,latest=false
     - name: Build and push single-arch amd64 image
+      if: github.event_name != 'pull_request'
       #if: startsWith(github.ref, 'refs/tags/v')
       uses: docker/build-push-action@v5
       with:
@@ -134,6 +136,7 @@ jobs:
         tags: ${{ steps.single-arch-meta-amd64.outputs.tags }}
         labels: ${{ steps.single-arch-meta-amd64.outputs.labels }}
     - name: OCI Metadata for single-arch arm64 image
+      if: github.event_name != 'pull_request'
       #if: startsWith(github.ref, 'refs/tags/v')
       id: single-arch-meta-arm64
       uses: docker/metadata-action@v5
@@ -148,6 +151,7 @@ jobs:
           type=semver,pattern={{version}},suffix=-arm64,latest=false
           type=sha,suffix=-arm64,latest=false
     - name: Build and push single-arch arm64 image
+      if: github.event_name != 'pull_request'
       #if: startsWith(github.ref, 'refs/tags/v')
       uses: docker/build-push-action@v5
       with:
@@ -178,6 +182,8 @@ jobs:
       if: github.event_name != 'pull_request'
       run: mv releases/cluster-operator.yml cluster-operator-${{ steps.meta.outputs.version }}.yml
     - id: 'auth'
+      name: Auth to Google Cloud
+      if: github.event_name != 'pull_request'
       uses: 'google-github-actions/auth@v1'
       with:
         workload_identity_provider: ${{ secrets.GCP_IDENTITY_PROVIDER }}


### PR DESCRIPTION
Forks do not copy over repo secrets. This step requires a repo secret, and it will fail if the action is triggered from a fork.
