### PR TITLE
Reverting docker/build-push-action version

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -103,7 +103,7 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
     - name: Build and push
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v3
       with:
         context: .
         platforms: linux/amd64, linux/arm64, linux/ppc64le, linux/s390x
@@ -128,7 +128,7 @@ jobs:
     - name: Build and push single-arch amd64 image
       if: github.event_name != 'pull_request'
       #if: startsWith(github.ref, 'refs/tags/v')
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v3
       with:
         context: .
         platforms: linux/amd64
@@ -153,7 +153,7 @@ jobs:
     - name: Build and push single-arch arm64 image
       if: github.event_name != 'pull_request'
       #if: startsWith(github.ref, 'refs/tags/v')
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v3
       with:
         context: .
         platforms: linux/arm64


### PR DESCRIPTION
v5 of this action generates artifacts with manifest containing `unknown` OS and architecture.
