### PR TITLE
Add security context

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,4 +51,12 @@ spec:
         - containerPort: 9782
           name: metrics
           protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - All
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This closes #1910 and #1960 

Adds a securityContext to the cluster operator deployment context. 
Adds securityContext to RabbitMQ Pods, containers, and init containers.