### PR TITLE
Disable ANONYMOUS login

### DIFF
--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -180,8 +180,8 @@ var _ = Describe("GenerateServerConfigMap", func() {
 
 					Expect(configMapBuilder.Update(configMap)).To(Succeed())
 					Expect(configMap.Data).To(HaveKeyWithValue("userDefinedConfiguration.conf", expectedConfiguration))
-					operatorDefaults, exists := configMap.Data["operatorDefaults.conf"]
-					Expect(exists).To(BeTrue())
+					Expect(configMap.Data).To(HaveKey("operatorDefaults.conf"))
+					operatorDefaults := configMap.Data["operatorDefaults.conf"]
 					Expect(operatorDefaults).NotTo(ContainSubstring("auth_mechanisms"))
 					Expect(operatorDefaults).NotTo(ContainSubstring("PLAIN"))
 					Expect(operatorDefaults).NotTo(ContainSubstring("ANONYMOUS"))


### PR DESCRIPTION
See https://github.com/rabbitmq/rabbitmq-server/pull/11999 for full context.

Starting with RabbitMQ 4.0, anonymous login should be disabled in production.

`anonymous_login_user` and `anonymous_login_pass` both default to `guest` in RabbitMQ 4.0. The rabbitmq/cluster-operator complies already with best practices by provisioning a new `default_user` and `default_pass` instead of using RabbitMQ's default `guest` user.
Instead of having RabbitMQ advertise the ANONYMOUS mechanism, this commit disables anonymous logins.

Because `anonymous_login_user` is a new RabbitMQ 4.0 `rabbitmq.conf` setting and the cluster-operator doesn't know what RabbitMQ version it deploys and setting `rabbitmq.conf` key `anonymous_login_user` in RabbitMQ 3.13 would make booting RabbitMQ fail, this commit modifies the `auth_mechanisms.*` settings in `rabbitmq.conf`:
If the user provided a conscious choice on what `auth_mechanisms` RabbitMQ should advertise, this configuration will be respected. If the user did not configure `auth_mechanisms`, the cluster-operator will disable ANONYMOUS logins by setting only:
```
auth_mechanisms.1 = PLAIN
auth_mechanisms.2 = AMQPLAIN
```