### PR TITLE
small fix on testing_and_publishing_OLM_bundle action

### DIFF
--- a/.github/workflows/testing_and_publishing_OLM_bundle.yml
+++ b/.github/workflows/testing_and_publishing_OLM_bundle.yml
@@ -164,6 +164,7 @@ jobs:
           run: | 
             BUNDLE_VERSION=${GITHUB_REF#refs/*/} 
             echo "BUNDLE_VERSION=${BUNDLE_VERSION:1}" >> $GITHUB_ENV
+          shell: bash
 
         - name: Set tag image for test version
           if: startsWith(github.ref, 'refs/tags/v') == false
@@ -185,7 +186,7 @@ jobs:
             cd community-operators/operators/rabbitmq-cluster-operator
             git branch rabbitmq-cluster-operator-$BUNDLE_VERSION
             git checkout rabbitmq-cluster-operator-$BUNDLE_VERSION
-            REPLACE_VERSION=$(ls | sort -n | tail -1)
+            REPLACE_VERSION=$(ls -1v | tail -2 | head -1)
             cp -fR ./../../../$BUNDLE_VERSION .  
             sed -i -e "s/replaces: null/replaces: rabbitmq-cluster-operator.v$REPLACE_VERSION/g" ./$BUNDLE_VERSION/manifests/rabbitmq.clusterserviceversion.yaml 
             sed -i -e "s/latest/$BUNDLE_VERSION/g" ./$BUNDLE_VERSION/manifests/rabbitmq.clusterserviceversion.yaml 
@@ -203,7 +204,7 @@ jobs:
             cd community-operators-prod/operators/rabbitmq-cluster-operator
             git branch rabbitmq-cluster-operator-$BUNDLE_VERSION
             git checkout rabbitmq-cluster-operator-$BUNDLE_VERSION
-            REPLACE_VERSION=$(ls | sort -n  | tail -1)
+            REPLACE_VERSION=$(ls -1v | tail -2 | head -1)
             cp -fR ./../../../$BUNDLE_VERSION-openshift .
             mv $BUNDLE_VERSION-openshift $BUNDLE_VERSION
             sed -i -e "s/replaces: null/replaces: rabbitmq-cluster-operator.v$REPLACE_VERSION/g" ./$BUNDLE_VERSION/manifests/rabbitmq.clusterserviceversion.yaml 


### PR DESCRIPTION
Similarly to: https://github.com/rabbitmq/cluster-operator/pull/1603

This is solving a small issue happening in the last released (changing shell to bash), plus a small correction in the way we compute the replace field operator to solve:

https://github.com/rabbitmq/cluster-operator/actions/runs/9056466175
