### PR TITLE
Revert docker/build-push-action version due to known issue

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -119,6 +119,7 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
     - name: Build and push
+      # Do not bump below action version (Known issue - https://github.com/docker/build-push-action/issues/820)
       uses: docker/build-push-action@v3
       with:
         context: .
@@ -144,6 +145,7 @@ jobs:
     - name: Build and push single-arch amd64 image
       if: github.event_name != 'pull_request'
       #if: startsWith(github.ref, 'refs/tags/v')
+      # Do not bump below action version (Known issue - https://github.com/docker/build-push-action/issues/820)
       uses: docker/build-push-action@v3
       with:
         context: .
@@ -169,6 +171,7 @@ jobs:
     - name: Build and push single-arch arm64 image
       if: github.event_name != 'pull_request'
       #if: startsWith(github.ref, 'refs/tags/v')
+      # Do not bump below action version (Known issue - https://github.com/docker/build-push-action/issues/820)
       uses: docker/build-push-action@v3
       with:
         context: .

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -119,7 +119,7 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
     - name: Build and push
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v3
       with:
         context: .
         platforms: linux/amd64, linux/arm64, linux/ppc64le, linux/s390x
@@ -144,7 +144,7 @@ jobs:
     - name: Build and push single-arch amd64 image
       if: github.event_name != 'pull_request'
       #if: startsWith(github.ref, 'refs/tags/v')
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v3
       with:
         context: .
         platforms: linux/amd64
@@ -169,7 +169,7 @@ jobs:
     - name: Build and push single-arch arm64 image
       if: github.event_name != 'pull_request'
       #if: startsWith(github.ref, 'refs/tags/v')
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v3
       with:
         context: .
         platforms: linux/arm64


### PR DESCRIPTION
Version 5 of docker/build-push-action produces `unknown` architecture and os in manifest