### PR TITLE
Include default delayStartSeconds value in documentation

### DIFF
--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -392,6 +392,7 @@ The purpose of this artificial delay is to ensure that DNS entries are up-to-dat
 For more information, see https://github.com/kubernetes/kubernetes/issues/92559
 If your Kubernetes DNS backend is configured with a low DNS cache value or publishes not ready addresses
 promptly, you can decrase this value or set it to 0.
+(Default `30` seconds)
 | *`secretBackend`* __xref:{anchor_prefix}-github-com-rabbitmq-cluster-operator-v2-api-v1beta1-secretbackend[$$SecretBackend$$]__ | Secret backend configuration for the RabbitmqCluster.
 Enables to fetch default user credentials and certificates from K8s external secret stores.
 |===


### PR DESCRIPTION
This closes N/A

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Documentation update to include the default value of `delayStartSeconds` (ie: value if not set)

## Additional Context

## Local Testing

N/A - documentation only change.
