### PR TITLE
PROPOSAL: Reduce init container memory from 500Mi to 64Mi

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	stsSuffix           string = "server"
-	initContainerCPU    string = "100m"
+	initContainerCPU    string = "20m"
 	initContainerMemory string = "64Mi"
 	defaultPVCName      string = "persistence"
 	DeletionMarker      string = "skipPreStopChecks"

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -36,7 +36,7 @@ import (
 const (
 	stsSuffix           string = "server"
 	initContainerCPU    string = "100m"
-	initContainerMemory string = "500Mi"
+	initContainerMemory string = "64Mi"
 	defaultPVCName      string = "persistence"
 	DeletionMarker      string = "skipPreStopChecks"
 )

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -783,9 +783,9 @@ var _ = Describe("StatefulSet", func() {
 
 			resources := statefulSet.Spec.Template.Spec.InitContainers[0].Resources
 			Expect(resources.Requests["cpu"]).To(Equal(k8sresource.MustParse("100m")))
-			Expect(resources.Requests["memory"]).To(Equal(k8sresource.MustParse("500Mi")))
+			Expect(resources.Requests["memory"]).To(Equal(k8sresource.MustParse("64Mi")))
 			Expect(resources.Limits["cpu"]).To(Equal(k8sresource.MustParse("100m")))
-			Expect(resources.Limits["memory"]).To(Equal(k8sresource.MustParse("500Mi")))
+			Expect(resources.Limits["memory"]).To(Equal(k8sresource.MustParse("64Mi")))
 		})
 
 		It("exposes required Container Ports", func() {

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -782,9 +782,9 @@ var _ = Describe("StatefulSet", func() {
 			Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 
 			resources := statefulSet.Spec.Template.Spec.InitContainers[0].Resources
-			Expect(resources.Requests["cpu"]).To(Equal(k8sresource.MustParse("100m")))
+			Expect(resources.Requests["cpu"]).To(Equal(k8sresource.MustParse("20m")))
 			Expect(resources.Requests["memory"]).To(Equal(k8sresource.MustParse("64Mi")))
-			Expect(resources.Limits["cpu"]).To(Equal(k8sresource.MustParse("100m")))
+			Expect(resources.Limits["cpu"]).To(Equal(k8sresource.MustParse("20m")))
 			Expect(resources.Limits["memory"]).To(Equal(k8sresource.MustParse("64Mi")))
 		})
 


### PR DESCRIPTION
It'd be great to get some feedback from users who changed the default init container resources - what did you change them to? I've tested successfully deployed RabbitMQ with a `50Mi` init container using:
* `rabbitmq:4.1-management`
* `bitnami/rabbitmq:4.1`
* `rabbitmq.packages.broadcom.com/vmware-tanzu-rabbitmq:4.1.0`

Given that an init container failure would be a terrible user experience, I'd rather have some headroom, hence `64Mi`.

When originally developed, it wasn't clear what would need to be done in the init container. With hindsight, there's very little to do and the init phase hasn't changed in a long time.

We also assumed that the resources requested for the init container would effectively be reused by the actual `rabbitmq` container later. Turns out that's not the case: https://github.com/kubernetes/kubernetes/issues/124282 init container resources are considered even after the init container completes its task.

This closes https://github.com/rabbitmq/cluster-operator/issues/960