### PR TITLE
olm: updates to support FBC format

### DIFF
--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -93,6 +93,7 @@ jobs:
             olm/manifests
             olm/metadata
             olm/bundle.Dockerfile
+            olm/release-config.yaml
           if-no-files-found: error
           retention-days: 1
 
@@ -179,6 +180,7 @@ jobs:
           GH_PROMPT_DISABLED: 1
           # secret_rabbitmq/kv/Shared-Shared-RabbitMQ%2Frabbitmq-ci/details
           GH_TOKEN: ${{ secrets.RABBITMQ_CI_TOKEN }}
+        # remove release config because this file is Red Hat marketplace specific
         run: |
           git config user.name "rabbitmq-ci"
           git config user.email ${{ secrets.RABBITMQ_CI_EMAIL }}
@@ -186,6 +188,7 @@ jobs:
           git checkout "rabbitmq-cluster-operator-$BUNDLE_VERSION"
           
           mkdir -pv operators/rabbitmq-cluster-operator/"$BUNDLE_VERSION"
+          rm -v -f olm-package-ci/release-config.yaml
           cp -v -fR olm-package-ci/* ./operators/rabbitmq-cluster-operator/"$BUNDLE_VERSION"/
           git add operators/rabbitmq-cluster-operator
           git commit -s -m "operator rabbitmq-cluster-operator release $BUNDLE_VERSION"
@@ -221,13 +224,15 @@ jobs:
           GH_PROMPT_DISABLED: 1
           # secret_rabbitmq/kv/Shared-Shared-RabbitMQ%2Frabbitmq-ci/details
           GH_TOKEN: ${{ secrets.RABBITMQ_CI_TOKEN }}
-        # IMPORTANT: this job does not open the PR automatically because the operator is configured differently in
-        # RedHat marketplace CI. In RedHat Marketplace, we have semver-mode for update strategy, and in operatorhub
-        # we have replaces-mode strategy.
+        # IMPORTANT: as of Jan 2026, the operator OLM manifests use File-Based-Catalog (FBC) format
+        # https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_workflow/
         # https://k8s-operatorhub.github.io/community-operators/operator-ci-yaml/
-        # As workaround, this job will create the branch with the new version, and a maintainer will make adjustments
-        # before manually opening a PR.
-        # TODO(Zerpet): make update strategy consistent
+        #
+        # This enables us to use the auto-release workflow. Notice how the below `run` section does not
+        # `rm` the release config file.
+        # https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_autorelease/
+        #
+        # The script removed the bundle.Dockerfile file because it is not needed for the FBC workflow.
         run: |
           git config user.name "rabbitmq-ci"
           git config user.email ${{ secrets.RABBITMQ_CI_EMAIL }}
@@ -235,7 +240,12 @@ jobs:
           git checkout "rabbitmq-cluster-operator-$BUNDLE_VERSION"
           
           mkdir -pv operators/rabbitmq-cluster-operator/"$BUNDLE_VERSION"
+          rm -v -f olm-package-ci/bundle.Dockerfile
           cp -v -fR olm-package-ci/* ./operators/rabbitmq-cluster-operator/"$BUNDLE_VERSION"/
           git add operators/rabbitmq-cluster-operator
           git commit -s -m "operator rabbitmq-cluster-operator release $BUNDLE_VERSION"
           git push --set-upstream origin "rabbitmq-cluster-operator-$BUNDLE_VERSION"
+
+          gh pr create --title "operator rabbitmq-cluster-operator (${{ env.BUNDLE_VERSION }})" \
+            --body "Update operator rabbitmq-cluster-operator (${{ needs.test-olm-package.outputs.olm_package_version }})" \
+            --repo redhat-openshift-ecosystem/community-operators-prod

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tmp/
 # Ignore manifests in OLM
 olm/manifests/*.y*ml
 olm/catalog/catalog.y*ml
+olm/release-config.yaml
 # Act - source of secret values
 /.secrets
 /.vars

--- a/olm.mk
+++ b/olm.mk
@@ -19,8 +19,9 @@ all::crd ## Default goal. Generates bundle manifests
 all::rbac
 all::deployment
 all::olm-manifests
+all::olm-release-config
 
-.PHONY: all crd rbac deployment olm-manifests clean
+.PHONY: all crd rbac deployment olm-manifests olm-release-config clean
 
 OLM_DIR = $(CURDIR)/olm/manifests
 $(OLM_DIR) :
@@ -55,6 +56,12 @@ olm-manifests: $(OLM_DIR) ## Render bundle manifests. Customise version using BU
 		--data-value version="$(BUNDLE_VERSION)" \
 		--data-value replaces="$(BUNDLE_REPLACES)" \
 		> $(OLM_DIR)/rabbitmq-cluster-operator.clusterserviceversion.yaml
+
+olm-release-config: $(OLM_DIR) ## Render release config manifests. Customise version using BUNDLE_VERSION and BUNDLE_CREATED_AT
+	ytt -f $(CURDIR)/olm/templates/release-config-template.yaml \
+		--data-value replaces="$(BUNDLE_REPLACES)" \
+		--data-values-file $(CURDIR)/olm/values-release.yaml \
+		> $(CURDIR)/olm/release-config.yaml
 
 clean:
 	rm -f -v $(CURDIR)/olm/manifests/*.y*ml

--- a/olm/templates/release-config-template.yaml
+++ b/olm/templates/release-config-template.yaml
@@ -1,0 +1,11 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:assert", "assert")
+
+---
+catalog_templates:
+#@ for version in data.values.supported_openshift_versions:
+  - template_name: #@ version + ".yaml"
+    channels: [stable]
+    #@ replaces = data.values.replaces
+    replaces: #@ replaces if replaces else assert.fail("replaces must be set")
+#@ end

--- a/olm/values-release.yaml
+++ b/olm/values-release.yaml
@@ -1,0 +1,3 @@
+---
+#! See https://access.redhat.com/support/policy/updates/openshift#dates for the list of supported OpenShift versions
+supported_openshift_versions: ["4.17", "4.18", "4.19", "4.20"]

--- a/olm/values.example.yaml
+++ b/olm/values.example.yaml
@@ -4,3 +4,5 @@ createdAt: '2025-05-02T09:11:31'
 image: quay.io/rabbitmqoperator/cluster-operator:2.14.0
 version: 2.14.0
 replaces: rabbitmq-cluster-operator.v2.13.0
+#! See https://access.redhat.com/support/policy/updates/openshift#dates for the list of supported OpenShift versions
+supported_openshift_versions: ["4.17", "4.18", "4.19"]


### PR DESCRIPTION
## Summary Of Changes

- Update OLM workflow to leverage File-Based Catalog in OLM

## Additional Context

Most of the changes were done as part of redhat-openshift-ecosystem/community-operators-prod#8682

This commit adds a new file required to leverage the FBC auto-release feature. The process in general lines is the same. The change to FBC is mainly in the okd community catalog. From our side, we must continue to producer operator OLM bundles. There is automation in OKD/OCP catalog repo to make necessary conversions to add new bundles to the catalog.

## Local Testing

Run `gmake -f olm.mk clean all` and observe the files generated. CI uses variables to substitute adequate values for a release.
