### PR TITLE
Fix RabbitMQ log output with Vault configured

### DIFF
--- a/docs/examples/vault-default-user/setup.sh
+++ b/docs/examples/vault-default-user/setup.sh
@@ -14,7 +14,7 @@ helm repo update
 # For OpenShift deployments, also set the following:
 # --set "global.openshift=true"
 helm install vault hashicorp/vault \
-    --version 0.19.0 \
+    --version 0.31.0 \
     --set='server.dev.enabled=true' \
     --set='server.logLevel=debug' \
     --set='injector.logLevel=debug' \

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -29,6 +29,7 @@ import (
 const (
 	ServerConfigMapName = "server-conf"
 	defaultRabbitmqConf = `
+log.console = true
 queue_master_locator = min-masters
 disk_free_limit.absolute = 2GB
 cluster_partition_handling = pause_minority

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -29,6 +29,7 @@ import (
 
 func defaultRabbitmqConf(instanceName string) string {
 	return iniString(`
+log.console                                = true
 queue_master_locator                       = min-masters
 disk_free_limit.absolute                   = 2GB
 cluster_partition_handling                 = pause_minority


### PR DESCRIPTION
This commit fixes the CI failure which tests the following example: https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/vault-default-user

RabbitMQ crashed at startup as follows:
```
failed to open log file at '/var/log/rabbitmq/rabbit@vault-default-user-server-0.vault-default-user-nodes.examples.log', reason: read-only file system
```

The problem was that with Vault configured the mount in https://github.com/rabbitmq/cluster-operator/blob/575cfacf74775a569202d08e406e4e6b5d9d1780/internal/resource/statefulset.go#L876 seems to hide the config file in
https://github.com/docker-library/rabbitmq/blob/master/conf.d/10-defaults.conf containing the setting
```
log.console = true
```

Without any vault, the config directory in the RabbitMQ pod looks as follows:
```
k exec r1-server-0 -c rabbitmq -- ls /etc/rabbitmq/conf.d
10-defaults.conf
10-operatorDefaults.conf
11-default_user.conf
90-userDefinedConfiguration.conf
```

With vault configured, the config directory in the RabbitMQ pod looks as follows:
```
k exec vault-default-user-server-0 -c rabbitmq -- ls /etc/rabbitmq/conf.d
10-operatorDefaults.conf
11-default_user.conf
90-userDefinedConfiguration.conf
```

This commit fixes the issue by adding
```
log.console = true
```
to file `10-operatorDefaults.conf`.

There is no harm if this setting is defined twice in different files in the `/etc/rabbitmq/conf.d` directory. The last one wins.
