### PR TITLE
Make destroy more defensive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,8 @@ deploy-sample: kustomize ## Deploy RabbitmqCluster defined in config/sample
 	"$(KUSTOMIZE)" build config/samples | $(KUBECTL) apply -f -
 
 destroy: kustomize ## Cleanup all controller artefacts
-	"$(KUSTOMIZE)" build config/default | $(KUBECTL) delete --ignore-not-found=true -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=true -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=true -f -
 
 .PHONY: run
 run::generate ## Run operator binary locally against the configured Kubernetes cluster in ~/.kube/config
@@ -356,7 +357,7 @@ undeploy-secure-metrics: kustomize ## Undeploy controller with secure metrics
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config
-	$(KUBECTL) delete -f config/crd --ignore-not-found=true
+	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=true -f -
 
 .PHONY: deploy-dev
 deploy-dev::docker-build-dev ## Deploy operator in the configured Kubernetes cluster in ~/.kube/config, with local changes


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Now it deletes the CRDs first. This ensure that any rabbitmqcluster resource is deleted first, before deleting the operator. When the CRDs and the operator are deleted at the same time, there's a race condition where the operator exits first, and it never clears the rabbitmqcluster finalizers, leaving the installation in an inconsistent state.

## Additional Context

Job stuck for 2 hours: https://github.com/rabbitmq/cluster-operator/actions/runs/23490683859/job/68368534809