### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
   schedule:
     interval: "weekly"
 - package-ecosystem: "gomod"
-  directory: "/bin/kubectl-rabbitmq-plugin/"
+  directory: "/kubectl-rabbitmq/"
   groups:
     all:
       patterns:


### PR DESCRIPTION
kubectl rabbitmq dependabot config did not match current structure.