### PR TITLE
Include LICENSE.txt and README.me in kubectl-rabbitmq archive

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -106,7 +106,7 @@ jobs:
 
     - name: Compress kubectl plugin
       working-directory: bin/kubectl-rabbitmq-plugin
-      run: tar -cvzf kubectl-rabbitmq-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz kubectl-rabbitmq-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}
+      run: tar -cvzf kubectl-rabbitmq-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz kubectl-rabbitmq-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }} ../../LICENSE.txt ../../README.md
 
     - name: Upload kubectl plugin artifact
       uses: actions/upload-artifact@v6


### PR DESCRIPTION
Because it is a requirement in krew CI.

https://github.com/kubernetes-sigs/krew-index/pull/5259