### PR TITLE
Use queue_master_locator random instead of min-masters

### DIFF
--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -28,7 +28,7 @@ import (
 const (
 	ServerConfigMapName = "server-conf"
 	defaultRabbitmqConf = `
-queue_master_locator = min-masters
+queue_master_locator = random
 disk_free_limit.absolute = 2GB
 cluster_partition_handling = pause_minority
 cluster_formation.peer_discovery_backend = rabbit_peer_discovery_k8s

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -12,6 +12,7 @@ package resource_test
 import (
 	"bytes"
 	"fmt"
+
 	"k8s.io/utils/ptr"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,7 +29,7 @@ import (
 
 func defaultRabbitmqConf(instanceName string) string {
 	return iniString(`
-queue_master_locator                       = min-masters
+queue_master_locator                       = random
 disk_free_limit.absolute                   = 2GB
 cluster_partition_handling                 = pause_minority
 cluster_formation.peer_discovery_backend   = rabbit_peer_discovery_k8s


### PR DESCRIPTION
### What?

Change the default `queue_master_locator` value from `min-masters` to `random`.

Note that `queue_master_locator` applies only to classic queues and can have values `client-local`, `random`, or `min-masters`.

(`queue_leader_locator` applies to quorum queues and streams and can values `client-local` or `balanced`).

### Why?

The current `min-masters` implementation reads **all** queue records. This becomes a severe performance bottleneck in clusters with many queues. Especially MQTT workloads will suffer as shown in https://github.com/rabbitmq/rabbitmq-server/discussions/10627

Ideally, `client-local` is used so that clients can publish or consume locally to the node they are connected to. `client-local` should also result in good distribution of queues across nodes given that clients usually connect to the RabbitMQ cluster through a K8s Service object.

However, the current definition import implementation will place all classic queues on a single node. Ideally definition import should make use of the additional `Node` paramater in
https://github.com/rabbitmq/rabbitmq-server/blob/9145b5386d3d7f67ec83b4a93bef35ff11e336b0/deps/rabbit/src/rabbit_definitions.erl#L836-L841 to distribute classic queues across nodes.
Therefore, for now, the simplest option is using `random`.

`random` will distribute classic queues good enough across nodes. Exceptions are rare, e.g.:
* You have a 5 node cluster and exactly 5 queues. In this case `min-masters` ensures that each node hosts a queue, while `random` does not guarantee it. However, for such special cases, the operator can override the value via config or policies.
* You scale out your cluster by adding a node. In this case `min-masters` ensures that new classic queues will be placed on the new node. However, scale outs are very rare given that scale ins (i.e. removing a node) are unsupported.

This commit will therefore allow MQTT use cases by default.