### PR TITLE
PrometheusRule for rabbitmq alarm states

### DIFF
--- a/observability/prometheus/rules/rabbitmq/cluster-alarms.yml
+++ b/observability/prometheus/rules/rabbitmq/cluster-alarms.yml
@@ -1,0 +1,60 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-cluster-alarms
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: MemoryAlarm
+      expr: |
+        max by(rabbitmq_cluster) (
+          max_over_time(rabbitmq_alarms_memory_used_watermark[5m])
+          * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) rabbitmq_identity_info
+        ) > 0
+      keep_firing_for: 5m
+      annotations:
+        description: |
+          RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}` memory alarm active. Publishers are blocked.
+        summary: |
+          A RabbitMQ node reached the `vm_memory_high_watermark` threshold.
+          See https://www.rabbitmq.com/docs/alarms#overview, https://www.rabbitmq.com/docs/memory.
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning
+    - alert: RabbitmqDiskAlarm
+      expr: |
+        max by(rabbitmq_cluster) (
+          max_over_time(rabbitmq_alarms_free_disk_space_watermark[5m])
+          * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) rabbitmq_identity_info
+        ) > 0
+      keep_firing_for: 5m
+      annotations:
+        description: |
+          RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}` disk alarm active. Publishers are blocked.
+        summary: |
+          A RabbitMQ node reached the `disk_free_limit` threshold.
+          See https://www.rabbitmq.com/docs/alarms#overview, https://www.rabbitmq.com/docs/disk-alarms.
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning
+    - alert: RabbitmqFileDescriptorAlarm
+      expr: |
+        max by(rabbitmq_cluster) (
+          max_over_time(rabbitmq_alarms_file_descriptor_limit[5m])
+          * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) rabbitmq_identity_info
+        ) > 0
+      keep_firing_for: 5m
+      annotations:
+        description: |
+          RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}` file descriptor alarm active. Publishers are blocked.
+        summary: |
+          A RabbitMQ node ran out of file descriptors.
+          See https://www.rabbitmq.com/docs/alarms#file-descriptors.
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning


### PR DESCRIPTION
This closes #1822

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Add a PrometheusRule with 3 alerts, one for each for the rabbitmq cluster alarm states.

## Testing

Tested in a local cluster, with my setup I get:
```
[FIRING: 1]
Alerts Firing:
- MemoryAlarm: RabbitMQ cluster rabbitmq memory alarm active. Publishers are blocked.
```

![image](https://github.com/user-attachments/assets/84a43070-6ba7-4dce-8196-31922af44ad7)
