### PR TITLE
Deploy RabbitMQ 4.1.3 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `4.1.1` by default, and should work with [any supported RabbitMQ version](https://www.rabbitmq.com/release-information) and [Kubernetes version](https://kubernetes.io/releases/).
+The operator deploys RabbitMQ `4.1.3` by default, and should work with [any supported RabbitMQ version](https://www.rabbitmq.com/release-information) and [Kubernetes version](https://kubernetes.io/releases/).
 
 ## Versioning
 

--- a/docs/examples/mtls-inter-node/rabbitmq.yaml
+++ b/docs/examples/mtls-inter-node/rabbitmq.yaml
@@ -3,6 +3,7 @@ kind: RabbitmqCluster
 metadata:
   name: mtls-inter-node
 spec:
+  image: rabbitmq:4.1.3-management
   rabbitmq:
     envConfig: |
       SERVER_ADDITIONAL_ERL_ARGS="-proto_dist inet_tls -ssl_dist_optfile /etc/rabbitmq/inter-node-tls.config"

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func init() {
 func main() {
 	var (
 		metricsAddr             string
-		defaultRabbitmqImage    = "rabbitmq:4.1.1-management"
+		defaultRabbitmqImage    = "rabbitmq:4.1.3-management"
 		controlRabbitmqImage    = false
 		defaultUserUpdaterImage = "rabbitmqoperator/default-user-credential-updater:1.0.2"
 		defaultImagePullSecrets = ""


### PR DESCRIPTION
Deploy RabbitMQ 4.1.3 by default