### PR TITLE
configure rules to merge rabbitmq_identity_info

### DIFF
--- a/observability/prometheus/rules/rabbitmq/cluster-alarms.yml
+++ b/observability/prometheus/rules/rabbitmq/cluster-alarms.yml
@@ -14,7 +14,7 @@ spec:
       expr: |
         max by(rabbitmq_cluster) (
           max_over_time(rabbitmq_alarms_memory_used_watermark[5m])
-          * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) rabbitmq_identity_info
+          * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
         ) > 0
       keep_firing_for: 5m
       annotations:
@@ -30,7 +30,7 @@ spec:
       expr: |
         max by(rabbitmq_cluster) (
           max_over_time(rabbitmq_alarms_free_disk_space_watermark[5m])
-          * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) rabbitmq_identity_info
+          * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
         ) > 0
       keep_firing_for: 5m
       annotations:
@@ -46,7 +46,7 @@ spec:
       expr: |
         max by(rabbitmq_cluster) (
           max_over_time(rabbitmq_alarms_file_descriptor_limit[5m])
-          * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) rabbitmq_identity_info
+          * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
         ) > 0
       keep_firing_for: 5m
       annotations:

--- a/observability/prometheus/rules/rabbitmq/container-restarts.yml
+++ b/observability/prometheus/rules/rabbitmq/container-restarts.yml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: ContainerRestarts
       expr: |
-        increase(kube_pod_container_status_restarts_total[10m]) * on(namespace, pod, container) group_left(rabbitmq_cluster) rabbitmq_identity_info
+        increase(kube_pod_container_status_restarts_total[10m]) * on(namespace, pod, container) group_left(rabbitmq_cluster) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
         >=
         1
       for: 5m

--- a/observability/prometheus/rules/rabbitmq/file-descriptors-near-limit.yml
+++ b/observability/prometheus/rules/rabbitmq/file-descriptors-near-limit.yml
@@ -12,9 +12,9 @@ spec:
     rules:
     - alert: FileDescriptorsNearLimit
       expr: |
-        sum by(namespace, rabbitmq_cluster, pod, rabbitmq_node) (max_over_time(rabbitmq_process_open_fds[5m]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) rabbitmq_identity_info)
+        sum by(namespace, rabbitmq_cluster, pod, rabbitmq_node) (max_over_time(rabbitmq_process_open_fds[5m]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster))
         /
-        sum by(namespace, rabbitmq_cluster, pod, rabbitmq_node) (rabbitmq_process_max_fds  * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) rabbitmq_identity_info)
+        sum by(namespace, rabbitmq_cluster, pod, rabbitmq_node) (rabbitmq_process_max_fds  * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster))
         > 0.8
       for: 10m
       annotations:

--- a/observability/prometheus/rules/rabbitmq/high-connection-churn.yml
+++ b/observability/prometheus/rules/rabbitmq/high-connection-churn.yml
@@ -13,15 +13,15 @@ spec:
     - alert: HighConnectionChurn
       expr: |
         (
-          sum(rate(rabbitmq_connections_closed_total[5m]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info) by(namespace, rabbitmq_cluster)
+          sum(rate(rabbitmq_connections_closed_total[5m]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)) by(namespace, rabbitmq_cluster)
           +
-          sum(rate(rabbitmq_connections_opened_total[5m]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info) by(namespace, rabbitmq_cluster)
+          sum(rate(rabbitmq_connections_opened_total[5m]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)) by(namespace, rabbitmq_cluster)
         )
         /
-        sum (rabbitmq_connections * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info) by (namespace, rabbitmq_cluster)
+        sum (rabbitmq_connections * on(instance) group_left(rabbitmq_cluster) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)) by (namespace, rabbitmq_cluster)
         > 0.1
         unless
-        sum (rabbitmq_connections * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info) by (namespace, rabbitmq_cluster)
+        sum (rabbitmq_connections * on(instance) group_left(rabbitmq_cluster) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)) by (namespace, rabbitmq_cluster)
         < 100
       for: 10m
       annotations:

--- a/observability/prometheus/rules/rabbitmq/insufficient-established-erlang-distribution-links.yml
+++ b/observability/prometheus/rules/rabbitmq/insufficient-established-erlang-distribution-links.yml
@@ -13,11 +13,11 @@ spec:
     - alert: InsufficientEstablishedErlangDistributionLinks
       # erlang_vm_dist_node_state: 1=pending, 2=up_pending, 3=up
       expr: |
-        count by (namespace, rabbitmq_cluster) (erlang_vm_dist_node_state * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info == 3)
+        count by (namespace, rabbitmq_cluster) (erlang_vm_dist_node_state * on(instance) group_left(rabbitmq_cluster) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster) == 3)
         <
-         count by (namespace, rabbitmq_cluster) (rabbitmq_build_info * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info)
+         count by (namespace, rabbitmq_cluster) (rabbitmq_build_info * on(instance) group_left(rabbitmq_cluster) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster))
          *
-        (count by (namespace, rabbitmq_cluster) (rabbitmq_build_info * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info) -1 )
+        (count by (namespace, rabbitmq_cluster) (rabbitmq_build_info * on(instance) group_left(rabbitmq_cluster) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)) -1 )
       for: 10m
       annotations:
         description: |

--- a/observability/prometheus/rules/rabbitmq/low-disk-watermark-predicted.yml
+++ b/observability/prometheus/rules/rabbitmq/low-disk-watermark-predicted.yml
@@ -14,13 +14,13 @@ spec:
       # The 2nd condition ensures that data points are available until 24 hours ago such that no false positive alerts are triggered for newly created RabbitMQ clusters.
       expr: |
         (
-          predict_linear(rabbitmq_disk_space_available_bytes[24h], 60*60*24) * on (instance, pod) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info
+          predict_linear(rabbitmq_disk_space_available_bytes[24h], 60*60*24) * on (instance, pod) group_left(rabbitmq_cluster, rabbitmq_node) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
           <
-          rabbitmq_disk_space_available_limit_bytes * on (instance, pod) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info
+          rabbitmq_disk_space_available_limit_bytes * on (instance, pod) group_left(rabbitmq_cluster, rabbitmq_node) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
         )
         and
         (
-          count_over_time(rabbitmq_disk_space_available_limit_bytes[2h] offset 22h) * on (instance, pod) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info
+          count_over_time(rabbitmq_disk_space_available_limit_bytes[2h] offset 22h) * on (instance, pod) group_left(rabbitmq_cluster, rabbitmq_node) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
           >
           0
         )


### PR DESCRIPTION
This closes #1855 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
If the same `rabbitmq_identity_info` (same pod, same cluster, etc.) is exported twice, only one of the values is used.

## Additional Context
When using the default ServiceMonitor from https://github.com/rabbitmq/cluster-operator/blob/main/observability/prometheus/monitors/rabbitmq-servicemonitor.yml, multiple Metrics-Endpoints are scraped that partly return the same value.

## Local Testing
It can be tested by applying the files to a test-cluster:
```
  - https://raw.githubusercontent.com/mmueller-rs/cluster-operator/fix-prometheus-rules-for-duplicate-metrics/observability/prometheus/rules/rabbitmq/cluster-alarms.yml
  - https://raw.githubusercontent.com/mmueller-rs/cluster-operator/fix-prometheus-rules-for-duplicate-metrics/observability/prometheus/rules/rabbitmq/container-restarts.yml
  - https://raw.githubusercontent.com/mmueller-rs/cluster-operator/fix-prometheus-rules-for-duplicate-metrics/observability/prometheus/rules/rabbitmq/file-descriptors-near-limit.yml
  - https://raw.githubusercontent.com/mmueller-rs/cluster-operator/fix-prometheus-rules-for-duplicate-metrics/observability/prometheus/rules/rabbitmq/high-connection-churn.yml
  - https://raw.githubusercontent.com/mmueller-rs/cluster-operator/fix-prometheus-rules-for-duplicate-metrics/observability/prometheus/rules/rabbitmq/insufficient-established-erlang-distribution-links.yml
  - https://raw.githubusercontent.com/mmueller-rs/cluster-operator/fix-prometheus-rules-for-duplicate-metrics/observability/prometheus/rules/rabbitmq/low-disk-watermark-predicted.yml
  - https://raw.githubusercontent.com/mmueller-rs/cluster-operator/fix-prometheus-rules-for-duplicate-metrics/observability/prometheus/rules/rabbitmq/no-majority-of-nodes-ready.yml
  - https://raw.githubusercontent.com/mmueller-rs/cluster-operator/fix-prometheus-rules-for-duplicate-metrics/observability/prometheus/rules/rabbitmq/persistent-volume-missing.yml
  - https://raw.githubusercontent.com/mmueller-rs/cluster-operator/fix-prometheus-rules-for-duplicate-metrics/observability/prometheus/rules/rabbitmq/recording-rules.yml
  - https://raw.githubusercontent.com/mmueller-rs/cluster-operator/fix-prometheus-rules-for-duplicate-metrics/observability/prometheus/rules/rabbitmq/tcp-sockets-near-limit.yml
  - https://raw.githubusercontent.com/mmueller-rs/cluster-operator/fix-prometheus-rules-for-duplicate-metrics/observability/prometheus/rules/rabbitmq/unroutable-messages.yml
```

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
