### PR TITLE
Combine dependabot groups.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
 - package-ecosystem: "gomod"
   directory: "/internal/tools/"
   groups:
-    tools:
+    all:
       patterns:
       - '*'
   schedule:
@@ -28,19 +28,23 @@ updates:
 - package-ecosystem: "gomod"
   directory: "/internal/promtool/"
   groups:
-    promtool:
+    all:
       patterns:
       - '*'
   schedule:
     interval: "daily"
 - package-ecosystem: "github-actions"
   directory: "/"
+  groups:
+    actions:
+      patterns:
+      - '*'
   schedule:
     interval: "weekly"
 - package-ecosystem: "gomod"
   directory: "/bin/kubectl-rabbitmq-plugin/"
   groups:
-    kubectl-rabbitmq-plugin:
+    all:
       patterns:
       - '*'
   schedule:


### PR DESCRIPTION
This allows dependabot to bump the kubectl plugin dependencies simultaneously to the controller dependencies (dependabot doesn't run go mod tidy anywhere but in the go file it's updating).

Also combined other dependabot groups into all to reduce the number of PRs dependabot creates.