### PR TITLE
Fix linter errors

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -16,7 +16,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -107,8 +106,8 @@ type RabbitmqClusterSpec struct {
 // Future secret backends could be Secrets Store CSI Driver.
 // If not configured, K8s Secrets will be used.
 type SecretBackend struct {
-	Vault          *VaultSpec              `json:"vault,omitempty"`
-	ExternalSecret v1.LocalObjectReference `json:"externalSecret,omitempty"`
+	Vault          *VaultSpec                  `json:"vault,omitempty"`
+	ExternalSecret corev1.LocalObjectReference `json:"externalSecret,omitempty"`
 }
 
 // VaultSpec will add Vault annotations (see https://www.vaultproject.io/docs/platform/k8s/injector/annotations)
@@ -500,15 +499,15 @@ type RabbitmqClusterList struct {
 	Items []RabbitmqCluster `json:"items"`
 }
 
-func (cluster RabbitmqCluster) ChildResourceName(name string) string {
+func (cluster *RabbitmqCluster) ChildResourceName(name string) string {
 	return strings.TrimSuffix(strings.Join([]string{cluster.Name, name}, "-"), "-")
 }
 
-func (cluster RabbitmqCluster) PVCName(i int) string {
+func (cluster *RabbitmqCluster) PVCName(i int) string {
 	return strings.Join([]string{"persistence", cluster.Name, "server", strconv.Itoa(i)}, "-")
 }
 
-func (cluster RabbitmqCluster) DisableDefaultTopologySpreadConstraints() bool {
+func (cluster *RabbitmqCluster) DisableDefaultTopologySpreadConstraints() bool {
 	value, ok := cluster.Annotations[DisableDefaultTopologySpreadAnnotation]
 	if ok && strings.TrimSpace(value) == "true" {
 		return true

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rabbitmq/cluster-operator/v2/internal/status"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -26,7 +25,6 @@ import (
 )
 
 var _ = Describe("RabbitmqCluster", func() {
-
 	Context("RabbitmqClusterSpec", func() {
 		It("can be created with a single replica", func() {
 			created := generateRabbitmqClusterObject("rabbit1")
@@ -69,11 +67,11 @@ var _ = Describe("RabbitmqCluster", func() {
 		It("can be created with resource requests", func() {
 			created := generateRabbitmqClusterObject("rabbit-resource-request")
 			created.Spec.Resources = &corev1.ResourceRequirements{
-				Limits: map[corev1.ResourceName]resource.Quantity{
+				Limits: map[corev1.ResourceName]k8sresource.Quantity{
 					corev1.ResourceCPU:    k8sresource.MustParse("100m"),
 					corev1.ResourceMemory: k8sresource.MustParse("100Mi"),
 				},
-				Requests: map[corev1.ResourceName]resource.Quantity{
+				Requests: map[corev1.ResourceName]k8sresource.Quantity{
 					corev1.ResourceCPU:    k8sresource.MustParse("100m"),
 					corev1.ResourceMemory: k8sresource.MustParse("100Mi"),
 				},
@@ -116,7 +114,7 @@ var _ = Describe("RabbitmqCluster", func() {
 			Expect(created.MemoryLimited()).To(BeTrue())
 
 			created.Spec.Resources = &corev1.ResourceRequirements{
-				Limits: map[corev1.ResourceName]resource.Quantity{},
+				Limits: map[corev1.ResourceName]k8sresource.Quantity{},
 			}
 			Expect(created.MemoryLimited()).To(BeFalse())
 		})
@@ -464,11 +462,11 @@ var _ = Describe("RabbitmqCluster", func() {
 			statefulset.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Resources: corev1.ResourceRequirements{
-						Limits: map[corev1.ResourceName]resource.Quantity{
-							"memory": resource.MustParse("100Mi"),
+						Limits: map[corev1.ResourceName]k8sresource.Quantity{
+							"memory": k8sresource.MustParse("100Mi"),
 						},
-						Requests: map[corev1.ResourceName]resource.Quantity{
-							"memory": resource.MustParse("100Mi"),
+						Requests: map[corev1.ResourceName]k8sresource.Quantity{
+							"memory": k8sresource.MustParse("100Mi"),
 						},
 					},
 				},

--- a/controllers/rabbitmqcluster_controller.go
+++ b/controllers/rabbitmqcluster_controller.go
@@ -135,7 +135,7 @@ func (r *RabbitmqClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	tlsErr := r.reconcileTLS(ctx, rabbitmqCluster)
-	if errors.Is(tlsErr, disableNonTLSConfigErr) {
+	if errors.Is(tlsErr, errDisableNonTLSConfig) {
 		return ctrl.Result{}, nil
 	} else if tlsErr != nil {
 		return ctrl.Result{}, tlsErr

--- a/controllers/reconcile_tls.go
+++ b/controllers/reconcile_tls.go
@@ -13,16 +13,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var disableNonTLSConfigErr = errors.New("TLS must be enabled if disableNonTLSListeners is set to true")
+var errDisableNonTLSConfig = errors.New("TLS must be enabled if disableNonTLSListeners is set to true")
 
 func (r *RabbitmqClusterReconciler) reconcileTLS(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
 	// if tls.disableNonTLSListeners set to true and TLS is not enabled, it's a configuration error
 	// reconcileTLS() will return a special error so the operator won't requeue
 	if rabbitmqCluster.DisableNonTLSListeners() && !rabbitmqCluster.TLSEnabled() {
-		r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError", disableNonTLSConfigErr.Error())
-		ctrl.LoggerFrom(ctx).Error(disableNonTLSConfigErr, "Error setting up TLS")
-		r.setReconcileSuccess(ctx, rabbitmqCluster, corev1.ConditionFalse, "TLSError", disableNonTLSConfigErr.Error())
-		return disableNonTLSConfigErr
+		r.Recorder.Event(rabbitmqCluster, corev1.EventTypeWarning, "TLSError", errDisableNonTLSConfig.Error())
+		ctrl.LoggerFrom(ctx).Error(errDisableNonTLSConfig, "Error setting up TLS")
+		r.setReconcileSuccess(ctx, rabbitmqCluster, corev1.ConditionFalse, "TLSError", errDisableNonTLSConfig.Error())
+		return errDisableNonTLSConfig
 	}
 
 	if rabbitmqCluster.SecretTLSEnabled() {

--- a/internal/resource/default_user_secret_test.go
+++ b/internal/resource/default_user_secret_test.go
@@ -12,7 +12,6 @@ package resource_test
 import (
 	b64 "encoding/base64"
 	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
@@ -20,7 +19,6 @@ import (
 	"gopkg.in/ini.v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
 )
@@ -39,7 +37,7 @@ var _ = Describe("DefaultUserSecret", func() {
 		Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
 		Expect(defaultscheme.AddToScheme(scheme)).To(Succeed())
 		instance = rabbitmqv1beta1.RabbitmqCluster{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "a name",
 				Namespace: "a namespace",
 			},

--- a/internal/resource/erlang_cookie_test.go
+++ b/internal/resource/erlang_cookie_test.go
@@ -11,12 +11,10 @@ package resource_test
 
 import (
 	b64 "encoding/base64"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,7 +37,7 @@ var _ = Describe("ErlangCookie", func() {
 		Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
 		Expect(defaultscheme.AddToScheme(scheme)).To(Succeed())
 		instance = rabbitmqv1beta1.RabbitmqCluster{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "a name",
 				Namespace: "a namespace",
 			},

--- a/internal/resource/rabbitmq_plugins_test.go
+++ b/internal/resource/rabbitmq_plugins_test.go
@@ -13,11 +13,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
-	"github.com/rabbitmq/cluster-operator/v2/internal/resource"
-	. "github.com/rabbitmq/cluster-operator/v2/internal/resource"
+	rmqresource "github.com/rabbitmq/cluster-operator/v2/internal/resource"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
 )
@@ -27,7 +25,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 	Context("DesiredPlugins", func() {
 		When("AdditionalPlugins is empty", func() {
 			It("returns list of required plugins", func() {
-				plugins := NewRabbitmqPlugins(nil)
+				plugins := rmqresource.NewRabbitmqPlugins(nil)
 				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s", "rabbitmq_prometheus", "rabbitmq_management"}))
 			})
 		})
@@ -35,7 +33,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 		When("AdditionalPlugins are provided", func() {
 			It("returns a concatenated list of plugins", func() {
 				morePlugins := []rabbitmqv1beta1.Plugin{"rabbitmq_shovel", "my_great_plugin"}
-				plugins := NewRabbitmqPlugins(morePlugins)
+				plugins := rmqresource.NewRabbitmqPlugins(morePlugins)
 
 				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s",
 					"rabbitmq_prometheus",
@@ -49,7 +47,7 @@ var _ = Describe("RabbitMQPlugins", func() {
 		When("AdditionalPlugins are provided with duplicates", func() {
 			It("returns a unique list of plugins", func() {
 				morePlugins := []rabbitmqv1beta1.Plugin{"rabbitmq_management", "rabbitmq_shovel", "my_great_plugin", "rabbitmq_shovel"}
-				plugins := NewRabbitmqPlugins(morePlugins)
+				plugins := rmqresource.NewRabbitmqPlugins(morePlugins)
 
 				Expect(plugins.DesiredPlugins()).To(ConsistOf([]string{"rabbitmq_peer_discovery_k8s",
 					"rabbitmq_prometheus",
@@ -64,8 +62,8 @@ var _ = Describe("RabbitMQPlugins", func() {
 	Context("PluginsConfigMap", func() {
 		var (
 			instance         rabbitmqv1beta1.RabbitmqCluster
-			configMapBuilder *resource.RabbitmqPluginsConfigMapBuilder
-			builder          *resource.RabbitmqResourceBuilder
+			configMapBuilder *rmqresource.RabbitmqPluginsConfigMapBuilder
+			builder          *rmqresource.RabbitmqResourceBuilder
 			scheme           *runtime.Scheme
 		)
 
@@ -74,12 +72,12 @@ var _ = Describe("RabbitMQPlugins", func() {
 			Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
 			Expect(defaultscheme.AddToScheme(scheme)).To(Succeed())
 			instance = rabbitmqv1beta1.RabbitmqCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "a name",
 					Namespace: "a namespace",
 				},
 			}
-			builder = &resource.RabbitmqResourceBuilder{
+			builder = &rmqresource.RabbitmqResourceBuilder{
 				Instance: &instance,
 				Scheme:   scheme,
 			}

--- a/internal/resource/rabbitmq_resource_builder_test.go
+++ b/internal/resource/rabbitmq_resource_builder_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/v2/internal/resource"
-	. "github.com/rabbitmq/cluster-operator/v2/internal/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
@@ -49,17 +48,17 @@ var _ = Describe("RabbitmqResourceBuilder", func() {
 
 			Expect(resourceBuilders).To(HaveLen(10))
 
-			expectedBuildersInOrder := []ResourceBuilder{
-				&HeadlessServiceBuilder{},
-				&ServiceBuilder{},
-				&ErlangCookieBuilder{},
-				&DefaultUserSecretBuilder{},
-				&RabbitmqPluginsConfigMapBuilder{},
-				&ServerConfigMapBuilder{},
-				&ServiceAccountBuilder{},
-				&RoleBuilder{},
-				&RoleBindingBuilder{},
-				&StatefulSetBuilder{},
+			expectedBuildersInOrder := []resource.ResourceBuilder{
+				&resource.HeadlessServiceBuilder{},
+				&resource.ServiceBuilder{},
+				&resource.ErlangCookieBuilder{},
+				&resource.DefaultUserSecretBuilder{},
+				&resource.RabbitmqPluginsConfigMapBuilder{},
+				&resource.ServerConfigMapBuilder{},
+				&resource.ServiceAccountBuilder{},
+				&resource.RoleBuilder{},
+				&resource.RoleBindingBuilder{},
+				&resource.StatefulSetBuilder{},
 			}
 
 			for i, resourceBuilder := range resourceBuilders {
@@ -77,7 +76,7 @@ var _ = Describe("RabbitmqResourceBuilder", func() {
 			It("returns all resource builders except for defaultUser K8s Secret", func() {
 				resourceBuilders := builder.ResourceBuilders()
 				Expect(resourceBuilders).To(HaveLen(9))
-				Expect(resourceBuilders).NotTo(ContainElement(BeAssignableToTypeOf(&DefaultUserSecretBuilder{})))
+				Expect(resourceBuilders).NotTo(ContainElement(BeAssignableToTypeOf(&resource.DefaultUserSecretBuilder{})))
 			})
 		})
 	})

--- a/internal/resource/role_binding_test.go
+++ b/internal/resource/role_binding_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rabbitmq/cluster-operator/v2/internal/resource"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
 )
@@ -35,7 +34,7 @@ var _ = Describe("RoleBinding", func() {
 		Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
 		Expect(defaultscheme.AddToScheme(scheme)).To(Succeed())
 		instance = rabbitmqv1beta1.RabbitmqCluster{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "a name",
 				Namespace: "a namespace",
 			},

--- a/internal/resource/role_test.go
+++ b/internal/resource/role_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rabbitmq/cluster-operator/v2/internal/resource"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
 )
@@ -35,7 +34,7 @@ var _ = Describe("Role", func() {
 		Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
 		Expect(defaultscheme.AddToScheme(scheme)).To(Succeed())
 		instance = rabbitmqv1beta1.RabbitmqCluster{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "a name",
 				Namespace: "a namespace",
 			},

--- a/internal/resource/service_account_test.go
+++ b/internal/resource/service_account_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rabbitmq/cluster-operator/v2/internal/resource"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
 )
@@ -35,7 +34,7 @@ var _ = Describe("ServiceAccount", func() {
 		Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
 		Expect(defaultscheme.AddToScheme(scheme)).To(Succeed())
 		instance = rabbitmqv1beta1.RabbitmqCluster{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "a name",
 				Namespace: "a namespace",
 			},

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rabbitmq/cluster-operator/v2/internal/resource"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
@@ -875,7 +874,7 @@ var _ = Context("Services", func() {
 
 func updateServiceWithAnnotations(rmqBuilder resource.RabbitmqResourceBuilder, instanceAnnotations, serviceAnnotations map[string]string) *corev1.Service {
 	instance := &rabbitmqv1beta1.RabbitmqCluster{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:        "foo",
 			Namespace:   "foo-namespace",
 			Annotations: instanceAnnotations,

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -19,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	defaultscheme "k8s.io/client-go/kubernetes/scheme"
@@ -113,7 +112,7 @@ var _ = Describe("StatefulSet", func() {
 				statefulSet := obj.(*appsv1.StatefulSet)
 
 				expectedPersistentVolumeClaim := corev1.PersistentVolumeClaim{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "persistence",
 						Namespace: instance.Namespace,
 						Labels: map[string]string{
@@ -121,7 +120,7 @@ var _ = Describe("StatefulSet", func() {
 							"app.kubernetes.io/component": "rabbitmq",
 							"app.kubernetes.io/part-of":   "rabbitmq",
 						},
-						OwnerReferences: []v1.OwnerReference{
+						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "rabbitmq.com/v1beta1",
 								Kind:               "RabbitmqCluster",
@@ -1546,7 +1545,7 @@ default_pass = {{ .Data.data.password }}
 
 			statefulSet.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "persistence",
 						Namespace: instance.Namespace,
 					},
@@ -1778,7 +1777,7 @@ default_pass = {{ .Data.data.password }}
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "pert-1",
 							Namespace: "foo-namespace",
-							OwnerReferences: []v1.OwnerReference{
+							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "rabbitmq.com/v1beta1",
 									Kind:               "RabbitmqCluster",
@@ -1802,7 +1801,7 @@ default_pass = {{ .Data.data.password }}
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "pert-2",
 							Namespace: "foo-namespace",
-							OwnerReferences: []v1.OwnerReference{
+							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "rabbitmq.com/v1beta1",
 									Kind:               "RabbitmqCluster",
@@ -1867,7 +1866,7 @@ default_pass = {{ .Data.data.password }}
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "pert-1",
 							Namespace: "foo-namespace",
-							OwnerReferences: []v1.OwnerReference{
+							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "rabbitmq.com/v1beta1",
 									Kind:               "RabbitmqCluster",
@@ -1891,7 +1890,7 @@ default_pass = {{ .Data.data.password }}
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "pert-2",
 							Namespace: "foo-namespace",
-							OwnerReferences: []v1.OwnerReference{
+							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "rabbitmq.com/v1beta1",
 									Kind:               "RabbitmqCluster",
@@ -2450,7 +2449,7 @@ func extractProjectedSecret(volume corev1.Volume, secretName string) corev1.Volu
 func generateRabbitmqCluster() rabbitmqv1beta1.RabbitmqCluster {
 	storage := k8sresource.MustParse("10Gi")
 	return rabbitmqv1beta1.RabbitmqCluster{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "foo-namespace",
 		},

--- a/internal/scaling/scaling_suite_test.go
+++ b/internal/scaling/scaling_suite_test.go
@@ -74,16 +74,16 @@ func generatePVC(rmq rabbitmqv1beta1.RabbitmqCluster, index int, size k8sresourc
 	}
 }
 
-type ActionMatcher struct {
+type actionMatcher struct {
 	expectedVerb         string
 	expectedResourceType string
 	expectedNamespace    string
 	actualAction         k8stesting.Action
 }
 
-func BeGetActionOnResource(expectedResourceType, expectedResourceName, expectedNamespace string) types.GomegaMatcher {
-	return &GetActionMatcher{
-		ActionMatcher{
+func beGetActionOnResource(expectedResourceType, expectedResourceName, expectedNamespace string) types.GomegaMatcher {
+	return &getActionMatcher{
+		actionMatcher{
 			expectedVerb:         "get",
 			expectedResourceType: expectedResourceType,
 			expectedNamespace:    expectedNamespace,
@@ -92,15 +92,15 @@ func BeGetActionOnResource(expectedResourceType, expectedResourceName, expectedN
 	}
 }
 
-type GetActionMatcher struct {
-	ActionMatcher
+type getActionMatcher struct {
+	actionMatcher
 	expectedResourceName string
 }
 
-func (matcher *GetActionMatcher) Match(actual interface{}) (bool, error) {
+func (matcher *getActionMatcher) Match(actual interface{}) (bool, error) {
 	genericAction, ok := actual.(k8stesting.Action)
 	if !ok {
-		return false, fmt.Errorf("BeGetActionOnResource must be passed an Action from the fakeClientset")
+		return false, fmt.Errorf("beGetActionOnResource must be passed an Action from the fakeClientset")
 	}
 	matcher.actualAction = genericAction
 
@@ -113,19 +113,19 @@ func (matcher *GetActionMatcher) Match(actual interface{}) (bool, error) {
 		action.GetName() == matcher.expectedResourceName, nil
 }
 
-func (matcher *GetActionMatcher) FailureMessage(actual interface{}) string {
+func (matcher *getActionMatcher) FailureMessage(actual interface{}) string {
 	return fmt.Sprintf("Expected '%s' on resource '%s' named '%s' in namespace '%s' to match the observed action:\n%+v\n",
 		matcher.expectedVerb, matcher.expectedResourceType, matcher.expectedResourceName, matcher.expectedNamespace, matcher.actualAction)
 }
 
-func (matcher *GetActionMatcher) NegatedFailureMessage(actual interface{}) string {
+func (matcher *getActionMatcher) NegatedFailureMessage(actual interface{}) string {
 	return fmt.Sprintf("Expected '%s' on resource '%s' named '%s' in namespace '%s' not to match the observed action:\n%+v\n",
 		matcher.expectedVerb, matcher.expectedResourceType, matcher.expectedResourceName, matcher.expectedNamespace, matcher.actualAction)
 }
 
-func BeDeleteActionOnResource(expectedResourceType, expectedResourceName, expectedNamespace string) types.GomegaMatcher {
-	return &DeleteActionMatcher{
-		ActionMatcher{
+func beDeleteActionOnResource(expectedResourceType, expectedResourceName, expectedNamespace string) types.GomegaMatcher {
+	return &deleteActionMatcher{
+		actionMatcher{
 			expectedVerb:         "delete",
 			expectedResourceType: expectedResourceType,
 			expectedNamespace:    expectedNamespace,
@@ -134,15 +134,15 @@ func BeDeleteActionOnResource(expectedResourceType, expectedResourceName, expect
 	}
 }
 
-type DeleteActionMatcher struct {
-	ActionMatcher
+type deleteActionMatcher struct {
+	actionMatcher
 	expectedResourceName string
 }
 
-func (matcher *DeleteActionMatcher) Match(actual interface{}) (bool, error) {
+func (matcher *deleteActionMatcher) Match(actual interface{}) (bool, error) {
 	genericAction, ok := actual.(k8stesting.Action)
 	if !ok {
-		return false, fmt.Errorf("BeDeleteActionOnResource must be passed an Action from the fakeClientset")
+		return false, fmt.Errorf("beDeleteActionOnResource must be passed an Action from the fakeClientset")
 	}
 	matcher.actualAction = genericAction
 
@@ -156,19 +156,19 @@ func (matcher *DeleteActionMatcher) Match(actual interface{}) (bool, error) {
 
 }
 
-func (matcher *DeleteActionMatcher) FailureMessage(actual interface{}) string {
+func (matcher *deleteActionMatcher) FailureMessage(actual interface{}) string {
 	return fmt.Sprintf("Expected '%s' on resource '%s' named '%s' in namespace '%s' to match the observed action:\n%+v\n",
 		matcher.expectedVerb, matcher.expectedResourceType, matcher.expectedResourceName, matcher.expectedNamespace, matcher.actualAction)
 }
 
-func (matcher *DeleteActionMatcher) NegatedFailureMessage(actual interface{}) string {
+func (matcher *deleteActionMatcher) NegatedFailureMessage(actual interface{}) string {
 	return fmt.Sprintf("Expected '%s' on resource '%s' named '%s' in namespace '%s' not to match the observed action:\n%+v\n",
 		matcher.expectedVerb, matcher.expectedResourceType, matcher.expectedResourceName, matcher.expectedNamespace, matcher.actualAction)
 }
 
-func BeUpdateActionOnResource(expectedResourceType, expectedResourceName, expectedNamespace string, updatedResourceMatcher types.GomegaMatcher) types.GomegaMatcher {
-	return &UpdateActionMatcher{
-		ActionMatcher{
+func beUpdateActionOnResource(expectedResourceType, expectedResourceName, expectedNamespace string, updatedResourceMatcher types.GomegaMatcher) types.GomegaMatcher {
+	return &updateActionMatcher{
+		actionMatcher{
 			expectedVerb:         "update",
 			expectedResourceType: expectedResourceType,
 			expectedNamespace:    expectedNamespace,
@@ -179,17 +179,17 @@ func BeUpdateActionOnResource(expectedResourceType, expectedResourceName, expect
 	}
 }
 
-type UpdateActionMatcher struct {
-	ActionMatcher
+type updateActionMatcher struct {
+	actionMatcher
 	expectedResourceName         string
 	updatedResourceMatcher       types.GomegaMatcher
 	failedUpdatedResourceMatcher bool
 }
 
-func (matcher *UpdateActionMatcher) Match(actual interface{}) (bool, error) {
+func (matcher *updateActionMatcher) Match(actual interface{}) (bool, error) {
 	genericAction, ok := actual.(k8stesting.Action)
 	if !ok {
-		return false, fmt.Errorf("BeUpdateActionOnResource must be passed an Action from the fakeClientset")
+		return false, fmt.Errorf("beUpdateActionOnResource must be passed an Action from the fakeClientset")
 	}
 	matcher.actualAction = genericAction
 
@@ -221,7 +221,7 @@ func (matcher *UpdateActionMatcher) Match(actual interface{}) (bool, error) {
 	return passedUpdatedResourceMatcher, nil
 }
 
-func (matcher *UpdateActionMatcher) FailureMessage(actual interface{}) string {
+func (matcher *updateActionMatcher) FailureMessage(actual interface{}) string {
 	if matcher.failedUpdatedResourceMatcher {
 		return matcher.updatedResourceMatcher.FailureMessage(actual)
 	}
@@ -229,7 +229,7 @@ func (matcher *UpdateActionMatcher) FailureMessage(actual interface{}) string {
 		matcher.expectedVerb, matcher.expectedResourceType, matcher.expectedResourceName, matcher.expectedNamespace, matcher.actualAction)
 }
 
-func (matcher *UpdateActionMatcher) NegatedFailureMessage(actual interface{}) string {
+func (matcher *updateActionMatcher) NegatedFailureMessage(actual interface{}) string {
 	if matcher.failedUpdatedResourceMatcher {
 		return matcher.updatedResourceMatcher.NegatedFailureMessage(actual)
 	}

--- a/internal/scaling/scaling_test.go
+++ b/internal/scaling/scaling_test.go
@@ -46,13 +46,13 @@ var _ = Describe("Scaling", func() {
 		It("scales the PVC", func() {
 			Expect(persistenceScaler.Scale(context.Background(), rmq, fifteenG)).To(Succeed())
 			Expect(fakeClientset.Actions()).To(MatchAllElementsWithIndex(IndexIdentity, Elements{
-				"0": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-				"1": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
-				"2": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-				"3": BeDeleteActionOnResource("statefulsets", "rabbit-server", namespace),
-				"4": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-				"5": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
-				"6": BeUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace, MatchFields(IgnoreExtras, Fields{
+				"0": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+				"1": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
+				"2": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+				"3": beDeleteActionOnResource("statefulsets", "rabbit-server", namespace),
+				"4": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+				"5": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
+				"6": beUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace, MatchFields(IgnoreExtras, Fields{
 					"Spec": MatchFields(IgnoreExtras, Fields{
 						"Resources": MatchFields(IgnoreExtras, Fields{
 							"Requests": MatchAllKeys(Keys{
@@ -72,8 +72,8 @@ var _ = Describe("Scaling", func() {
 		It("performs no actions other than checking for the PVC's existence", func() {
 			Expect(persistenceScaler.Scale(context.Background(), rmq, fifteenG)).To(Succeed())
 			Expect(fakeClientset.Actions()).To(MatchAllElementsWithIndex(IndexIdentity, Elements{
-				"0": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-				"1": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
+				"0": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+				"1": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
 			}))
 		})
 	})
@@ -85,11 +85,11 @@ var _ = Describe("Scaling", func() {
 		It("does not delete the StatefulSet, but still updates the PVC", func() {
 			Expect(persistenceScaler.Scale(context.Background(), rmq, fifteenG)).To(Succeed())
 			Expect(fakeClientset.Actions()).To(MatchAllElementsWithIndex(IndexIdentity, Elements{
-				"0": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-				"1": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
-				"2": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-				"3": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
-				"4": BeUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace, MatchFields(IgnoreExtras, Fields{
+				"0": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+				"1": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
+				"2": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+				"3": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
+				"4": beUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace, MatchFields(IgnoreExtras, Fields{
 					"Spec": MatchFields(IgnoreExtras, Fields{
 						"Resources": MatchFields(IgnoreExtras, Fields{
 							"Requests": MatchAllKeys(Keys{
@@ -109,7 +109,7 @@ var _ = Describe("Scaling", func() {
 		It("raises an error", func() {
 			Expect(persistenceScaler.Scale(context.Background(), rmq, oneG)).To(MatchError("shrinking persistent volumes is not supported"))
 			Expect(fakeClientset.Actions()).To(MatchAllElementsWithIndex(IndexIdentity, Elements{
-				"0": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
+				"0": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
 			}))
 		})
 	})
@@ -122,14 +122,14 @@ var _ = Describe("Scaling", func() {
 		It("raises an error if trying to move to persistent storage", func() {
 			Expect(persistenceScaler.Scale(context.Background(), rmq, tenG)).To(MatchError("changing from ephemeral to persistent storage is not supported"))
 			Expect(fakeClientset.Actions()).To(MatchAllElementsWithIndex(IndexIdentity, Elements{
-				"0": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
+				"0": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
 			}))
 		})
 		It("does nothing if remaining as ephemeral storage", func() {
 			Expect(persistenceScaler.Scale(context.Background(), rmq, ephemeralStorage)).To(Succeed())
 			Expect(fakeClientset.Actions()).To(MatchAllElementsWithIndex(IndexIdentity, Elements{
-				"0": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-				"1": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
+				"0": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+				"1": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
 			}))
 		})
 	})
@@ -146,15 +146,15 @@ var _ = Describe("Scaling", func() {
 			It("deletes the statefulset and updates each individual PVC", func() {
 				Expect(persistenceScaler.Scale(context.Background(), rmq, fifteenG)).To(Succeed())
 				Expect(fakeClientset.Actions()).To(MatchAllElementsWithIndex(IndexIdentity, Elements{
-					"0": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-					"1": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
-					"2": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-1", namespace),
-					"3": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace),
-					"4": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-					"5": BeDeleteActionOnResource("statefulsets", "rabbit-server", namespace),
-					"6": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-					"7": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
-					"8": BeUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace, MatchFields(IgnoreExtras, Fields{
+					"0": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+					"1": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
+					"2": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-1", namespace),
+					"3": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace),
+					"4": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+					"5": beDeleteActionOnResource("statefulsets", "rabbit-server", namespace),
+					"6": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+					"7": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
+					"8": beUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace, MatchFields(IgnoreExtras, Fields{
 						"Spec": MatchFields(IgnoreExtras, Fields{
 							"Resources": MatchFields(IgnoreExtras, Fields{
 								"Requests": MatchAllKeys(Keys{
@@ -163,8 +163,8 @@ var _ = Describe("Scaling", func() {
 							}),
 						}),
 					})),
-					"9": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-1", namespace),
-					"10": BeUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-1", namespace, MatchFields(IgnoreExtras, Fields{
+					"9": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-1", namespace),
+					"10": beUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-1", namespace, MatchFields(IgnoreExtras, Fields{
 						"Spec": MatchFields(IgnoreExtras, Fields{
 							"Resources": MatchFields(IgnoreExtras, Fields{
 								"Requests": MatchAllKeys(Keys{
@@ -173,8 +173,8 @@ var _ = Describe("Scaling", func() {
 							}),
 						}),
 					})),
-					"11": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace),
-					"12": BeUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace, MatchFields(IgnoreExtras, Fields{
+					"11": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace),
+					"12": beUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace, MatchFields(IgnoreExtras, Fields{
 						"Spec": MatchFields(IgnoreExtras, Fields{
 							"Resources": MatchFields(IgnoreExtras, Fields{
 								"Requests": MatchAllKeys(Keys{
@@ -197,15 +197,15 @@ var _ = Describe("Scaling", func() {
 			It("deletes the statefulset and updates the PVCs that exist", func() {
 				Expect(persistenceScaler.Scale(context.Background(), rmq, fifteenG)).To(Succeed())
 				Expect(fakeClientset.Actions()).To(MatchAllElementsWithIndex(IndexIdentity, Elements{
-					"0": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-					"1": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
-					"2": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-1", namespace),
-					"3": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace),
-					"4": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-					"5": BeDeleteActionOnResource("statefulsets", "rabbit-server", namespace),
-					"6": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-					"7": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
-					"8": BeUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace, MatchFields(IgnoreExtras, Fields{
+					"0": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+					"1": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
+					"2": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-1", namespace),
+					"3": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace),
+					"4": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+					"5": beDeleteActionOnResource("statefulsets", "rabbit-server", namespace),
+					"6": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+					"7": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
+					"8": beUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace, MatchFields(IgnoreExtras, Fields{
 						"Spec": MatchFields(IgnoreExtras, Fields{
 							"Resources": MatchFields(IgnoreExtras, Fields{
 								"Requests": MatchAllKeys(Keys{
@@ -214,8 +214,8 @@ var _ = Describe("Scaling", func() {
 							}),
 						}),
 					})),
-					"9": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace),
-					"10": BeUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace, MatchFields(IgnoreExtras, Fields{
+					"9": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace),
+					"10": beUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace, MatchFields(IgnoreExtras, Fields{
 						"Spec": MatchFields(IgnoreExtras, Fields{
 							"Resources": MatchFields(IgnoreExtras, Fields{
 								"Requests": MatchAllKeys(Keys{
@@ -239,15 +239,15 @@ var _ = Describe("Scaling", func() {
 			It("deletes the statefulset and updates the PVCs that exist", func() {
 				Expect(persistenceScaler.Scale(context.Background(), rmq, fifteenG)).To(Succeed())
 				Expect(fakeClientset.Actions()).To(MatchAllElementsWithIndex(IndexIdentity, Elements{
-					"0": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-					"1": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
-					"2": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-1", namespace),
-					"3": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace),
-					"4": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-					"5": BeDeleteActionOnResource("statefulsets", "rabbit-server", namespace),
-					"6": BeGetActionOnResource("statefulsets", "rabbit-server", namespace),
-					"7": BeGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace),
-					"8": BeUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace, MatchFields(IgnoreExtras, Fields{
+					"0": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+					"1": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-0", namespace),
+					"2": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-1", namespace),
+					"3": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace),
+					"4": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+					"5": beDeleteActionOnResource("statefulsets", "rabbit-server", namespace),
+					"6": beGetActionOnResource("statefulsets", "rabbit-server", namespace),
+					"7": beGetActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace),
+					"8": beUpdateActionOnResource("persistentvolumeclaims", "persistence-rabbit-server-2", namespace, MatchFields(IgnoreExtras, Fields{
 						"Spec": MatchFields(IgnoreExtras, Fields{
 							"Resources": MatchFields(IgnoreExtras, Fields{
 								"Requests": MatchAllKeys(Keys{

--- a/system_tests/utils_test.go
+++ b/system_tests/utils_test.go
@@ -952,8 +952,8 @@ func publishAndConsumeSTOMPMsg(hostname, port, username, password string, tlsCon
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		defer secureConn.Close()
 
-		for retry := 0; retry < 5; retry++ {
-			fmt.Printf("Attempt #%d to connect using STOMPS\n", retry)
+		for r := 0; r < 5; r++ {
+			fmt.Printf("Attempt #%d to connect using STOMPS\n", r)
 			conn, err = stomp.Connect(secureConn,
 				stomp.ConnOpt.Login(username, password),
 				stomp.ConnOpt.AcceptVersion(stomp.V12), // RabbitMQ STOMP plugin supports STOMP versions 1.0 through 1.2
@@ -967,8 +967,8 @@ func publishAndConsumeSTOMPMsg(hostname, port, username, password string, tlsCon
 			time.Sleep(2 * time.Second)
 		}
 	} else {
-		for retry := 0; retry < 5; retry++ {
-			fmt.Printf("Attempt #%d to connect using STOMP\n", retry)
+		for r := 0; r < 5; r++ {
+			fmt.Printf("Attempt #%d to connect using STOMP\n", r)
 			conn, err = stomp.Dial("tcp",
 				fmt.Sprintf("%s:%s", hostname, port),
 				stomp.ConnOpt.Login(username, password),


### PR DESCRIPTION

This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- **Fix linter errors**
- **Unexport functions in scaling test suite**

## Additional Context

The linter is [staticcheck](https://staticcheck.dev/), latest version at this time 2024.1.1. The errors reported were:

- Duplicated imports
- Variables shadowing a package name

## Local Testing

- [x] Unit tests passing after changes
- [x] Integration tests passing after changes

