### PR TITLE
feat: support override sts rmq container probe

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -286,6 +286,14 @@ func patchPodSpec(podSpec, podSpecOverride *corev1.PodSpec) (corev1.PodSpec, err
 		sortVolumeMounts(patchedPodSpec.Containers[0].VolumeMounts)
 	}
 
+	// also support patch liveness and readiness, detail see https://github.com/rabbitmq/cluster-operator/issues/1698
+	if rmqContainer.LivenessProbe != nil {
+		patchedPodSpec.Containers[0].LivenessProbe = rmqContainer.LivenessProbe
+	}
+	if rmqContainer.ReadinessProbe != nil {
+		patchedPodSpec.Containers[0].ReadinessProbe = rmqContainer.ReadinessProbe
+	}
+
 	// A user may wish to override the controller-set securityContext for the RabbitMQ & init containers so that the
 	// container runtime can override them. If the securityContext has been set to an empty struct, `strategicpatch.StrategicMergePatch`
 	// won't pick this up, so manually override it here.


### PR DESCRIPTION
## Summary Of Changes
feat #1698

demo:
```
apiVersion: rabbitmq.com/v1beta1
kind: RabbitmqCluster
metadata:
  name: hello-world
spec:
  override:
    statefulSet:
      spec:
        template:
          spec:
            containers:
              - name: rabbitmq
                readinessProbe:
                  exec:
                    command:
                    - rabbitmq-diagnostics
                    - ping
                  initialDelaySeconds: 20
                  periodSeconds: 60
                  timeoutSeconds: 10
```
