### PR TITLE
Skip ImagePullSecrets update when DEFAULT_IMAGE_PULL_SECRETS is empty

### DIFF
--- a/internal/controller/reconcile_operator_defaults.go
+++ b/internal/controller/reconcile_operator_defaults.go
@@ -22,7 +22,7 @@ func (r *RabbitmqClusterReconciler) reconcileOperatorDefaults(ctx context.Contex
 		}
 	}
 
-	if rabbitmqCluster.Spec.ImagePullSecrets == nil {
+	if rabbitmqCluster.Spec.ImagePullSecrets == nil && r.DefaultImagePullSecrets != "" {
 		// split the comma separated list of default image pull secrets from
 		// the 'DEFAULT_IMAGE_PULL_SECRETS' env var, but ignore empty strings.
 		for reference := range strings.SplitSeq(r.DefaultImagePullSecrets, ",") {
@@ -30,8 +30,10 @@ func (r *RabbitmqClusterReconciler) reconcileOperatorDefaults(ctx context.Contex
 				rabbitmqCluster.Spec.ImagePullSecrets = append(rabbitmqCluster.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: reference})
 			}
 		}
-		if requeue, err := r.updateRabbitmqCluster(ctx, rabbitmqCluster, "image pull secrets"); err != nil {
-			return requeue, err
+		if len(rabbitmqCluster.Spec.ImagePullSecrets) > 0 {
+			if requeue, err := r.updateRabbitmqCluster(ctx, rabbitmqCluster, "image pull secrets"); err != nil {
+				return requeue, err
+			}
 		}
 	}
 

--- a/internal/controller/reconcile_operator_defaults_internal_test.go
+++ b/internal/controller/reconcile_operator_defaults_internal_test.go
@@ -1,0 +1,94 @@
+/*
+RabbitMQ Cluster Operator
+
+Copyright 2026 Broadcom, Inc. All Rights Reserved.
+
+This product is licensed to you under the Mozilla Public license, Version 2.0 (the "License").  You may not use this product except in compliance with the Mozilla Public License.
+
+This product may include a number of subcomponents with separate copyright notices and License terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+var _ = Describe("reconcileOperatorDefaults", func() {
+	When("DEFAULT_IMAGE_PULL_SECRETS is empty", func() {
+		It("does not Update the cluster when ImagePullSecrets is nil", func() {
+			ctx := context.Background()
+
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
+
+			presetUserUpdaterImage := "preset-uu-image:1.0"
+			cluster := &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-no-defaults",
+					Namespace: "default",
+				},
+				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
+					// Pre-set Image and DefaultUserUpdaterImage so the only branch
+					// in reconcileOperatorDefaults that could trigger an Update is
+					// the ImagePullSecrets one we are testing.
+					Image: "preset-image:1.0",
+					SecretBackend: rabbitmqv1beta1.SecretBackend{
+						Vault: &rabbitmqv1beta1.VaultSpec{
+							DefaultUserPath:         "some-path",
+							DefaultUserUpdaterImage: &presetUserUpdaterImage,
+						},
+					},
+				},
+			}
+
+			updateCallCount := 0
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(cluster).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+						updateCallCount++
+						return c.Update(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			reconciler := &RabbitmqClusterReconciler{
+				Client:                  fakeClient,
+				Scheme:                  scheme,
+				DefaultRabbitmqImage:    "default-rabbit-image:stable",
+				DefaultUserUpdaterImage: "default-uu-image:unstable",
+				DefaultImagePullSecrets: "",
+			}
+
+			By("invoking reconcileOperatorDefaults with empty DefaultImagePullSecrets")
+			requeue, err := reconciler.reconcileOperatorDefaults(ctx, cluster)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requeue).To(BeZero())
+
+			By("not calling Update on the cluster")
+			Expect(updateCallCount).To(Equal(0))
+
+			By("leaving in-memory ImagePullSecrets as nil")
+			Expect(cluster.Spec.ImagePullSecrets).To(BeNil())
+
+			By("leaving the persisted ImagePullSecrets as nil")
+			fetched := &rabbitmqv1beta1.RabbitmqCluster{}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(cluster), fetched)).To(Succeed())
+			Expect(fetched.Spec.ImagePullSecrets).To(BeNil())
+		})
+	})
+})

--- a/internal/controller/reconcile_operator_defaults_test.go
+++ b/internal/controller/reconcile_operator_defaults_test.go
@@ -11,50 +11,52 @@ import (
 )
 
 var _ = Describe("ReconcileOperatorDefaults", func() {
-	var cluster *rabbitmqv1beta1.RabbitmqCluster
+	Context("with operator defaults configured", func() {
+		var cluster *rabbitmqv1beta1.RabbitmqCluster
 
-	BeforeEach(func() {
-		cluster = &rabbitmqv1beta1.RabbitmqCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-default",
-				Namespace: "default",
-			},
-			Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-				SecretBackend: rabbitmqv1beta1.SecretBackend{
-					Vault: &rabbitmqv1beta1.VaultSpec{
-						DefaultUserPath: "some-path",
+		BeforeEach(func() {
+			cluster = &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-default",
+					Namespace: "default",
+				},
+				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
+					SecretBackend: rabbitmqv1beta1.SecretBackend{
+						Vault: &rabbitmqv1beta1.VaultSpec{
+							DefaultUserPath: "some-path",
+						},
 					},
 				},
-			},
-		}
+			}
 
-		Expect(client.Create(ctx, cluster)).To(Succeed())
-		waitForClusterCreation(ctx, cluster, client)
-	})
+			Expect(client.Create(ctx, cluster)).To(Succeed())
+			waitForClusterCreation(ctx, cluster, client)
+		})
 
-	It("handles operator defaults correctly", func() {
-		fetchedCluster := &rabbitmqv1beta1.RabbitmqCluster{}
-		Expect(client.Get(ctx, k8sclient.ObjectKeyFromObject(cluster), fetchedCluster)).To(Succeed())
+		It("handles operator defaults correctly", func() {
+			fetchedCluster := &rabbitmqv1beta1.RabbitmqCluster{}
+			Expect(client.Get(ctx, k8sclient.ObjectKeyFromObject(cluster), fetchedCluster)).To(Succeed())
 
-		By("setting the image spec with the default image")
-		Expect(fetchedCluster.Spec.Image).To(Equal(defaultRabbitmqImage))
+			By("setting the image spec with the default image")
+			Expect(fetchedCluster.Spec.Image).To(Equal(defaultRabbitmqImage))
 
-		By("setting the default user updater image to the controller default")
-		Expect(fetchedCluster.Spec.SecretBackend.Vault.DefaultUserUpdaterImage).To(PointTo(Equal(defaultUserUpdaterImage)))
+			By("setting the default user updater image to the controller default")
+			Expect(fetchedCluster.Spec.SecretBackend.Vault.DefaultUserUpdaterImage).To(PointTo(Equal(defaultUserUpdaterImage)))
 
-		By("setting the default imagePullSecrets")
-		Expect(statefulSet(ctx, cluster).Spec.Template.Spec.ImagePullSecrets).To(ConsistOf(
-			[]corev1.LocalObjectReference{
-				{
-					Name: "image-secret-1",
+			By("setting the default imagePullSecrets")
+			Expect(statefulSet(ctx, cluster).Spec.Template.Spec.ImagePullSecrets).To(ConsistOf(
+				[]corev1.LocalObjectReference{
+					{
+						Name: "image-secret-1",
+					},
+					{
+						Name: "image-secret-2",
+					},
+					{
+						Name: "image-secret-3",
+					},
 				},
-				{
-					Name: "image-secret-2",
-				},
-				{
-					Name: "image-secret-3",
-				},
-			},
-		))
+			))
+		})
 	})
 })


### PR DESCRIPTION
Avoid unnecessary API updates when no default image pull secrets are configured. Only reconcile ImagePullSecrets if there are changes or the DEFAULT_IMAGE_PULL_SECRETS env var is non-empty and results in actual secrets being added to the spec.

ai-assisted=yes

This closes #2098 
