### PR TITLE
removing encoded rabbitmq-system namespace in system-tests

### DIFF
--- a/system_tests/system_test.go
+++ b/system_tests/system_test.go
@@ -475,7 +475,7 @@ CONSOLE_LOG=new`
 				waitForRabbitmqUpdate(cluster)
 
 				var err error
-				username, password, err = getUsernameAndPassword(ctx, clientSet, "rabbitmq-system", "tls-test-rabbit")
+				username, password, err = getUsernameAndPassword(ctx, clientSet, namespace, "tls-test-rabbit")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -615,7 +615,7 @@ CONSOLE_LOG=new`
 
 			hostname = kubernetesNodeIp(ctx, clientSet)
 			var err error
-			username, password, err = getUsernameAndPassword(ctx, clientSet, "rabbitmq-system", instanceName)
+			username, password, err = getUsernameAndPassword(ctx, clientSet, namespace, instanceName)
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
This will allow us to run the system-tests in a different namespace than the default "rabbitmq-system" 