### PR TITLE
Support scale to zero rabbitMQ

### DIFF
--- a/controllers/reconcile_scale_zero.go
+++ b/controllers/reconcile_scale_zero.go
@@ -1,0 +1,98 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
+	"github.com/rabbitmq/cluster-operator/v2/internal/status"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const beforeZeroReplicasConfigured = "rabbitmq.com/before-zero-replicas-configured"
+
+// scaleToZero checks if the desired replicas is zero and the current replicas is not zero.
+func (r *RabbitmqClusterReconciler) scaleToZero(current, sts *appsv1.StatefulSet) bool {
+	currentReplicas := *current.Spec.Replicas
+	desiredReplicas := *sts.Spec.Replicas
+	return desiredReplicas == 0 && currentReplicas > 0
+}
+
+// scaleFromZero checks if the current replicas is zero and the desired replicas is greater than zero.
+func (r *RabbitmqClusterReconciler) scaleFromZero(current, sts *appsv1.StatefulSet) bool {
+	currentReplicas := *current.Spec.Replicas
+	desiredReplicas := *sts.Spec.Replicas
+	return currentReplicas == 0 && desiredReplicas > 0
+}
+
+// scaleDownFromZero checks if the current replicas is desired replicas would be greatter than replicas configured before zero state.
+func (r *RabbitmqClusterReconciler) scaleDownFromZero(ctx context.Context, cluster *v1beta1.RabbitmqCluster, sts *appsv1.StatefulSet) bool {
+	var err error
+	var beforeZeroReplicas int64
+	desiredReplicas := *sts.Spec.Replicas
+	annotationValue, ok := cluster.Annotations[beforeZeroReplicasConfigured]
+	if !ok {
+		return false
+	}
+
+	beforeZeroReplicas, err = strconv.ParseInt(annotationValue, 10, 32)
+	if err != nil {
+		msg := "Failed to convert string to integer for before-zero-replicas-configuration annotation"
+		reason := "TransformErrorOperation"
+		err = r.recordEventsAndSetCondition(ctx, cluster, status.ReconcileSuccess, corev1.ConditionFalse, corev1.EventTypeWarning, reason, msg)
+		if err != nil {
+			return true
+		}
+		return true
+	}
+
+	if desiredReplicas < int32(beforeZeroReplicas) {
+		msg := fmt.Sprintf("Cluster Scale down not supported; tried to scale cluster from %d nodes to %d nodes", int32(beforeZeroReplicas), desiredReplicas)
+		reason := "UnsupportedOperation"
+		err = r.recordEventsAndSetCondition(ctx, cluster, status.ReconcileSuccess, corev1.ConditionFalse, corev1.EventTypeWarning, reason, msg)
+		if err != nil {
+			return true
+		}
+		return true
+	}
+	return false
+}
+
+// saveReplicasBeforeZero saves the current replicas count in an annotation before scaling down to zero.
+// This is used to prevent scaling down when the cluster change from zero replicas to a number less than the saved replicas count.
+func (r *RabbitmqClusterReconciler) saveReplicasBeforeZero(ctx context.Context, cluster *v1beta1.RabbitmqCluster, current *appsv1.StatefulSet) error {
+	var err error
+	currentReplicas := *current.Spec.Replicas
+	logger := ctrl.LoggerFrom(ctx)
+	msg := "Cluster Scale down to 0 replicas."
+	reason := "ScaleDownToZero"
+	logger.Info(msg)
+	err = r.updateAnnotation(ctx, cluster, cluster.Namespace, cluster.Name, beforeZeroReplicasConfigured, fmt.Sprint(currentReplicas))
+	r.Recorder.Event(cluster, corev1.EventTypeNormal, reason, msg)
+	return err
+}
+
+// If the annotation rabbitmq.com/before-zero-replicas-configured exists it will be deleted.
+func (r *RabbitmqClusterReconciler) removeReplicasBeforeZeroAnnotationIfExists(ctx context.Context, cluster *v1beta1.RabbitmqCluster) {
+	if _, ok := cluster.Annotations[beforeZeroReplicasConfigured]; ok {
+		r.deleteAnnotation(ctx, cluster, beforeZeroReplicasConfigured)
+	}
+}
+
+func (r *RabbitmqClusterReconciler) recordEventsAndSetCondition(ctx context.Context, cluster *v1beta1.RabbitmqCluster, condType status.RabbitmqClusterConditionType, condStatus corev1.ConditionStatus, eventType, reason, msg string) error {
+	logger := ctrl.LoggerFrom(ctx)
+	var statusErr error
+	logger.Error(errors.New(reason), msg)
+	r.Recorder.Event(cluster, eventType, reason, msg)
+	cluster.Status.SetCondition(condType, condStatus, reason, msg)
+	if statusErr := r.Status().Update(ctx, cluster); statusErr != nil {
+		logger.Error(statusErr, "Failed to update ReconcileSuccess condition state")
+	}
+	return statusErr
+
+}

--- a/controllers/reconcile_scale_zero_test.go
+++ b/controllers/reconcile_scale_zero_test.go
@@ -1,0 +1,231 @@
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
+	"github.com/rabbitmq/cluster-operator/v2/internal/status"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Cluster scale to zero", func() {
+	var (
+		cluster          *rabbitmqv1beta1.RabbitmqCluster
+		defaultNamespace = "default"
+		ctx              = context.Background()
+	)
+
+	AfterEach(func() {
+		Expect(client.Delete(ctx, cluster)).To(Succeed())
+		waitForClusterDeletion(ctx, cluster, client)
+		Eventually(func() bool {
+			rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+			err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
+			return apierrors.IsNotFound(err)
+		}).Should(BeTrue())
+	})
+
+	It("scale to zero", func() {
+		By("update statefulSet replicas to zero", func() {
+			cluster = &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rabbitmq-to-zero",
+					Namespace: defaultNamespace,
+				},
+				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
+					Replicas: ptr.To(int32(2)),
+				},
+			}
+			Expect(client.Create(ctx, cluster)).To(Succeed())
+			waitForClusterCreation(ctx, cluster, client)
+
+			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
+				r.Spec.Replicas = ptr.To(int32(0))
+			})).To(Succeed())
+
+			Eventually(func() int32 {
+				sts, err := clientSet.AppsV1().StatefulSets(defaultNamespace).Get(ctx, cluster.ChildResourceName("server"), metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return *sts.Spec.Replicas
+			}, 10, 1).Should(Equal(int32(0)))
+
+		})
+
+		By("setting ReconcileSuccess to 'true'", func() {
+			Eventually(func() string {
+				rabbit := &rabbitmqv1beta1.RabbitmqCluster{}
+				Expect(client.Get(ctx, runtimeClient.ObjectKey{
+					Name:      cluster.Name,
+					Namespace: defaultNamespace,
+				}, rabbit)).To(Succeed())
+
+				for i := range rabbit.Status.Conditions {
+					if rabbit.Status.Conditions[i].Type == status.ReconcileSuccess {
+						return fmt.Sprintf(
+							"ReconcileSuccess status: %s, with reason: %s and message: %s",
+							rabbit.Status.Conditions[i].Status,
+							rabbit.Status.Conditions[i].Reason,
+							rabbit.Status.Conditions[i].Message)
+					}
+				}
+				return "ReconcileSuccess status: condition not present"
+			}, 0).Should(Equal("ReconcileSuccess status: True, " +
+				"with reason: Success " +
+				"and message: Finish reconciling"))
+		})
+	})
+})
+
+var _ = Describe("Cluster scale from zero", func() {
+	var (
+		cluster          *rabbitmqv1beta1.RabbitmqCluster
+		defaultNamespace = "default"
+		ctx              = context.Background()
+	)
+
+	AfterEach(func() {
+		Expect(client.Delete(ctx, cluster)).To(Succeed())
+		waitForClusterDeletion(ctx, cluster, client)
+		Eventually(func() bool {
+			rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+			err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
+			return apierrors.IsNotFound(err)
+		}).Should(BeTrue())
+	})
+
+	It("scale from zero", func() {
+		By("update statefulSet replicas from zero", func() {
+			cluster = &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rabbitmq-from-zero",
+					Namespace: defaultNamespace,
+					Annotations: map[string]string{
+						"rabbitmq.com/before-zero-replicas-configured": "2",
+					},
+				},
+				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
+					Replicas: ptr.To(int32(0)),
+				},
+			}
+			Expect(client.Create(ctx, cluster)).To(Succeed())
+			waitForClusterCreation(ctx, cluster, client)
+
+			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
+				r.Spec.Replicas = ptr.To(int32(2))
+			})).To(Succeed())
+
+			Eventually(func() int32 {
+				sts, err := clientSet.AppsV1().StatefulSets(defaultNamespace).Get(ctx, cluster.ChildResourceName("server"), metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return *sts.Spec.Replicas
+			}, 10, 1).Should(Equal(int32(2)))
+
+		})
+
+		By("setting ReconcileSuccess to 'true'", func() {
+			Eventually(func() string {
+				rabbit := &rabbitmqv1beta1.RabbitmqCluster{}
+				Expect(client.Get(ctx, runtimeClient.ObjectKey{
+					Name:      cluster.Name,
+					Namespace: defaultNamespace,
+				}, rabbit)).To(Succeed())
+
+				for i := range rabbit.Status.Conditions {
+					if rabbit.Status.Conditions[i].Type == status.ReconcileSuccess {
+						return fmt.Sprintf(
+							"ReconcileSuccess status: %s, with reason: %s and message: %s",
+							rabbit.Status.Conditions[i].Status,
+							rabbit.Status.Conditions[i].Reason,
+							rabbit.Status.Conditions[i].Message)
+					}
+				}
+				return "ReconcileSuccess status: condition not present"
+			}, 0).Should(Equal("ReconcileSuccess status: True, " +
+				"with reason: Success " +
+				"and message: Finish reconciling"))
+		})
+	})
+})
+
+var _ = Describe("Cluster scale from zero to less replicas configured", Ordered, func() {
+	var (
+		cluster          *rabbitmqv1beta1.RabbitmqCluster
+		defaultNamespace = "default"
+		ctx              = context.Background()
+	)
+
+	AfterEach(func() {
+		Expect(client.Delete(ctx, cluster)).To(Succeed())
+		waitForClusterDeletion(ctx, cluster, client)
+		Eventually(func() bool {
+			rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+			err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
+			return apierrors.IsNotFound(err)
+		}).Should(BeTrue())
+	})
+
+	It("scale from zero to less replicas", func() {
+		By("update statefulSet replicas from zero", func() {
+			cluster = &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rabbitmq-from-zero-to-less",
+					Namespace: defaultNamespace,
+					Annotations: map[string]string{
+						"rabbitmq.com/before-zero-replicas-configured": "2",
+					},
+				},
+				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
+					Replicas: ptr.To(int32(0)),
+				},
+			}
+			Expect(client.Create(ctx, cluster)).To(Succeed())
+			waitForClusterCreation(ctx, cluster, client)
+
+			Expect(updateWithRetry(cluster, func(r *rabbitmqv1beta1.RabbitmqCluster) {
+				r.Spec.Replicas = ptr.To(int32(1))
+			})).To(Succeed())
+
+			Consistently(func() int32 {
+				sts, err := clientSet.AppsV1().StatefulSets(defaultNamespace).Get(ctx, cluster.ChildResourceName("server"), metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return *sts.Spec.Replicas
+			}, 10, 1).Should(Equal(int32(0)))
+
+		})
+
+		By("setting 'Warning' events", func() {
+			Expect(aggregateEventMsgs(ctx, cluster, "UnsupportedOperation")).To(
+				ContainSubstring("Cluster Scale down not supported"))
+		})
+
+		By("setting ReconcileSuccess to 'false'", func() {
+			Eventually(func() string {
+				rabbit := &rabbitmqv1beta1.RabbitmqCluster{}
+				Expect(client.Get(ctx, runtimeClient.ObjectKey{
+					Name:      cluster.Name,
+					Namespace: defaultNamespace,
+				}, rabbit)).To(Succeed())
+
+				for i := range rabbit.Status.Conditions {
+					if rabbit.Status.Conditions[i].Type == status.ReconcileSuccess {
+						return fmt.Sprintf(
+							"ReconcileSuccess status: %s, with reason: %s and message: %s",
+							rabbit.Status.Conditions[i].Status,
+							rabbit.Status.Conditions[i].Reason,
+							rabbit.Status.Conditions[i].Message)
+					}
+				}
+				return "ReconcileSuccess status: condition not present"
+			}, 0).Should(Equal("ReconcileSuccess status: False, " +
+				"with reason: UnsupportedOperation " +
+				"and message: Cluster Scale down not supported; tried to scale cluster from 2 nodes to 1 nodes"))
+		})
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/rabbitmq/cluster-operator/v2
 
-go 1.24.2
-
-toolchain go1.24.3
+go 1.24.4
 
 require (
 	github.com/cloudflare/cfssl v1.6.5


### PR DESCRIPTION
This closes https://github.com/rabbitmq/cluster-operator/issues/1876 

As talked in the issue we add some logic to allow scale to zero the rabbitMQ.

Also we add some logic to prevent the scale down when opt-out from zero.

We add new annotation `rabbitmq.com/before-zero-replicas-configured` to save the replicas configured before put rabbitMQ to zero.

With this annotation we verify if the desired replicas after zero state are equals or greater than replicas before zero state.
If the replicas don't pass the verification it will works like `scaleDown`.

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
