### PR TITLE
Update CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == "pull_request" }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,19 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE.txt'
+      - 'PROJECT'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE.txt'
+      - 'PROJECT'
   schedule:
     - cron: '0 0 * * 0'
 


### PR DESCRIPTION
## Summary Of Changes

Dependabot does not have write permissions in the repository, and it
causes failures when running on push events, because CodeQL needs write
access to upload the results of the scaning to GitHub.

This commit adds a conditional to run CodeQL if the event is a pull
request, OR if the actor is not dependabot. This conditional should
filter "push" events when dependabot is the actor, and always run pull
request scans.

## Additional Context

Following guidance from this useful error message:

https://github.com/rabbitmq/cluster-operator/actions/runs/11572316735/job/32212033650#step:6:56

