### PR TITLE
Remove cluster-operator resources from 'all' category

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -29,7 +29,7 @@ const DisableDefaultTopologySpreadAnnotation = "rabbitmq.com/disable-default-top
 // +kubebuilder:printcolumn:name="AllReplicasReady",type="string",JSONPath=".status.conditions[?(@.type == 'AllReplicasReady')].status"
 // +kubebuilder:printcolumn:name="ReconcileSuccess",type="string",JSONPath=".status.conditions[?(@.type == 'ReconcileSuccess')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:shortName={"rmq"},categories=all;rabbitmq
+// +kubebuilder:resource:shortName={"rmq"},categories=rabbitmq
 // RabbitmqCluster is the Schema for the RabbitmqCluster API. Each instance of this object
 // corresponds to a single RabbitMQ cluster.
 type RabbitmqCluster struct {

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -10,13 +10,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: rabbitmqclusters.rabbitmq.com
 spec:
   group: rabbitmq.com
   names:
     categories:
-      - all
       - rabbitmq
     kind: RabbitmqCluster
     listKind: RabbitmqClusterList


### PR DESCRIPTION
## Summary Of Changes

- Remove the operator resources from the `all` category

## Additional Context

Because 3rd party operators are not meant to modify the build-in `all`
category. It is acceptable to create a new category such as `rabbitmq`.

At the moment, running `kubectl get all` will fetch `RabbitmqCluster` objects.
The same was done in Topology Operator almost 2 years ago in rabbitmq/messaging-topology-operator/pull/809

## Local Testing

- Deploy GA version of the operator
- Create a `RabbitmqCluster`
- Run `kubectl get all`
- Observe that `RabbitmqCluster` object is listed
- Destroy all
- Deploy the CRD in this PR
- Create a `RabbitmqCluster` object
- Run `kubectl get all`
- Observe that `RabbitmqCluster` is **not** listed
- Run `kubectl get crd rabbitmqclusters.rabbitmq.com -o jsonpath='{.spec.names.categories}'`
- Observe that only "rabbitmq" shows as category
