### PR TITLE
WIP: Action to sync the helm chart

### DIFF
--- a/.github/workflows/update_helm_chart.yml
+++ b/.github/workflows/update_helm_chart.yml
@@ -3,13 +3,12 @@
 name: update_helm_chart
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+    - action_to_sync_helm_chart
     
   workflow_dispatch:
-
-env:
-
+    
 jobs:
     create-chart-pr:
         name: Create pull request to char repo
@@ -21,27 +20,43 @@ jobs:
           uses: actions/checkout@v4
           with:
             repository: rabbitmq-pro/tanzu-rabbitmq-operator-chart
+            ref: adding_sync_operators_action_scripts
             token: ${{ secrets.GIT_HUB_INFRA_REPO_ACCESS_TOKEN }}
             path: ./tanzu-rabbitmq-operator-chart
 
-        - name: Update helm released version and CRD
-          run: |   
+        - name: Set tag image for tagged version
+          if: startsWith(github.ref, 'refs/tags/v')
+          run: | 
             BUNDLE_VERSION=${GITHUB_REF#refs/*/} 
-            BUNDLE_VERSION=${BUNDLE_VERSION:1}
+            echo "BUNDLE_VERSION=${BUNDLE_VERSION:1}" >> $GITHUB_ENV
+  
+        # For manual testing
+        - name: Set tag image for test version
+          if: startsWith(github.ref, 'refs/tags/v') == false
+          run: | 
+            echo "BUNDLE_VERSION=2.9.0" >> $GITHUB_ENV
+
+        - name: Update helm released version and CRD - test
+          env:
+            GH_TOKEN: ${{ secrets.GIT_HUB_INFRA_REPO_ACCESS_TOKEN }}
+            BUNDLE_VERSION: ${{ env.BUNDLE_VERSION }}
+          run: | 
             cd ./tanzu-rabbitmq-operator-chart
-            git branch update_crd_and_version
-            git checkout update_crd_and_version
-            cp ./../config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml ./tanzu-rabbitmq-operator-chart/crds/rabbitmq-cluster/
-            sed -i '' 's/cluster-operator:.*/cluster-operator:$BUNDLE_VERSION/' ./Chart.yaml
-            python3 ./scripts/update_cluster_operator_clusterrole.py ./scripts/generators/rabbitmq-cluster-operator/clusterrole.yml ./scripts/generators/rabbitmq-cluster-operator/clusterrole-generator.yml 
-            cp ./scripts/generators/rabbitmq-cluster-operator/clusterrole-generator.yml  ./../templates/cluster-operator/clusterrole.yaml 
+            git config --global user.name "rabbitmq-ci"
+            git config --global user.email rabbitmq-ci@vmware.com
+            git branch rabbitmq_cluster_operator_update_crd_and_versions_$BUNDLE_VERSION
+            git checkout rabbitmq_cluster_operator_update_crd_and_versions_$BUNDLE_VERSION
+            cp ./../config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml ./crds/rabbitmq-cluster/
+            sed -i -e "s/cluster-operator:.*/cluster-operator:$BUNDLE_VERSION/" ./Chart.yaml
+            pip3 install pytest
+            python3 ./scripts/update_cluster_operator_clusterrole.py ./../config/rbac/role.yaml ./scripts/generators/rabbitmq-cluster-operator/clusterrole-generator.yml 
+            python3 ./scripts/update_cluster_operator_value_version.py ./values.yaml "rabbitmqoperator/cluster-operator" $BUNDLE_VERSION
+            cp ./scripts/generators/rabbitmq-cluster-operator/clusterrole-generator.yml  ./templates/cluster-operator/clusterrole.yaml 
             git checkout ./scripts/generators/rabbitmq-cluster-operator/clusterrole-generator.yml
             git add .
             git commit -m "Updating RabbitMQ cluster operator version and CRD"
-
-        - name: Create Pull Request
-          uses: peter-evans/create-pull-request@v6
-
+            git push --force origin rabbitmq_cluster_operator_update_crd_and_versions_$BUNDLE_VERSION
+#gh pr create --title "RabbitMQ cluster operator: Update versions, CRD and clusterrole" --body "RabbitMQ cluster operator: Update image versions, CRD and clusterrole" --base main
 
 
 

--- a/.github/workflows/update_helm_chart.yml
+++ b/.github/workflows/update_helm_chart.yml
@@ -1,0 +1,49 @@
+# This action updates operator version, CRD, and clusterrole in our helm chart
+# For more information see https://github.com/rabbitmq-pro/tanzu-rabbitmq-operator-chart
+name: update_helm_chart
+
+on:
+  release:
+    types: [published]
+    
+  workflow_dispatch:
+
+env:
+
+jobs:
+    create-chart-pr:
+        name: Create pull request to char repo
+        runs-on: ubuntu-latest
+        steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Checkout helm repo
+          uses: actions/checkout@v4
+          with:
+            repository: rabbitmq-pro/tanzu-rabbitmq-operator-chart
+            token: ${{ secrets.GIT_HUB_INFRA_REPO_ACCESS_TOKEN }}
+            path: ./tanzu-rabbitmq-operator-chart
+
+        - name: Update helm released version and CRD
+          run: |   
+            BUNDLE_VERSION=${GITHUB_REF#refs/*/} 
+            BUNDLE_VERSION=${BUNDLE_VERSION:1}
+            cd ./tanzu-rabbitmq-operator-chart
+            git branch update_crd_and_version
+            git checkout update_crd_and_version
+            cp ./../config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml ./tanzu-rabbitmq-operator-chart/crds/rabbitmq-cluster/
+            sed -i '' 's/cluster-operator:.*/cluster-operator:$BUNDLE_VERSION/' ./Chart.yaml
+            python3 ./scripts/update_cluster_operator_clusterrole.py ./scripts/generators/rabbitmq-cluster-operator/clusterrole.yml ./scripts/generators/rabbitmq-cluster-operator/clusterrole-generator.yml 
+            cp ./scripts/generators/rabbitmq-cluster-operator/clusterrole-generator.yml  ./../templates/cluster-operator/clusterrole.yaml 
+            git checkout ./scripts/generators/rabbitmq-cluster-operator/clusterrole-generator.yml
+            git add .
+            git commit -m "Updating RabbitMQ cluster operator version and CRD"
+
+        - name: Create Pull Request
+          uses: peter-evans/create-pull-request@v6
+
+
+
+
+
+            


### PR DESCRIPTION
## Summary Of Changes

This action triggered on a new operator release will submit a PR to our helm-chart commercial repo in order to keep the image versions, crds and clusterrole updated.

It is using some internal python scripts in order to manage the update.

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
