### PR TITLE
Optionally enable all feature flags automatically

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -15,10 +15,11 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 
+	"slices"
+
 	corev1 "k8s.io/api/core/v1"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"slices"
 )
 
 const DisableDefaultTopologySpreadAnnotation = "rabbitmq.com/disable-default-topology-spread-constraints"
@@ -81,6 +82,9 @@ type RabbitmqClusterSpec struct {
 	// Has no effect if the cluster only consists of one node.
 	// For more information, see https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
 	SkipPostDeploySteps bool `json:"skipPostDeploySteps,omitempty"`
+	// Set to true to automatically enable all feature flags after each upgrade
+	// For more information, see https://www.rabbitmq.com/docs/feature-flags
+	AutoEnableAllFeatureFlags bool `json:"autoEnableAllFeatureFlags,omitempty"`
 	// TerminationGracePeriodSeconds is the timeout that each rabbitmqcluster pod will have to terminate gracefully.
 	// It defaults to 604800 seconds ( a week long) to ensure that the container preStop lifecycle hook can finish running.
 	// For more information, see: https://github.com/rabbitmq/cluster-operator/blob/main/docs/design/20200520-graceful-pod-termination.md

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -936,6 +936,11 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                   type: object
+                autoEnableAllFeatureFlags:
+                  description: |-
+                    Set to true to automatically enable all feature flags after each upgrade
+                    For more information, see https://www.rabbitmq.com/docs/feature-flags
+                  type: boolean
                 delayStartSeconds:
                   default: 30
                   description: |-

--- a/controllers/reconcile_cli.go
+++ b/controllers/reconcile_cli.go
@@ -49,7 +49,7 @@ func (r *RabbitmqClusterReconciler) runRabbitmqCLICommandsIfAnnotated(ctx contex
 	}
 
 	// If RabbitMQ cluster is newly created, enable all feature flags since some are disabled by default
-	if sts.Annotations != nil && sts.Annotations[stsCreateAnnotation] != "" {
+	if sts.Annotations != nil && sts.Annotations[stsCreateAnnotation] != "" || rmq.Spec.AutoEnableAllFeatureFlags {
 		if err := r.runEnableFeatureFlagsCommand(ctx, rmq, sts); err != nil {
 			return 0, err
 		}

--- a/controllers/reconcile_cli_test.go
+++ b/controllers/reconcile_cli_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Reconcile CLI", func() {
 							cluster.Spec.AutoEnableAllFeatureFlags = false
 						}
 					})).Should(Succeed())
-					Eventually(fakeExecutor.ExecutedCommands).Within(time.Second * 5).WithPolling(time.Second).
+					Consistently(fakeExecutor.ExecutedCommands).Within(time.Second * 5).WithPolling(time.Second).
 						ShouldNot(ContainElement(command{"bash", "-c", "rabbitmqctl enable_feature_flag all"}))
 				})
 			})

--- a/controllers/reconcile_cli_test.go
+++ b/controllers/reconcile_cli_test.go
@@ -120,6 +120,7 @@ var _ = Describe("Reconcile CLI", func() {
 						return annotations
 					}, 5).Should(HaveKey("rabbitmq.com/queueRebalanceNeededAt"))
 					Expect(fakeExecutor.ExecutedCommands()).NotTo(ContainElement(command{"sh", "-c", "rabbitmq-queues rebalance all"}))
+					Expect(fakeExecutor.ExecutedCommands()).NotTo(ContainElement(command{"bash", "-c", "rabbitmqctl enable_feature_flag all"}))
 					_, err := time.Parse(time.RFC3339, annotations["rabbitmq.com/queueRebalanceNeededAt"])
 					Expect(err).NotTo(HaveOccurred(), "Annotation rabbitmq.com/queueRebalanceNeededAt was not a valid RFC3339 timestamp")
 				})
@@ -134,6 +135,7 @@ var _ = Describe("Reconcile CLI", func() {
 						return rmq.ObjectMeta.Annotations
 					}, 5).ShouldNot(HaveKey("rabbitmq.com/queueRebalanceNeededAt"))
 					Expect(fakeExecutor.ExecutedCommands()).To(ContainElement(command{"sh", "-c", "rabbitmq-queues rebalance all"}))
+					Expect(fakeExecutor.ExecutedCommands()).To(ContainElement(command{"bash", "-c", "rabbitmqctl enable_feature_flag all"}))
 				})
 			})
 		})

--- a/controllers/reconcile_cli_test.go
+++ b/controllers/reconcile_cli_test.go
@@ -1,6 +1,7 @@
 package controllers_test
 
 import (
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -17,13 +18,8 @@ import (
 var _ = Describe("Reconcile CLI", func() {
 	var (
 		cluster          *rabbitmqv1beta1.RabbitmqCluster
-		annotations      map[string]string
 		defaultNamespace = "default"
 	)
-
-	BeforeEach(func() {
-		annotations = map[string]string{}
-	})
 
 	AfterEach(func() {
 		Expect(client.Delete(ctx, cluster)).To(Succeed())
@@ -79,6 +75,7 @@ var _ = Describe("Reconcile CLI", func() {
 			Expect(client.Create(ctx, cluster)).To(Succeed())
 			waitForClusterCreation(ctx, cluster, client)
 		})
+
 		When("the cluster is updated", func() {
 			var sts *appsv1.StatefulSet
 
@@ -94,48 +91,114 @@ var _ = Describe("Reconcile CLI", func() {
 			})
 
 			It("triggers the controller to run rabbitmq-queues rebalance all", func() {
+				k := komega.New(client)
+
 				By("setting an annotation on the CR", func() {
-					Eventually(func() map[string]string {
-						rmq := &rabbitmqv1beta1.RabbitmqCluster{}
-						Expect(client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)).To(Succeed())
-						annotations = rmq.ObjectMeta.Annotations
-						return annotations
-					}, 5).Should(HaveKey("rabbitmq.com/queueRebalanceNeededAt"))
-					_, err := time.Parse(time.RFC3339, annotations["rabbitmq.com/queueRebalanceNeededAt"])
+					rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+					rmq.Name = "rabbitmq-three"
+					rmq.Namespace = defaultNamespace
+					Eventually(k.Object(rmq)).Within(time.Second * 5).WithPolling(time.Second).Should(HaveField("ObjectMeta.Annotations", HaveKey("rabbitmq.com/queueRebalanceNeededAt")))
+
+					_, err := time.Parse(time.RFC3339, rmq.Annotations["rabbitmq.com/queueRebalanceNeededAt"])
 					Expect(err).NotTo(HaveOccurred(), "annotation rabbitmq.com/queueRebalanceNeededAt was not a valid RFC3339 timestamp")
 				})
 
 				By("not removing the annotation when all replicas are updated but not yet ready", func() {
-					sts.Status.CurrentReplicas = 3
-					sts.Status.CurrentRevision = "some-new-revision"
-					sts.Status.UpdatedReplicas = 3
-					sts.Status.UpdateRevision = "some-new-revision"
-					sts.Status.ReadyReplicas = 2
-					Expect(client.Status().Update(ctx, sts)).To(Succeed())
-					Eventually(func() map[string]string {
-						rmq := &rabbitmqv1beta1.RabbitmqCluster{}
-						err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
-						Expect(err).To(BeNil())
-						annotations = rmq.ObjectMeta.Annotations
-						return annotations
-					}, 5).Should(HaveKey("rabbitmq.com/queueRebalanceNeededAt"))
+					// Setup transition
+					Eventually(k.UpdateStatus(sts, func() {
+						sts.Status.CurrentReplicas = 3
+						sts.Status.CurrentRevision = "some-new-revision"
+						sts.Status.UpdatedReplicas = 3
+						sts.Status.UpdateRevision = "some-new-revision"
+						sts.Status.ReadyReplicas = 2
+					})).Should(Succeed())
+
+					// by not removing the annotation
+					rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+					rmq.Name = "rabbitmq-three"
+					rmq.Namespace = defaultNamespace
+					Eventually(k.Object(rmq)).Within(time.Second * 5).WithPolling(time.Second).Should(HaveField("ObjectMeta.Annotations", HaveKey("rabbitmq.com/queueRebalanceNeededAt")))
+
+					// by not running the commands
 					Expect(fakeExecutor.ExecutedCommands()).NotTo(ContainElement(command{"sh", "-c", "rabbitmq-queues rebalance all"}))
 					Expect(fakeExecutor.ExecutedCommands()).NotTo(ContainElement(command{"bash", "-c", "rabbitmqctl enable_feature_flag all"}))
-					_, err := time.Parse(time.RFC3339, annotations["rabbitmq.com/queueRebalanceNeededAt"])
+					_, err := time.Parse(time.RFC3339, rmq.Annotations["rabbitmq.com/queueRebalanceNeededAt"])
 					Expect(err).NotTo(HaveOccurred(), "Annotation rabbitmq.com/queueRebalanceNeededAt was not a valid RFC3339 timestamp")
 				})
 
 				By("removing the annotation once all Pods are up, and triggering the queue rebalance", func() {
+					// setup transition to all pods ready
 					sts.Status.ReadyReplicas = 3
 					Expect(client.Status().Update(ctx, sts)).To(Succeed())
-					Eventually(func() map[string]string {
-						rmq := &rabbitmqv1beta1.RabbitmqCluster{}
-						err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
-						Expect(err).To(BeNil())
-						return rmq.ObjectMeta.Annotations
-					}, 5).ShouldNot(HaveKey("rabbitmq.com/queueRebalanceNeededAt"))
+
+					// by not having the annotation
+					rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+					rmq.Name = "rabbitmq-three"
+					rmq.Namespace = defaultNamespace
+					Eventually(k.Object(rmq)).Within(time.Second * 5).WithPolling(time.Second).ShouldNot(HaveField("ObjectMeta.Annotations", HaveKey("rabbitmq.com/queueRebalanceNeededAt")))
+
+					// by executing the commands
 					Expect(fakeExecutor.ExecutedCommands()).To(ContainElement(command{"sh", "-c", "rabbitmq-queues rebalance all"}))
 					Expect(fakeExecutor.ExecutedCommands()).To(ContainElement(command{"bash", "-c", "rabbitmqctl enable_feature_flag all"}))
+				})
+			})
+		})
+
+		Describe("autoEnableAllFeatureFlags", func() {
+			var (
+				sts *appsv1.StatefulSet
+				k   komega.Komega
+			)
+
+			BeforeEach(func() {
+				k = komega.New(client)
+				sts = statefulSet(ctx, cluster)
+				sts.Status = appsv1.StatefulSetStatus{
+					Replicas:          3,
+					ReadyReplicas:     3,
+					CurrentReplicas:   3,
+					UpdatedReplicas:   3,
+					CurrentRevision:   "the last one",
+					UpdateRevision:    "the last one",
+					AvailableReplicas: 3,
+				}
+				sts.Annotations = make(map[string]string)
+				Expect(client.Status().Update(ctx, sts)).To(Succeed())
+			})
+
+			When("disabled", func() {
+				It("doesn't call enable_feature_flag CLI", func() {
+					// BeforeEach updated the STS from zero replicas ready to all ready
+					// Initial rabbitmqcluster create command has reconciles pending to have
+					// all replicas ready to execute commands. We have to reset the "registry"
+					// of commands.
+					fakeExecutor.ResetExecutedCommands()
+
+					Eventually(k.Update(cluster, func() {
+						if cluster != nil {
+							cluster.Spec.AutoEnableAllFeatureFlags = false
+						}
+					})).Should(Succeed())
+					Eventually(fakeExecutor.ExecutedCommands).Within(time.Second * 5).WithPolling(time.Second).
+						ShouldNot(ContainElement(command{"bash", "-c", "rabbitmqctl enable_feature_flag all"}))
+				})
+			})
+
+			When("enabled", func() {
+				It("calls enable_feature_flag CLI", func() {
+					// BeforeEach updated the STS from zero replicas ready to all ready
+					// Initial rabbitmqcluster create command has reconciles pending to have
+					// all replicas ready to execute commands. We have to reset the "registry"
+					// of commands.
+					fakeExecutor.ResetExecutedCommands()
+
+					Eventually(k.Update(cluster, func() {
+						if cluster != nil {
+							cluster.Spec.AutoEnableAllFeatureFlags = true
+						}
+					})).Should(Succeed())
+					Eventually(fakeExecutor.ExecutedCommands).Within(time.Second * 5).WithPolling(time.Second).
+						Should(ContainElement(command{"bash", "-c", "rabbitmqctl enable_feature_flag all"}))
 				})
 			})
 		})

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -382,6 +382,8 @@ Must be provided together with ImagePullSecrets in order to use an image in a pr
 Set to true to prevent the operator rebalancing queue leaders after a cluster update.
 Has no effect if the cluster only consists of one node.
 For more information, see https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
+| *`autoEnableAllFeatureFlags`* __boolean__ | Set to true to automatically enable all feature flags after each upgrade
+For more information, see https://www.rabbitmq.com/docs/feature-flags
 | *`terminationGracePeriodSeconds`* __integer__ | TerminationGracePeriodSeconds is the timeout that each rabbitmqcluster pod will have to terminate gracefully.
 It defaults to 604800 seconds ( a week long) to ensure that the container preStop lifecycle hook can finish running.
 For more information, see: https://github.com/rabbitmq/cluster-operator/blob/main/docs/design/20200520-graceful-pod-termination.md


### PR DESCRIPTION
If the cluster definition contains:
```
spec:
  autoEnableAllFeatureFlags: true
```

then after each cluster restart, the Operator will call `rabbitmqctl enable_feature_flag all`, which enables all stable feature flags. The property is `false` by default, so this feature is opt-in.

Resolves https://github.com/rabbitmq/cluster-operator/issues/1240