### PR TITLE
Update docker cache in CI

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -176,6 +176,8 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Build to TAR
       id: build_tar
@@ -187,6 +189,9 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         outputs: |
           type=docker,dest=./operator.tar
+        # Workaround to "disable" cache from registry
+        cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
+        cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=min
 
     - name: Upload Operator artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This should fix errors like this one:

https://github.com/rabbitmq/cluster-operator/actions/runs/12830020781
