### PR TITLE
RMQ-1955, RMQ-1960 : Bump go to fix CVE-2025-4674 and CVE-2025-47907

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rabbitmq/cluster-operator/v2
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/cloudflare/cfssl v1.6.5

--- a/internal/promtool/go.mod
+++ b/internal/promtool/go.mod
@@ -1,6 +1,6 @@
 module promtool
 
-go 1.24.3
+go 1.24.6
 
 tool github.com/prometheus/prometheus/cmd/promtool
 

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,8 +1,6 @@
 module tools
 
-go 1.24.2
-
-toolchain go1.24.3
+go 1.24.6
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect


### PR DESCRIPTION
## Summary Of Changes
Bump go to fix CVE-2025-4674 and CVE-2025-47907