### PR TITLE
Increase max length of additionalConfig

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -383,7 +383,7 @@ type RabbitmqClusterConfigurationSpec struct {
 	// Modify to add to the rabbitmq.conf file in addition to default configurations set by the operator.
 	// Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime.
 	// For more information on this config, see https://www.rabbitmq.com/configure.html#config-file
-	// +kubebuilder:validation:MaxLength:=2000
+	// +kubebuilder:validation:MaxLength:=100000
 	AdditionalConfig string `json:"additionalConfig,omitempty"`
 	// Specify any rabbitmq advanced.config configurations to apply to the cluster.
 	// For more information on advanced config, see https://www.rabbitmq.com/configure.html#advanced-config-file

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -4886,7 +4886,7 @@ spec:
                         Modify to add to the rabbitmq.conf file in addition to default configurations set by the operator.
                         Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime.
                         For more information on this config, see https://www.rabbitmq.com/configure.html#config-file
-                      maxLength: 2000
+                      maxLength: 100000
                       type: string
                     additionalPlugins:
                       description: 'List of plugins to enable in addition to essential plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s.'


### PR DESCRIPTION
A maximum string lenth of 2,000 was too restrictive. The new limit of 100,000 matches the limit of `advancedConfig`.

Resolves #1707