### PR TITLE
set endPort as default in the netpols examples

### DIFF
--- a/docs/examples/network-policies/allow-inter-node-traffic.yaml
+++ b/docs/examples/network-policies/allow-inter-node-traffic.yaml
@@ -21,6 +21,7 @@ spec:
     - port: 6000  # stream replication, if streams are being used
       endPort: 6500
     - port: 25672 # clustering
+    - port: 35672 # CLI tooling
       endPort: 35682
   ingress:
   - from:

--- a/docs/examples/network-policies/allow-inter-node-traffic.yaml
+++ b/docs/examples/network-policies/allow-inter-node-traffic.yaml
@@ -19,22 +19,9 @@ spec:
     ports:
     - port: 4369  # epmd
     - port: 6000  # stream replication, if streams are being used
-      endPort: 6500 # if your cluster version is below 1.22 (see below) you should use a helm loop or something similar
+      endPort: 6500
     - port: 25672 # clustering
-    - port: 35672 # CLI tooling
-    - port: 35673 # CLI tooling
-    - port: 35674 # CLI tooling
-    - port: 35675 # CLI tooling
-    - port: 35676 # CLI tooling
-    - port: 35677 # CLI tooling
-    - port: 35678 # CLI tooling
-    - port: 35679 # CLI tooling
-    - port: 35680 # CLI tooling
-    - port: 35681 # CLI tooling
-    - port: 35682 # CLI tooling
-  # If using the k8s feature gate NetworkPolicyEndPort (enabled by default 1.22+), the last 11 entries can be simplified to:
-  # - port: 35672 # CLI tooling
-  #   endPort: 35682
+      endPort: 35682
   ingress:
   - from:
     - podSelector:
@@ -44,19 +31,7 @@ spec:
     ports:
     - port: 4369  # epmd
     - port: 6000  # stream replication, if streams are being used
-      endPort: 6500 # if your cluster version is below 1.22 (see below) you should use a helm loop or something similar
+      endPort: 6500 
     - port: 25672 # clustering
     - port: 35672 # CLI tooling
-    - port: 35673 # CLI tooling
-    - port: 35674 # CLI tooling
-    - port: 35675 # CLI tooling
-    - port: 35676 # CLI tooling
-    - port: 35677 # CLI tooling
-    - port: 35678 # CLI tooling
-    - port: 35679 # CLI tooling
-    - port: 35680 # CLI tooling
-    - port: 35681 # CLI tooling
-    - port: 35682 # CLI tooling
-  # If using the k8s feature gate NetworkPolicyEndPort (enabled by default 1.22+), the last 11 entries can be simplified to:
-  # - port: 35672 # CLI tooling
-  #   endPort: 35682
+      endPort: 35682


### PR DESCRIPTION
We have Kubernetes 1.32 currently i think nearly nobody is on Kubernetes 1.21 and lower - i would like to propose to reflect this in the docs. 