### PR TITLE
Deploy RabbitMQ 4.1.1 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `4.1.0` by default, and should work with [any supported RabbitMQ version](https://www.rabbitmq.com/release-information) and [Kubernetes version](https://kubernetes.io/releases/).
+The operator deploys RabbitMQ `4.1.1` by default, and should work with [any supported RabbitMQ version](https://www.rabbitmq.com/release-information) and [Kubernetes version](https://kubernetes.io/releases/).
 
 ## Versioning
 

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func init() {
 func main() {
 	var (
 		metricsAddr             string
-		defaultRabbitmqImage    = "rabbitmq:4.1.0-management"
+		defaultRabbitmqImage    = "rabbitmq:4.1.1-management"
 		controlRabbitmqImage    = false
 		defaultUserUpdaterImage = "rabbitmqoperator/default-user-credential-updater:1.0.2"
 		defaultImagePullSecrets = ""


### PR DESCRIPTION
Deploy RabbitMQ 4.1.1 by default