### PR TITLE
Update queue grafana dashboard

### DIFF
--- a/observability/grafana/dashboards/rabbitmq-queue.yml
+++ b/observability/grafana/dashboards/rabbitmq-queue.yml
@@ -329,7 +329,7 @@ data:
                   
                 ],
                 "query":{
-                  "query":"query_result(rabbitmq_detailed_queue_messages{namespace=\"$namespace\"} * on (instance, job) group_left(rabbitmq_cluster) topk(1, rabbitmq_identity_info{namespace=\"$namespace\", rabbitmq_cluster=\"$rabbitmq_cluster\") without (rabbitmq_endpoint))",
+                  "query":"query_result(rabbitmq_detailed_queue_messages{namespace=\"$namespace\"} * on (instance, job) group_left(rabbitmq_cluster) topk(1, rabbitmq_identity_info{namespace=\"$namespace\", rabbitmq_cluster=\"$rabbitmq_cluster\"}) without (rabbitmq_endpoint))",
                   "refId":"StandardVariableQuery"
                 },
                 "refresh":2,


### PR DESCRIPTION
The with the update to grafana 4.1 extra labels were added to `rabbitmq_identity_info` which broke a bunch of rules in https://github.com/rabbitmq/cluster-operator/issues/1855 this also updates the grafana queue dashboard since that also broke on the rabbitmq update


**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
