### PR TITLE
Add web amqp port.

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -364,9 +364,9 @@ type TLSSpec struct {
 	// Name of a Secret in the same Namespace as the RabbitmqCluster, containing the Certificate Authority's public certificate for TLS.
 	// The Secret must store this as ca.crt.
 	// This Secret can be created by running `kubectl create secret generic ca-secret --from-file=ca.crt=path/to/ca.crt`
-	// Used for mTLS, and TLS for rabbitmq_web_stomp and rabbitmq_web_mqtt.
+	// Used for mTLS, and TLS for rabbitmq_web_amqp, rabbitmq_web_stomp and rabbitmq_web_mqtt.
 	CaSecretName string `json:"caSecretName,omitempty"`
-	// When set to true, the RabbitmqCluster disables non-TLS listeners for RabbitMQ, management plugin and for any enabled plugins in the following list: stomp, mqtt, web_stomp, web_mqtt.
+	// When set to true, the RabbitmqCluster disables non-TLS listeners for RabbitMQ, management plugin and for any enabled plugins in the following list: stomp, mqtt, web_stomp, web_mqtt, web_amqp.
 	// Only TLS-enabled clients will be able to connect.
 	DisableNonTLSListeners bool `json:"disableNonTLSListeners,omitempty"`
 }

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -5375,11 +5375,11 @@ spec:
                         Name of a Secret in the same Namespace as the RabbitmqCluster, containing the Certificate Authority's public certificate for TLS.
                         The Secret must store this as ca.crt.
                         This Secret can be created by running `kubectl create secret generic ca-secret --from-file=ca.crt=path/to/ca.crt`
-                        Used for mTLS, and TLS for rabbitmq_web_stomp and rabbitmq_web_mqtt.
+                        Used for mTLS, and TLS for rabbitmq_web_amqp, rabbitmq_web_stomp and rabbitmq_web_mqtt.
                       type: string
                     disableNonTLSListeners:
                       description: |-
-                        When set to true, the RabbitmqCluster disables non-TLS listeners for RabbitMQ, management plugin and for any enabled plugins in the following list: stomp, mqtt, web_stomp, web_mqtt.
+                        When set to true, the RabbitmqCluster disables non-TLS listeners for RabbitMQ, management plugin and for any enabled plugins in the following list: stomp, mqtt, web_stomp, web_mqtt, web_amqp.
                         Only TLS-enabled clients will be able to connect.
                       type: boolean
                     secretName:

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -590,8 +590,8 @@ This Secret can be created by running `kubectl create secret tls tls-secret --ce
 | *`caSecretName`* __string__ | Name of a Secret in the same Namespace as the RabbitmqCluster, containing the Certificate Authority's public certificate for TLS.
 The Secret must store this as ca.crt.
 This Secret can be created by running `kubectl create secret generic ca-secret --from-file=ca.crt=path/to/ca.crt`
-Used for mTLS, and TLS for rabbitmq_web_stomp and rabbitmq_web_mqtt.
-| *`disableNonTLSListeners`* __boolean__ | When set to true, the RabbitmqCluster disables non-TLS listeners for RabbitMQ, management plugin and for any enabled plugins in the following list: stomp, mqtt, web_stomp, web_mqtt.
+Used for mTLS, and TLS for rabbitmq_web_amqp, rabbitmq_web_stomp and rabbitmq_web_mqtt.
+| *`disableNonTLSListeners`* __boolean__ | When set to true, the RabbitmqCluster disables non-TLS listeners for RabbitMQ, management plugin and for any enabled plugins in the following list: stomp, mqtt, web_stomp, web_mqtt, web_amqp.
 Only TLS-enabled clients will be able to connect.
 |===
 

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -231,6 +231,25 @@ func (builder *ServerConfigMapBuilder) Update(object client.Object) error {
 				}
 			}
 		}
+		if builder.Instance.AdditionalPluginEnabled("rabbitmq_web_amqp") {
+			if !builder.Instance.DisableNonTLSListeners() {
+				if _, err := userConfigurationSection.NewKey("web_amqp.tcp.port", "15678"); err != nil {
+					return err
+				}
+			}
+			if _, err := userConfigurationSection.NewKey("web_amqp.tls.port", "15677"); err != nil {
+				return err
+			}
+			if _, err := userConfigurationSection.NewKey("web_amqp.tls.cacertfile", caCertPath); err != nil {
+				return err
+			}
+			if _, err := userConfigurationSection.NewKey("web_amqp.tls.certfile", tlsCertPath); err != nil {
+				return err
+			}
+			if _, err := userConfigurationSection.NewKey("web_amqp.tls.keyfile", tlsKeyPath); err != nil {
+				return err
+			}
+		}
 	}
 
 	if builder.Instance.MemoryLimited() {

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -356,9 +356,9 @@ CONSOLE_LOG=new`
 				Expect(configMap.Data).To(HaveKeyWithValue("userDefinedConfiguration.conf", expectedConfiguration))
 			})
 
-			When("Web MQTT and Web STOMP are enabled", func() {
+			When("Web AMQP, Web MQTT and Web STOMP are enabled", func() {
 				It("adds TLS config for the additional plugins", func() {
-					additionalPlugins := []rabbitmqv1beta1.Plugin{"rabbitmq_web_mqtt", "rabbitmq_web_stomp"}
+					additionalPlugins := []rabbitmqv1beta1.Plugin{"rabbitmq_web_amqp", "rabbitmq_web_mqtt", "rabbitmq_web_stomp"}
 
 					instance.Name = "rabbit-tls"
 					instance.Spec.TLS.SecretName = "tls-secret"
@@ -393,7 +393,13 @@ CONSOLE_LOG=new`
 						web_stomp.ssl.port       = 15673
 						web_stomp.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
 						web_stomp.ssl.certfile   = /etc/rabbitmq-tls/tls.crt
-						web_stomp.ssl.keyfile    = /etc/rabbitmq-tls/tls.key`)
+						web_stomp.ssl.keyfile    = /etc/rabbitmq-tls/tls.key
+
+						web_amqp.tcp.port       = 15678
+						web_amqp.tls.port       = 15677
+						web_amqp.tls.cacertfile = /etc/rabbitmq-tls/ca.crt
+						web_amqp.tls.certfile   = /etc/rabbitmq-tls/tls.crt
+						web_amqp.tls.keyfile    = /etc/rabbitmq-tls/tls.key`)
 
 					Expect(configMapBuilder.Update(configMap)).To(Succeed())
 					Expect(configMap.Data).To(HaveKeyWithValue("userDefinedConfiguration.conf", expectedConfiguration))
@@ -496,6 +502,7 @@ CONSOLE_LOG=new`
 						},
 						Rabbitmq: rabbitmqv1beta1.RabbitmqClusterConfigurationSpec{
 							AdditionalPlugins: []rabbitmqv1beta1.Plugin{
+								"rabbitmq_web_amqp",
 								"rabbitmq_web_mqtt",
 								"rabbitmq_web_stomp",
 							},
@@ -532,7 +539,12 @@ CONSOLE_LOG=new`
 					web_stomp.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt
 					web_stomp.ssl.certfile   = /etc/rabbitmq-tls/tls.crt
 					web_stomp.ssl.keyfile    = /etc/rabbitmq-tls/tls.key
-					web_stomp.tcp.listener = none`)
+					web_stomp.tcp.listener = none
+
+					web_amqp.tls.port       = 15677
+					web_amqp.tls.cacertfile = /etc/rabbitmq-tls/ca.crt
+					web_amqp.tls.certfile   = /etc/rabbitmq-tls/tls.crt
+					web_amqp.tls.keyfile    = /etc/rabbitmq-tls/tls.key`)
 
 				Expect(configMapBuilder.Update(configMap)).To(Succeed())
 				Expect(configMap.Data).To(HaveKeyWithValue("userDefinedConfiguration.conf", expectedConfiguration))

--- a/internal/resource/default_user_secret.go
+++ b/internal/resource/default_user_secret.go
@@ -135,6 +135,7 @@ func (builder *DefaultUserSecretBuilder) updatePorts(secret *corev1.Secret) {
 		"rabbitmq_stream":    "stream-port",
 		"rabbitmq_web_mqtt":  "web-mqtt-port",
 		"rabbitmq_web_stomp": "web-stomp-port",
+		"rabbitmq_web_amqp":  "web-amqp-port",
 	}
 	TLSPort := map[string]string{
 		"mqtt-port":      "8883",
@@ -142,6 +143,7 @@ func (builder *DefaultUserSecretBuilder) updatePorts(secret *corev1.Secret) {
 		"stream-port":    "5551",
 		"web-mqtt-port":  "15676",
 		"web-stomp-port": "15673",
+		"web-amqp-port":  "15677",
 	}
 	port := map[string]string{
 		"mqtt-port":      "1883",
@@ -149,6 +151,7 @@ func (builder *DefaultUserSecretBuilder) updatePorts(secret *corev1.Secret) {
 		"stream-port":    "5552",
 		"web-mqtt-port":  "15675",
 		"web-stomp-port": "15674",
+		"web-amqp-port":  "15678",
 	}
 
 	if builder.Instance.Spec.TLS.SecretName != "" {

--- a/internal/resource/default_user_secret_test.go
+++ b/internal/resource/default_user_secret_test.go
@@ -157,14 +157,15 @@ var _ = Describe("DefaultUserSecret", func() {
 		})
 	})
 
-	Context("when MQTT, STOMP, streams, WebMQTT, and WebSTOMP are enabled", func() {
-		It("adds the MQTT, STOMP, stream, WebMQTT, and WebSTOMP ports to the user secret", func() {
+	Context("when MQTT, STOMP, streams, WebAMQP, WebMQTT, and WebSTOMP are enabled", func() {
+		It("adds the MQTT, STOMP, stream, WebAMQP, WebMQTT, and WebSTOMP ports to the user secret", func() {
 			var port []byte
 
 			instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{
 				"rabbitmq_mqtt",
 				"rabbitmq_stomp",
 				"rabbitmq_stream",
+				"rabbitmq_web_amqp",
 				"rabbitmq_web_mqtt",
 				"rabbitmq_web_stomp",
 			}
@@ -192,6 +193,10 @@ var _ = Describe("DefaultUserSecret", func() {
 			port, ok = secret.Data["web-stomp-port"]
 			Expect(ok).To(BeTrue(), "Failed to find key \"web-stomp-port\" in the generated Secret")
 			Expect(port).To(BeEquivalentTo("15674"))
+
+			port, ok = secret.Data["web-amqp-port"]
+			Expect(ok).To(BeTrue(), "Failed to find key \"web-amqp-port\" in the generated Secret")
+			Expect(port).To(BeEquivalentTo("15678"))
 		})
 	})
 
@@ -211,7 +216,7 @@ var _ = Describe("DefaultUserSecret", func() {
 		})
 
 		Context("when MQTT, STOMP, streams, WebMQTT, and WebSTOMP are enabled", func() {
-			It("adds the MQTTS, STOMPS, streams, WebMQTTS, and WebSTOMPS ports to the user secret", func() {
+			It("adds the MQTTS, STOMPS, streams, WebAMQPS, WebMQTTS, and WebSTOMPS ports to the user secret", func() {
 				var port []byte
 
 				instance.Spec.TLS.SecretName = "tls-secret"
@@ -221,6 +226,7 @@ var _ = Describe("DefaultUserSecret", func() {
 					"rabbitmq_stream",
 					"rabbitmq_web_mqtt",
 					"rabbitmq_web_stomp",
+					"rabbitmq_web_amqp",
 				}
 
 				obj, err := defaultUserSecretBuilder.Build()
@@ -246,6 +252,10 @@ var _ = Describe("DefaultUserSecret", func() {
 				port, ok = secret.Data["web-stomp-port"]
 				Expect(ok).To(BeTrue(), "Failed to find key \"web-stomp-port\" in the generated Secret")
 				Expect(port).To(BeEquivalentTo("15673"))
+
+				port, ok = secret.Data["web-amqp-port"]
+				Expect(ok).To(BeTrue(), "Failed to find key \"web-stomp-port\" in the generated Secret")
+				Expect(port).To(BeEquivalentTo("15677"))
 			})
 		})
 	})

--- a/internal/resource/service.go
+++ b/internal/resource/service.go
@@ -178,6 +178,15 @@ func (builder *ServiceBuilder) generateServicePortsMap() map[string]corev1.Servi
 				AppProtocol: ptr.To("http"),
 			}
 		}
+		if builder.Instance.AdditionalPluginEnabled("rabbitmq_web_amqp") {
+			servicePortsMap["web-amqp"] = corev1.ServicePort{
+				Protocol:    corev1.ProtocolTCP,
+				Port:        15678,
+				TargetPort:  intstr.FromInt(15678),
+				Name:        "web-amqp",
+				AppProtocol: ptr.To("http"),
+			}
+		}
 
 		if builder.Instance.StreamNeeded() {
 			servicePortsMap["stream"] = corev1.ServicePort{
@@ -271,6 +280,15 @@ func (builder *ServiceBuilder) generateServicePortsMap() map[string]corev1.Servi
 				Port:        15676,
 				Name:        "web-mqtt-tls",
 				TargetPort:  intstr.FromInt(15676),
+				AppProtocol: ptr.To("https"),
+			}
+		}
+		if builder.Instance.AdditionalPluginEnabled("rabbitmq_web_amqp") {
+			servicePortsMap["web-amqp-tls"] = corev1.ServicePort{
+				Protocol:    corev1.ProtocolTCP,
+				Port:        15677,
+				Name:        "web-amqp-tls",
+				TargetPort:  intstr.FromInt(15677),
 				AppProtocol: ptr.To("https"),
 			}
 		}

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -153,12 +153,19 @@ var _ = Context("Services", func() {
 				})
 			})
 
-			When("rabbitmq_web_mqtt and rabbitmq_web_stomp are enabled", func() {
+			When("rabbitmq_web_amqp, rabbitmq_web_mqtt and rabbitmq_web_stomp are enabled", func() {
 				It("opens ports for those plugins", func() {
 					instance.Spec.TLS.CaSecretName = "caname"
-					instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_web_mqtt", "rabbitmq_web_stomp"}
+					instance.Spec.Rabbitmq.AdditionalPlugins = []rabbitmqv1beta1.Plugin{"rabbitmq_web_amqp", "rabbitmq_web_mqtt", "rabbitmq_web_stomp"}
 					Expect(serviceBuilder.Update(svc)).To(Succeed())
 					Expect(svc.Spec.Ports).To(ContainElements([]corev1.ServicePort{
+						{
+							Name:        "web-amqp-tls",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        15677,
+							TargetPort:  intstr.FromInt(15677),
+							AppProtocol: ptr.To("https"),
+						},
 						{
 							Name:        "web-mqtt-tls",
 							Protocol:    corev1.ProtocolTCP,
@@ -586,6 +593,7 @@ var _ = Context("Services", func() {
 				Entry(nil, "rabbitmq_web_mqtt", "web-mqtt", 15675, ptr.To("http")),
 				Entry(nil, "rabbitmq_stomp", "stomp", 61613, ptr.To("stomp.github.io/stomp")),
 				Entry(nil, "rabbitmq_web_stomp", "web-stomp", 15674, ptr.To("http")),
+				Entry(nil, "rabbitmq_web_amqp", "web-amqp", 15678, ptr.To("http")),
 				Entry(nil, "rabbitmq_stream", "stream", 5552, ptr.To("rabbitmq.com/stream")),
 				Entry(nil, "rabbitmq_multi_dc_replication", "stream", 5552, ptr.To("rabbitmq.com/stream")),
 				Entry(nil, "rabbitmq_stream_management", "stream", 5552, ptr.To("rabbitmq.com/stream")),

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -1024,6 +1024,12 @@ func (builder *StatefulSetBuilder) updateContainerPorts() []corev1.ContainerPort
 			ContainerPort: 15674,
 		})
 	}
+	if builder.Instance.AdditionalPluginEnabled("rabbitmq_web_amqp") {
+		ports = append(ports, corev1.ContainerPort{
+			Name:          "web-amqp",
+			ContainerPort: 15678,
+		})
+	}
 
 	if builder.Instance.StreamNeeded() {
 		ports = append(ports, corev1.ContainerPort{
@@ -1080,6 +1086,13 @@ func (builder *StatefulSetBuilder) updateContainerPorts() []corev1.ContainerPort
 			ports = append(ports, corev1.ContainerPort{
 				Name:          "web-stomp-tls",
 				ContainerPort: 15673,
+			})
+		}
+
+		if builder.Instance.AdditionalPluginEnabled("rabbitmq_web_amqp") {
+			ports = append(ports, corev1.ContainerPort{
+				Name:          "web-amqp-tls",
+				ContainerPort: 15677,
 			})
 		}
 	}
@@ -1140,6 +1153,13 @@ func (builder *StatefulSetBuilder) updateContainerPortsOnlyTLSListeners() []core
 			ports = append(ports, corev1.ContainerPort{
 				Name:          "web-stomp-tls",
 				ContainerPort: 15673,
+			})
+		}
+
+		if builder.Instance.AdditionalPluginEnabled("rabbitmq_web_amqp") {
+			ports = append(ports, corev1.ContainerPort{
+				Name:          "web-amqp-tls",
+				ContainerPort: 15677,
 			})
 		}
 	}

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -820,6 +820,7 @@ var _ = Describe("StatefulSet", func() {
 			Entry(nil, "rabbitmq_web_mqtt", "web-mqtt", 15675),
 			Entry(nil, "rabbitmq_stomp", "stomp", 61613),
 			Entry(nil, "rabbitmq_web_stomp", "web-stomp", 15674),
+			Entry(nil, "rabbitmq_web_amqp", "web-amqp", 15678),
 			Entry(nil, "rabbitmq_stream", "stream", 5552),
 			Entry(nil, "rabbitmq_multi_dc_replication", "stream", 5552),
 			Entry(nil, "rabbitmq_stream_management", "stream", 5552),


### PR DESCRIPTION
Support AMQP over Websockets.
Websocket protocols now only require TLS, not mTLS.

[RMQ-2768]
ai-assisted=no