### PR TITLE
Removing version from kubectl plugin artefact name

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -99,13 +99,13 @@ jobs:
 
     - name: Compress kubectl plugin
       working-directory: kubectl-rabbitmq
-      run: tar -cvzf kubectl-rabbitmq-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz kubectl-rabbitmq-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }} ../LICENSE.txt ../README.md
+      run: tar -cvzf kubectl-rabbitmq-${{ matrix.os }}-${{ matrix.arch }}.tar.gz kubectl-rabbitmq-${{ matrix.os }}-${{ matrix.arch }} ../LICENSE.txt ../README.md
 
     - name: Upload kubectl plugin artifact
       uses: actions/upload-artifact@v7
       with:
         name: kubectl-rabbitmq-${{ matrix.os }}-${{ matrix.arch }}
-        path: kubectl-rabbitmq/kubectl-rabbitmq-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+        path: kubectl-rabbitmq/kubectl-rabbitmq-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
 
   unit_integration_tests:
     name: unit and integration tests

--- a/hack/rabbitmq.yaml
+++ b/hack/rabbitmq.yaml
@@ -19,23 +19,23 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    {{addURIAndSha "https://github.com/rabbitmq/cluster-operator/releases/download/{{ .TagName }}/kubectl-rabbitmq-{{ .TagName }}-darwin-amd64.tar.gz" .TagName }}
-    bin: kubectl-rabbitmq-{{ .TagName }}-darwin-amd64
+    {{addURIAndSha "https://github.com/rabbitmq/cluster-operator/releases/download/{{ .TagName }}/kubectl-rabbitmq-darwin-amd64.tar.gz" .TagName }}
+    bin: kubectl-rabbitmq-darwin-amd64
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    {{addURIAndSha "https://github.com/rabbitmq/cluster-operator/releases/download/{{ .TagName }}/kubectl-rabbitmq-{{ .TagName }}-darwin-arm64.tar.gz" .TagName }}
-    bin: kubectl-rabbitmq-{{ .TagName }}-darwin-arm64
+    {{addURIAndSha "https://github.com/rabbitmq/cluster-operator/releases/download/{{ .TagName }}/kubectl-rabbitmq-darwin-arm64.tar.gz" .TagName }}
+    bin: kubectl-rabbitmq-darwin-arm64
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    {{addURIAndSha "https://github.com/rabbitmq/cluster-operator/releases/download/{{ .TagName }}/kubectl-rabbitmq-{{ .TagName }}-linux-amd64.tar.gz" .TagName }}
-    bin: kubectl-rabbitmq-{{ .TagName }}-linux-amd64
+    {{addURIAndSha "https://github.com/rabbitmq/cluster-operator/releases/download/{{ .TagName }}/kubectl-rabbitmq-linux-amd64.tar.gz" .TagName }}
+    bin: kubectl-rabbitmq-linux-amd64
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    {{addURIAndSha "https://github.com/rabbitmq/cluster-operator/releases/download/{{ .TagName }}/kubectl-rabbitmq-{{ .TagName }}-linux-arm64.tar.gz" .TagName }}
-    bin: kubectl-rabbitmq-{{ .TagName }}-linux-arm64
+    {{addURIAndSha "https://github.com/rabbitmq/cluster-operator/releases/download/{{ .TagName }}/kubectl-rabbitmq-linux-arm64.tar.gz" .TagName }}
+    bin: kubectl-rabbitmq-linux-arm64

--- a/kubectl-rabbitmq/Makefile
+++ b/kubectl-rabbitmq/Makefile
@@ -2,7 +2,7 @@
 GO_OS = $(shell go env GOOS)
 GO_ARCH = $(shell go env GOARCH)
 PLUGIN_VERSION ?= dev
-PLUGIN_NAME := kubectl-rabbitmq-$(PLUGIN_VERSION)-$(GO_OS)-$(GO_ARCH)
+PLUGIN_NAME := kubectl-rabbitmq-$(GO_OS)-$(GO_ARCH)
 
 DEFAULT_GOAL := build
 SOURCES := $(wildcard *.go)


### PR DESCRIPTION
As advised in kubernetes-sigs/krew-index/pull/5481, because that will allow krew PRs to auto-merge.

Tested locally with `act`. Artefact names produced as expected.