### PR TITLE
Improve cluster deletion

### DIFF
--- a/controllers/rabbitmqcluster_controller_test.go
+++ b/controllers/rabbitmqcluster_controller_test.go
@@ -43,6 +43,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 
 	var (
 		cluster          *rabbitmqv1beta1.RabbitmqCluster
+		suffix           string
 		defaultNamespace = "default"
 	)
 
@@ -781,9 +782,11 @@ var _ = Describe("RabbitmqClusterController", func() {
 			storageClassName = "my-storage-class"
 			myStorage = k8sresource.MustParse("100Gi")
 			q, _ = k8sresource.ParseQuantity("10Gi")
+			suffix = fmt.Sprintf("-%d", time.Now().UnixNano())
+			clusterName := "rabbitmq-sts-override" + suffix
 			cluster = &rabbitmqv1beta1.RabbitmqCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "rabbitmq-sts-override",
+					Name:      clusterName,
 					Namespace: defaultNamespace,
 				},
 				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
@@ -797,7 +800,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 											Name:      "persistence",
 											Namespace: defaultNamespace,
 											Labels: map[string]string{
-												"app.kubernetes.io/name": "rabbitmq-sts-override",
+												"app.kubernetes.io/name": clusterName,
 											},
 											Annotations: map[string]string{},
 										},
@@ -815,7 +818,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 											Name:      "disk-2",
 											Namespace: defaultNamespace,
 											Labels: map[string]string{
-												"app.kubernetes.io/name": "rabbitmq-sts-override",
+												"app.kubernetes.io/name": clusterName,
 											},
 										},
 										Spec: corev1.PersistentVolumeClaimSpec{
@@ -872,14 +875,14 @@ var _ = Describe("RabbitmqClusterController", func() {
 			defaultMode := int32(420)
 
 			Expect(sts.ObjectMeta.Labels).To(Equal(map[string]string{
-				"app.kubernetes.io/name":      "rabbitmq-sts-override",
+				"app.kubernetes.io/name":      "rabbitmq-sts-override" + suffix,
 				"app.kubernetes.io/component": "rabbitmq",
 				"app.kubernetes.io/part-of":   "rabbitmq",
 			}))
 
-			Expect(sts.Spec.ServiceName).To(Equal("rabbitmq-sts-override-nodes"))
+			Expect(sts.Spec.ServiceName).To(Equal("rabbitmq-sts-override" + suffix + "-nodes"))
 			Expect(sts.Spec.Selector.MatchLabels).To(Equal(map[string]string{
-				"app.kubernetes.io/name": "rabbitmq-sts-override",
+				"app.kubernetes.io/name": "rabbitmq-sts-override" + suffix,
 			}))
 
 			Expect(len(sts.Spec.VolumeClaimTemplates)).To(Equal(2))
@@ -888,9 +891,9 @@ var _ = Describe("RabbitmqClusterController", func() {
 			Expect(sts.Spec.VolumeClaimTemplates[0].ObjectMeta.Namespace).To(Equal("default"))
 			Expect(sts.Spec.VolumeClaimTemplates[0].ObjectMeta.Labels).To(Equal(
 				map[string]string{
-					"app.kubernetes.io/name": "rabbitmq-sts-override",
+					"app.kubernetes.io/name": "rabbitmq-sts-override" + suffix,
 				}))
-			Expect(sts.Spec.VolumeClaimTemplates[0].OwnerReferences[0].Name).To(Equal("rabbitmq-sts-override"))
+			Expect(sts.Spec.VolumeClaimTemplates[0].OwnerReferences[0].Name).To(Equal("rabbitmq-sts-override" + suffix))
 			Expect(sts.Spec.VolumeClaimTemplates[0].Spec).To(Equal(
 				corev1.PersistentVolumeClaimSpec{
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -906,9 +909,9 @@ var _ = Describe("RabbitmqClusterController", func() {
 			Expect(sts.Spec.VolumeClaimTemplates[1].ObjectMeta.Namespace).To(Equal("default"))
 			Expect(sts.Spec.VolumeClaimTemplates[1].ObjectMeta.Labels).To(Equal(
 				map[string]string{
-					"app.kubernetes.io/name": "rabbitmq-sts-override",
+					"app.kubernetes.io/name": "rabbitmq-sts-override" + suffix,
 				}))
-			Expect(sts.Spec.VolumeClaimTemplates[1].OwnerReferences[0].Name).To(Equal("rabbitmq-sts-override"))
+			Expect(sts.Spec.VolumeClaimTemplates[1].OwnerReferences[0].Name).To(Equal("rabbitmq-sts-override" + suffix))
 			Expect(sts.Spec.VolumeClaimTemplates[1].Spec).To(Equal(
 				corev1.PersistentVolumeClaimSpec{
 					VolumeMode:       &volumeMode,
@@ -941,7 +944,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 								{
 									ConfigMap: &corev1.ConfigMapProjection{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "rabbitmq-sts-override-server-conf",
+											Name: "rabbitmq-sts-override" + suffix + "-server-conf",
 										},
 										Items: []corev1.KeyToPath{
 											{
@@ -958,7 +961,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 								{
 									Secret: &corev1.SecretProjection{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "rabbitmq-sts-override-default-user",
+											Name: "rabbitmq-sts-override" + suffix + "-default-user",
 										},
 										Items: []corev1.KeyToPath{
 											{
@@ -979,7 +982,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							DefaultMode: &defaultMode,
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "rabbitmq-sts-override-plugins-conf",
+								Name: "rabbitmq-sts-override" + suffix + "-plugins-conf",
 							},
 						},
 					},
@@ -1002,7 +1005,7 @@ var _ = Describe("RabbitmqClusterController", func() {
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							DefaultMode: &defaultMode,
-							SecretName:  "rabbitmq-sts-override-erlang-cookie",
+							SecretName:  "rabbitmq-sts-override" + suffix + "-erlang-cookie",
 						},
 					},
 				},

--- a/controllers/reconcile_finalizer.go
+++ b/controllers/reconcile_finalizer.go
@@ -3,13 +3,14 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	"github.com/rabbitmq/cluster-operator/v2/internal/resource"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	clientretry "k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,48 +22,37 @@ const deletionFinalizer = "deletion.finalizers.rabbitmqclusters.rabbitmq.com"
 // addFinalizerIfNeeded adds a deletion finalizer if the RabbitmqCluster does not have one yet and is not marked for deletion
 func (r *RabbitmqClusterReconciler) addFinalizerIfNeeded(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
 	if rabbitmqCluster.ObjectMeta.DeletionTimestamp.IsZero() && !controllerutil.ContainsFinalizer(rabbitmqCluster, deletionFinalizer) {
-		controllerutil.AddFinalizer(rabbitmqCluster, deletionFinalizer)
-		if err := r.Client.Update(ctx, rabbitmqCluster); err != nil {
-			return err
-		}
+		return clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
+			controllerutil.AddFinalizer(rabbitmqCluster, deletionFinalizer)
+			return r.Client.Update(ctx, rabbitmqCluster)
+		})
 	}
 	return nil
 }
 
 func (r *RabbitmqClusterReconciler) removeFinalizer(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
-	controllerutil.RemoveFinalizer(rabbitmqCluster, deletionFinalizer)
-	return r.Client.Update(ctx, rabbitmqCluster)
+	return clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
+		currentRabbitmqCluster := &rabbitmqv1beta1.RabbitmqCluster{}
+		err := r.Client.Get(ctx, types.NamespacedName{Name: rabbitmqCluster.Name, Namespace: rabbitmqCluster.Namespace}, currentRabbitmqCluster)
+		if err != nil {
+			ctrl.LoggerFrom(ctx).Error(err, "Failed to get latest RabbitmqCluster for finalizer removal")
+			return client.IgnoreNotFound(err)
+		}
+		controllerutil.RemoveFinalizer(currentRabbitmqCluster, deletionFinalizer)
+		return r.Client.Update(ctx, currentRabbitmqCluster)
+	})
 }
 
 func (r *RabbitmqClusterReconciler) prepareForDeletion(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
 	if controllerutil.ContainsFinalizer(rabbitmqCluster, deletionFinalizer) {
-		if err := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
-			uid, err := r.statefulSetUID(ctx, rabbitmqCluster)
-			if err != nil {
-				return err
-			}
-			sts := &appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      rabbitmqCluster.ChildResourceName("server"),
-					Namespace: rabbitmqCluster.Namespace,
-				},
-			}
-			// Add label on all Pods to be picked up in pre-stop hook via Downward API
-			if err := r.addRabbitmqDeletionLabel(ctx, rabbitmqCluster); err != nil {
-				return fmt.Errorf("failed to add deletion markers to RabbitmqCluster Pods: %w", err)
-			}
-			// Delete StatefulSet immediately after changing pod labels to minimize risk of them respawning.
-			// There is a window where the StatefulSet could respawn Pods without the deletion label in this order.
-			// But we can't delete it before because the DownwardAPI doesn't update once a Pod enters Terminating.
-			// Addressing #648: if both rabbitmqCluster and the statefulSet returned by r.Get() are stale (and match each other),
-			// setting the stale statefulSet's uid in the precondition can avoid mis-deleting any currently running statefulSet sharing the same name.
-			if err := r.Client.Delete(ctx, sts, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); client.IgnoreNotFound(err) != nil {
-				return fmt.Errorf("cannot delete StatefulSet: %w", err)
-			}
+		clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
+			return r.addRabbitmqDeletionLabel(ctx, rabbitmqCluster)
+		})
 
-			return nil
-		}); err != nil {
-			ctrl.LoggerFrom(ctx).Error(err, "RabbitmqCluster deletion")
+		// wait for up to 3 seconds for the labels to propagate
+		timeout := time.Now().Add(3 * time.Second)
+		for time.Now().Before(timeout) && !r.checkIfLabelPropagated(ctx, rabbitmqCluster) {
+			time.Sleep(200 * time.Millisecond)
 		}
 
 		if err := r.removeFinalizer(ctx, rabbitmqCluster); err != nil {
@@ -81,6 +71,7 @@ func (r *RabbitmqClusterReconciler) addRabbitmqDeletionLabel(ctx context.Context
 	}
 	listOptions := client.ListOptions{
 		LabelSelector: selector,
+		Namespace:     rabbitmqCluster.Namespace,
 	}
 
 	if err := r.Client.List(ctx, pods, &listOptions); err != nil {
@@ -96,4 +87,16 @@ func (r *RabbitmqClusterReconciler) addRabbitmqDeletionLabel(ctx context.Context
 	}
 
 	return nil
+}
+
+func (r *RabbitmqClusterReconciler) checkIfLabelPropagated(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) bool {
+	logger := ctrl.LoggerFrom(ctx)
+	podName := fmt.Sprintf("%s-0", rabbitmqCluster.ChildResourceName("server"))
+	cmd := "cat /etc/pod-info/skipPreStopChecks"
+	stdout, _, err := r.exec(rabbitmqCluster.Namespace, podName, "rabbitmq", "sh", "-c", cmd)
+	if err != nil {
+		logger.Info("Failed to check for deletion label propagation, deleting anyway", "pod", podName, "command", cmd, "stdout", stdout)
+		return true
+	}
+	return strings.HasPrefix(stdout, "true")
 }

--- a/controllers/reconcile_no_persistence_test.go
+++ b/controllers/reconcile_no_persistence_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Persistence", func() {
 		zeroGi := k8sresource.MustParse("0Gi")
 		cluster = &rabbitmqv1beta1.RabbitmqCluster{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "rabbitmq-shrink",
+				Name:      "rabbitmq-no-persistence",
 				Namespace: defaultNamespace,
 			},
 			Spec: rabbitmqv1beta1.RabbitmqClusterSpec{


### PR DESCRIPTION
There were 3 issues:
* the STS could get deleted before deletion label propagated, leading to some pods terminating for a long time, because they didn't skip quorum checks
* there was an unnecessary explicit STS deletion
* addRabbitmqDeletionLabel was not filtering by namespace, potentially performing operations on wrong/too many pods (if there were multiple clusters with the same name in different namespaces)
