### PR TITLE
small fix on test_and_publish_OLM_bundle

### DIFF
--- a/.github/workflows/testing_and_publishing_OLM_bundle.yml
+++ b/.github/workflows/testing_and_publishing_OLM_bundle.yml
@@ -42,6 +42,7 @@ jobs:
           run: | 
             BUNDLE_VERSION=${GITHUB_REF#refs/*/} 
             echo "BUNDLE_VERSION=${BUNDLE_VERSION:1}" >> $GITHUB_ENV
+          shell: bash
 
         - name: Set tag image for test version
           if: startsWith(github.ref, 'refs/tags/v') == false


### PR DESCRIPTION
Small fix on test_and_publish_OLM_bundle action workflow.

There is a small issue during the last release: 
https://github.com/rabbitmq/cluster-operator/actions/runs/8539313818/job/23393756084

Basically the sh shell doesn't recognize properly the line:
BUNDLE_VERSION=${BUNDLE_VERSION:1}

giving a bad substitution error.

This should fix this issue.

This PR is also bumping GO to 1.22 and golang.org/x/net to v0.23.0 in order to avoid the new vulnerability issue detected in https://github.com/rabbitmq/cluster-operator/actions/runs/8552381205/job/23433359006

It is also adding some missing crd fields to our CRD after a make manifests.
It maybe related to  https://github.com/rabbitmq/cluster-operator/commit/be674d6b3e5632ccd335360ee87821eaeea0e828
