### PR TITLE
Log a line when FIPS is enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,11 @@ ARG TARGETOS
 ARG TARGETARCH
 ENV GOOS=$TARGETOS
 ENV GOARCH=$TARGETARCH
+
+# FIPS
+ARG FIPS_MODE=off
+ENV GOFIPS140=$FIPS_MODE
+
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -tags timetzdata -o manager main.go
 
 # ---------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ $(KUBEBUILDER_ASSETS):
 
 .PHONY: kubebuilder-assets
 kubebuilder-assets: $(KUBEBUILDER_ASSETS)
+	@echo "export KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
 
 .PHONY: kubebuilder-assets-rm
 kubebuilder-assets-rm:


### PR DESCRIPTION

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

This helps to determine whether FIPS is enabled. It is not necssary to
build the Operator in FIPS mode. The env variable GODEBUG allows to
enable FIPS in Go 1.24+, like so: `GODEBUG=fips140=on`

## Local Testing

System tests passing locally.
