### PR TITLE
updating cluster operator crd

### DIFF
--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -4794,6 +4794,9 @@ spec:
                                 For example "pki/issue/hashicorp-com".
                                 required
                               type: string
+                            pkiRootPath:
+                              description: Specifies an optional path to retrieve the root CA from vault.  Useful if certificates are issued by an intermediate CA
+                              type: string
                           type: object
                       type: object
                   type: object


### PR DESCRIPTION
The cluster operator crd is currently not updated. 

make manifests is adding the pkiRootPath field. 
This was probably a step missing in:

https://github.com/rabbitmq/cluster-operator/commit/be674d6b3e5632ccd335360ee87821eaeea0e828


