### PR TITLE
Fix kubectl-build workflow

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -99,7 +99,7 @@ jobs:
 
     - name: Compress kubectl plugin
       working-directory: kubectl-rabbitmq
-      run: tar -cvzf kubectl-rabbitmq-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz kubectl-rabbitmq-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }} ../../LICENSE.txt ../../README.md
+      run: tar -cvzf kubectl-rabbitmq-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz kubectl-rabbitmq-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }} ../LICENSE.txt ../README.md
 
     - name: Upload kubectl plugin artifact
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
As part of kubebuilder v4 migration PR, the path of kubectl-rabbitmq plugin changed, and as such, changed the relative path to README and LICENSE.

Tested locally using nektos/act. Verified the fix in #2084 and this change.
