### PR TITLE
Remove old unused dependabot config.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,22 +17,6 @@ updates:
       versions: ["0.19.x"]
     - dependency-name: "github.com/go-logr/logr"
       versions: ["0.2.x"]
-- package-ecosystem: "gomod"
-  directory: "/internal/tools/"
-  groups:
-    all:
-      patterns:
-      - '*'
-  schedule:
-    interval: "daily"
-- package-ecosystem: "gomod"
-  directory: "/internal/promtool/"
-  groups:
-    all:
-      patterns:
-      - '*'
-  schedule:
-    interval: "daily"
 - package-ecosystem: "github-actions"
   directory: "/"
   groups:


### PR DESCRIPTION
With the recent migration we no longer have separate go module files in `/internal/tools/` or `/internal/promtool/`.