### PR TITLE
Add rabbitmq.com/disable-default-topology-spread-constraints annotation

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -21,6 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const DisableDefaultTopologySpreadAnnotation = "rabbitmq.com/disable-default-topology-spread-constraints"
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AllReplicasReady",type="string",JSONPath=".status.conditions[?(@.type == 'AllReplicasReady')].status"
@@ -504,6 +506,14 @@ func (cluster RabbitmqCluster) ChildResourceName(name string) string {
 
 func (cluster RabbitmqCluster) PVCName(i int) string {
 	return strings.Join([]string{"persistence", cluster.Name, "server", strconv.Itoa(i)}, "-")
+}
+
+func (cluster RabbitmqCluster) DisableDefaultTopologySpreadConstraints() bool {
+	value, ok := cluster.Annotations[DisableDefaultTopologySpreadAnnotation]
+	if ok && strings.TrimSpace(value) == "true" {
+		return true
+	}
+	return false
 }
 
 func init() {


### PR DESCRIPTION
When the annotation rabbitmq.com/disable-default-topology-spread-constraints is set to "true", the default topologySpreadConstraints based on label topology.kubernetes.io/zone is omitted.

As  @Zerpet suggested in issue #1687, I added the annotation to skip the default topology constraint configuration because the override was not working as expected ( #1690 ), and @mkuratczyk was not satisfied with the behavior.

This closes #1687

**Note to reviewers:** Remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

When a user adds the annotation  `rabbitmq.com/disable-default-topology-spread-constraints: "true"` in their RabbitMQCluster custom resource, the default topology spread constraint is omitted.

## Additional Context



## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
