### PR TITLE
force string for resource attributes in examples

### DIFF
--- a/docs/examples/production-ready/rabbitmq.yaml
+++ b/docs/examples/production-ready/rabbitmq.yaml
@@ -6,10 +6,10 @@ spec:
   replicas: 3
   resources:
     requests:
-      cpu: 4
+      cpu: 4000m
       memory: 10Gi
     limits:
-      cpu: 4
+      cpu: 4000m
       memory: 10Gi
   rabbitmq:
     additionalConfig: |


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

This fixes the datatype of the resource attributes in the production ready example. Otherwise this example will cause CD tools like Flux, to constantly update the resource and change it back to a numeric value.
Since the `production-ready` example is rather prominently mentioned in the docs, I think it might make sense to provide an example that doesn't trigger changes by CD tools (even though using a numeric is allowed).
