### PR TITLE
imagePullSecrets is an array

### DIFF
--- a/bin/kubectl-rabbitmq
+++ b/bin/kubectl-rabbitmq
@@ -267,7 +267,7 @@ create() {
             ;;
         "--image-pull-secret")
             shift 1
-            echo "  imagePullSecret: $1" >>"$rabbitmq_manifest_file"
+            echo "  imagePullSecrets: [ name: $1 ]" >>"$rabbitmq_manifest_file"
             shift 1
             ;;
         "--unlimited")


### PR DESCRIPTION
Without the fix, passing `--image-pull-secret` would lead to validation failure.