### PR TITLE
Fix olm action

### DIFF
--- a/.github/workflows/testing_and_publishing_OLM_bundle.yml
+++ b/.github/workflows/testing_and_publishing_OLM_bundle.yml
@@ -3,9 +3,8 @@
 name: Test & Publish OLM Package
 
 on:
-  push:
-    branches: 
-      - test_olm_action
+  release:
+    types: [published]
     
   workflow_dispatch:
     inputs:
@@ -98,7 +97,7 @@ jobs:
             mkdir upload
             mv "$BUNDLE_VERSION" ./upload
             cp ./rabbitmq_olm_package_repo/generators/cluster_operator_generators/cluster-service-version-generator-openshift.yml ./rabbitmq_olm_package_repo/generators/cluster_operator_generators/cluster-service-version-generator.yml
-            poetry run generate_bundle ./rabbitmq_olm_package_repo/manifests_crds/cluster-operator.yaml $BUNDLE_VERSION ./
+            poetry run generate_bundle ./../releases/cluster-operator.yml $BUNDLE_VERSION ./
             mv "$BUNDLE_VERSION" ./upload/$BUNDLE_VERSION-openshift
 
         - name: Upload OLM Package

--- a/.github/workflows/testing_and_publishing_OLM_bundle.yml
+++ b/.github/workflows/testing_and_publishing_OLM_bundle.yml
@@ -3,8 +3,9 @@
 name: Test & Publish OLM Package
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: 
+      - test_olm_action
     
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Looks like a small issue in the manifest path passed to poetry during the second execution.

The action with this modification is passing:

https://github.com/rabbitmq/cluster-operator/actions/runs/12909404544

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
