### PR TITLE
Deploy 3.13 by default

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -234,7 +234,7 @@ jobs:
     strategy:
       matrix:
         rabbitmq-image:
-        - rabbitmq:3.9.9-management
+        - rabbitmq:3.11.0-management
         - rabbitmq:management
         - pivotalrabbitmq/rabbitmq:main-otp-min-bazel
         - pivotalrabbitmq/rabbitmq:main-otp-max-bazel
@@ -280,7 +280,7 @@ jobs:
     strategy:
       matrix:
         rabbitmq-image:
-        - rabbitmq:3.9.9-management
+        - rabbitmq:3.11.0-management
         - rabbitmq:management
     steps:
     - name: Install Go
@@ -321,12 +321,12 @@ jobs:
     strategy:
       matrix:
         rabbitmq-image:
-        - rabbitmq:3.9.9-management
+        - rabbitmq:3.11.0-management
         - rabbitmq:management
         - pivotalrabbitmq/rabbitmq:main-otp-min-bazel
         - pivotalrabbitmq/rabbitmq:main-otp-max-bazel
         include:
-        - rabbitmq-image: rabbitmq:3.9.9-management
+        - rabbitmq-image: rabbitmq:3.11.0-management
           gke-cluster: ci-bunny-1
         - rabbitmq-image: rabbitmq:management
           gke-cluster: ci-bunny-1

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -16,8 +16,8 @@ env:
   GO_VERSION: ~1.21
   # Taken from https://github.com/kubernetes-sigs/kind/releases/tag/v0.18.0
   # The image here should be listed under 'Images built for this release' for the version of kind in go.mod
-  KIND_NODE_IMAGE: "kindest/node:v1.26.3@sha256:61b92f38dff6ccc29969e7aa154d34e38b89443af1a2c14e6cfbd2df6419c66f"
-  KIND_OLDEST_NODE_IMAGE: "kindest/node:v1.19.16@sha256:81f552397c1e6c1f293f967ecb1344d8857613fb978f963c30e907c32f598467"
+  KIND_NODE_IMAGE: "kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245"
+  KIND_OLDEST_NODE_IMAGE: "kindest/node:v1.26.3@sha256:61b92f38dff6ccc29969e7aa154d34e38b89443af1a2c14e6cfbd2df6419c66f"
   BASELINE_UPGRADE_VERSION: v2.1.0
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.13.0` by default, and supports versions from `3.9.9` upwards. The operator requires Kubernetes `1.19` or newer.
+The operator deploys RabbitMQ `3.13.1` by default, and supports versions from `3.9.9` upwards. The operator requires Kubernetes `1.19` or newer.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.13.1` by default, and supports versions from `3.9.9` upwards. The operator requires Kubernetes `1.19` or newer.
+The operator deploys RabbitMQ `3.13.1` by default, and should work with [any supported RabbitMQ version](https://www.rabbitmq.com/release-information) and [Kubernetes version](https://kubernetes.io/releases/).
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `3.12.2` by default, and supports versions from `3.9.9` upwards. The operator requires Kubernetes `1.19` or newer.
+The operator deploys RabbitMQ `3.13.0` by default, and supports versions from `3.9.9` upwards. The operator requires Kubernetes `1.19` or newer.
 
 ## Versioning
 

--- a/bin/kubectl-rabbitmq.bats
+++ b/bin/kubectl-rabbitmq.bats
@@ -161,8 +161,8 @@ eventually() {
 @test "enable-all-feature-flags enables all feature flags" {
   kubectl rabbitmq enable-all-feature-flags bats-default
 
-  states=$(kubectl exec bats-default-server-0 -- rabbitmqctl list_feature_flags --silent state --formatter=json)
-  [[ $(jq 'map(select(.state=="disabled")) | length' <<< "$states") -eq 0 ]]
+  states=$(kubectl exec bats-default-server-0 -- rabbitmqctl list_feature_flags --silent state --formatter=json name state stability)
+  [[ $(jq 'map(select(.stability!="experimental" and .state=="disabled")) | length' <<< "$states") -eq 0 ]]
 }
 
 @test "perf-test runs perf-test" {

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func init() {
 func main() {
 	var (
 		metricsAddr             string
-		defaultRabbitmqImage    = "rabbitmq:3.13.0-management"
+		defaultRabbitmqImage    = "rabbitmq:3.13.1-management"
 		controlRabbitmqImage    = false
 		defaultUserUpdaterImage = "rabbitmqoperator/default-user-credential-updater:1.0.2"
 		defaultImagePullSecrets = ""

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func init() {
 func main() {
 	var (
 		metricsAddr             string
-		defaultRabbitmqImage    = "rabbitmq:3.12.2-management"
+		defaultRabbitmqImage    = "rabbitmq:3.13.0-management"
 		controlRabbitmqImage    = false
 		defaultUserUpdaterImage = "rabbitmqoperator/default-user-credential-updater:1.0.2"
 		defaultImagePullSecrets = ""


### PR DESCRIPTION
Bump the default to 3.13.1. Do not mention some old RMQ and Kubernetes versions that likely work, but we surely don't test new Operator versions with them