### PR TITLE
Update BASELINE_UPGRADE_VERSION to v2.12.0

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -18,7 +18,7 @@ env:
   # The image here should be listed under 'Images built for this release' for the version of kind in go.mod
   KIND_NODE_IMAGE: "kindest/node:v1.32.0"
   KIND_OLDEST_NODE_IMAGE: "kindest/node:v1.29.12"
-  BASELINE_UPGRADE_VERSION: v2.1.0
+  BASELINE_UPGRADE_VERSION: v2.12.0
 
 jobs:
   kubectl_tests:


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Because version 2.1.0 is from 3 years ago. 2.12.0 is from 1 year ago. The delta between 2.1.0 and 2.19.0+ is simply too great, in Kubernetes versions and CRD changes, therefore, it's highly unlikely that upgrade 2.1.0 -> 2.19.0+ won't cause a rolling upgrade of all rabbits. The same may not be true for "closer" versions e.g. 2.12.0 -> 2.19.0+

## Additional Context

Since v2.12.1, all operator "upgrades" from the baseline v2.1.0 cause a rolling restart of all rabbits 🫠 
