### PR TITLE
Support override default topologySpreadContraints

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -298,6 +298,14 @@ func patchPodSpec(podSpec, podSpecOverride *corev1.PodSpec) (corev1.PodSpec, err
 		}
 	}
 
+	// A user can may wish to override the default TopologySpreadConstraints. To remove the default constraints without adding new ones,
+	// set this to an empty array. To append to the default constraint is not supported, the user should put it explicitly in the override.
+	// As the merge key for the TopologySpreadConstraints is the TopologyKey there is no way to remove it with the `strategicpatch.StrategicMergePatch`.
+	// When a user wants to overwrite these topology constraints it can be assumed that the default will not be used, besides, in a rare case
+	// when appending the default is needed, then, to put it explicitly in the override is not a big deal.
+	if podSpecOverride.TopologySpreadConstraints != nil {
+		patchedPodSpec.TopologySpreadConstraints = podSpecOverride.TopologySpreadConstraints
+	}
 	return patchedPodSpec, nil
 }
 


### PR DESCRIPTION
Allow a user to override the default TopologySpreadConstraints. Appending to the default constraint is not supported, so the user should put it explicitly in the override. In a rare case, when appending the default is needed, putting it explicitly in the override is not a big deal.

This closes #1687 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
