### PR TITLE
adding back replaces field on operatorhub publication

### DIFF
--- a/.github/workflows/testing_and_publishing_OLM_bundle.yml
+++ b/.github/workflows/testing_and_publishing_OLM_bundle.yml
@@ -209,7 +209,10 @@ jobs:
             git branch rabbitmq-cluster-operator-$BUNDLE_VERSION
             git checkout rabbitmq-cluster-operator-$BUNDLE_VERSION
 
+            REPLACE_VERSION=$(ls -1v ./operators/rabbitmq-cluster-operator/ | tail -2 | head -1)
+            
             cp -v -fR olm-package-ci/"$BUNDLE_VERSION" ./operators/rabbitmq-cluster-operator/
+            sed -i -e "s/replaces: null/replaces: rabbitmq-cluster-operator.v$REPLACE_VERSION/g" ./operators/rabbitmq-cluster-operator/$BUNDLE_VERSION/manifests/rabbitmq.clusterserviceversion.yaml
             sed -i -e "s/latest/$BUNDLE_VERSION/g" ./operators/rabbitmq-cluster-operator/$BUNDLE_VERSION/manifests/rabbitmq.clusterserviceversion.yaml
             git add operators/rabbitmq-cluster-operator
             git commit -s -m "RabbitMQ Operator release $BUNDLE_VERSION"


### PR DESCRIPTION
This closes #

This should solve the automation problem for the OLM publication.

In case of operatorhub.io we still need to specify the replaces/skip fields in case of operatorhub marketplace we need to avoid these fields. Otherwise the redhat checks will fail

See also: https://github.com/rabbitmq/OLM-Package-Repo/issues/26

These modifications were tested.

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
