### PR TITLE
Annotate RabbitmqCluster with RabbitMQ and Erlang version

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -22,7 +22,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const DisableDefaultTopologySpreadAnnotation = "rabbitmq.com/disable-default-topology-spread-constraints"
+const (
+	DisableDefaultTopologySpreadAnnotation = "rabbitmq.com/disable-default-topology-spread-constraints"
+	RabbitmqVersionAnnotation              = "rabbitmq.com/version"
+	ErlangVersionAnnotation                = "rabbitmq.com/erlang-version"
+	VersionNotAnnotated                    = "VersionNotAnnotated"
+)
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
@@ -533,6 +538,26 @@ func (cluster *RabbitmqCluster) DisableDefaultTopologySpreadConstraints() bool {
 		return true
 	}
 	return false
+}
+
+func (cluster *RabbitmqCluster) GetRabbitMQVersion() string {
+	if cluster.Annotations == nil {
+		return VersionNotAnnotated
+	}
+	if value, ok := cluster.Annotations[RabbitmqVersionAnnotation]; ok {
+		return value
+	}
+	return VersionNotAnnotated
+}
+
+func (cluster *RabbitmqCluster) GetErlangVersion() string {
+	if cluster.Annotations == nil {
+		return VersionNotAnnotated
+	}
+	if value, ok := cluster.Annotations[ErlangVersionAnnotation]; ok {
+		return value
+	}
+	return VersionNotAnnotated
 }
 
 func init() {

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -162,6 +162,50 @@ var _ = Describe("RabbitmqCluster", func() {
 			})
 		})
 
+		Describe("GetRabbitMQVersion", func() {
+			It("returns the correct version when annotated", func() {
+				resource := generateRabbitmqClusterObject("rabbit-version")
+				resource.Annotations = map[string]string{
+					RabbitmqVersionAnnotation: "3.13.0",
+				}
+				Expect(resource.GetRabbitMQVersion()).To(Equal("3.13.0"))
+			})
+
+			It("returns VersionNotAnnotated when annotation is missing", func() {
+				resource := generateRabbitmqClusterObject("rabbit-version-missing")
+				resource.Annotations = map[string]string{}
+				Expect(resource.GetRabbitMQVersion()).To(Equal(VersionNotAnnotated))
+			})
+
+			It("returns VersionNotAnnotated when annotations are nil", func() {
+				resource := generateRabbitmqClusterObject("rabbit-version-nil")
+				resource.Annotations = nil
+				Expect(resource.GetRabbitMQVersion()).To(Equal(VersionNotAnnotated))
+			})
+		})
+
+		Describe("GetErlangVersion", func() {
+			It("returns the correct version when annotated", func() {
+				resource := generateRabbitmqClusterObject("erlang-version")
+				resource.Annotations = map[string]string{
+					ErlangVersionAnnotation: "26.2.1",
+				}
+				Expect(resource.GetErlangVersion()).To(Equal("26.2.1"))
+			})
+
+			It("returns VersionNotAnnotated when annotation is missing", func() {
+				resource := generateRabbitmqClusterObject("erlang-version-missing")
+				resource.Annotations = map[string]string{}
+				Expect(resource.GetErlangVersion()).To(Equal(VersionNotAnnotated))
+			})
+
+			It("returns VersionNotAnnotated when annotations are nil", func() {
+				resource := generateRabbitmqClusterObject("erlang-version-nil")
+				resource.Annotations = nil
+				Expect(resource.GetErlangVersion()).To(Equal(VersionNotAnnotated))
+			})
+		})
+
 		Context("Default settings", func() {
 			var (
 				rmqClusterInstance      RabbitmqCluster

--- a/internal/controller/rabbitmqcluster_controller.go
+++ b/internal/controller/rabbitmqcluster_controller.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/rabbitmq/cluster-operator/v2/internal/metadata"
+	"github.com/rabbitmq/cluster-operator/v2/internal/rabbitmqclient"
 	"github.com/rabbitmq/cluster-operator/v2/internal/resource"
 	"github.com/rabbitmq/cluster-operator/v2/internal/status"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -69,6 +70,7 @@ type RabbitmqClusterReconciler struct {
 	ClusterConfig           *rest.Config
 	Clientset               *kubernetes.Clientset
 	PodExecutor             PodExecutor
+	RabbitmqClientFactory   rabbitmqclient.RabbitmqClientFactory
 	DefaultRabbitmqImage    string
 	DefaultUserUpdaterImage string
 	DefaultImagePullSecrets string
@@ -264,6 +266,14 @@ func (r *RabbitmqClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		// Don't fail reconciliation if quorum check fails
 	}
 
+	// Annotate RabbitMQ and Erlang versions on the custom resource
+	if requeueAfter, err := r.reconcileRabbitmqVersionAnnotation(ctx, rabbitmqCluster); err != nil || requeueAfter > 0 {
+		if err != nil {
+			r.setReconcileSuccess(ctx, rabbitmqCluster, corev1.ConditionFalse, "FailedVersionAnnotation", err.Error())
+		}
+		return ctrl.Result{RequeueAfter: requeueAfter}, err
+	}
+
 	// By this point the StatefulSet may have finished deploying. Run any
 	// post-deploy steps if so, or requeue until the deployment is finished.
 	if requeueAfter, err := r.runRabbitmqCLICommandsIfAnnotated(ctx, rabbitmqCluster); err != nil || requeueAfter > 0 {
@@ -393,6 +403,10 @@ func (r *RabbitmqClusterReconciler) setReconcileSuccess(ctx context.Context, rab
 }
 
 func (r *RabbitmqClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.RabbitmqClientFactory == nil {
+		r.RabbitmqClientFactory = &rabbitmqclient.DefaultRabbitmqClientFactory{}
+	}
+
 	for _, resource := range []client.Object{&appsv1.StatefulSet{}, &corev1.ConfigMap{}, &corev1.Service{}} {
 		if err := mgr.GetFieldIndexer().IndexField(context.Background(), resource, ownerKey, addResourceToIndex); err != nil {
 			return err

--- a/internal/controller/reconcile_cli.go
+++ b/internal/controller/reconcile_cli.go
@@ -130,3 +130,46 @@ func allReplicasReadyAndUpdated(sts *appsv1.StatefulSet) bool {
 func statefulSetBeingUpdated(sts *appsv1.StatefulSet) bool {
 	return sts.Status.CurrentRevision != sts.Status.UpdateRevision
 }
+
+func (r *RabbitmqClusterReconciler) reconcileRabbitmqVersionAnnotation(ctx context.Context, rmq *rabbitmqv1beta1.RabbitmqCluster) (requeueAfter time.Duration, err error) {
+	logger := ctrl.LoggerFrom(ctx)
+	sts, err := r.statefulSet(ctx, rmq)
+	if err != nil {
+		return 0, err
+	}
+	if !allReplicasReadyAndUpdated(sts) {
+		logger.V(1).Info("not all replicas ready yet; requeuing request to update version annotations")
+		return 15 * time.Second, nil
+	}
+
+	if rmq.Annotations != nil && rmq.Annotations[rabbitmqv1beta1.RabbitmqVersionAnnotation] != "" && rmq.Annotations[rabbitmqv1beta1.ErlangVersionAnnotation] != "" {
+		return 0, nil
+	}
+
+	podName := fmt.Sprintf("%s-0", rmq.ChildResourceName("server"))
+	rabbitClient, err := r.RabbitmqClientFactory.GetClientForPod(ctx, r.APIReader, rmq, podName)
+	if err != nil {
+		logger.V(1).Info("Failed to get client for pod", "pod", podName, "error", err)
+		return 0, nil
+	}
+
+	overview, err := rabbitClient.Overview()
+	if err != nil {
+		logger.V(1).Info("Failed to get overview from pod", "pod", podName, "error", err)
+		return 0, nil
+	}
+
+	if rmq.Annotations == nil {
+		rmq.Annotations = make(map[string]string)
+	}
+
+	rmq.Annotations[rabbitmqv1beta1.RabbitmqVersionAnnotation] = overview.RabbitMQVersion
+	rmq.Annotations[rabbitmqv1beta1.ErlangVersionAnnotation] = overview.ErlangVersion
+
+	if err := r.Update(ctx, rmq); err != nil {
+		return 0, fmt.Errorf("failed to update RabbitmqCluster with version annotations: %w", err)
+	}
+
+	logger.Info("successfully annotated RabbitMQ and Erlang versions", "rabbitmq_version", overview.RabbitMQVersion, "erlang_version", overview.ErlangVersion)
+	return 0, nil
+}

--- a/internal/controller/reconcile_cli.go
+++ b/internal/controller/reconcile_cli.go
@@ -142,10 +142,6 @@ func (r *RabbitmqClusterReconciler) reconcileRabbitmqVersionAnnotation(ctx conte
 		return 15 * time.Second, nil
 	}
 
-	if rmq.Annotations != nil && rmq.Annotations[rabbitmqv1beta1.RabbitmqVersionAnnotation] != "" && rmq.Annotations[rabbitmqv1beta1.ErlangVersionAnnotation] != "" {
-		return 0, nil
-	}
-
 	podName := fmt.Sprintf("%s-0", rmq.ChildResourceName("server"))
 	rabbitClient, err := r.RabbitmqClientFactory.GetClientForPod(ctx, r.APIReader, rmq, podName)
 	if err != nil {
@@ -156,6 +152,12 @@ func (r *RabbitmqClusterReconciler) reconcileRabbitmqVersionAnnotation(ctx conte
 	overview, err := rabbitClient.Overview()
 	if err != nil {
 		logger.V(1).Info("Failed to get overview from pod", "pod", podName, "error", err)
+		return 0, nil
+	}
+
+	if rmq.Annotations != nil &&
+		rmq.Annotations[rabbitmqv1beta1.RabbitmqVersionAnnotation] == overview.RabbitMQVersion &&
+		rmq.Annotations[rabbitmqv1beta1.ErlangVersionAnnotation] == overview.ErlangVersion {
 		return 0, nil
 	}
 

--- a/internal/controller/reconcile_cli_test.go
+++ b/internal/controller/reconcile_cli_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -328,6 +329,91 @@ var _ = Describe("Reconcile CLI", func() {
 					Expect(fakeExecutor.ExecutedCommands()).NotTo(ContainElement(command{"sh", "-c", "rabbitmq-queues rebalance all"}))
 				})
 			})
+		})
+	})
+
+	When("the cluster needs version annotations", func() {
+		BeforeEach(func() {
+			cluster = &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("rabbitmq-version-annotation-%d", time.Now().UnixNano()),
+					Namespace: defaultNamespace,
+				},
+				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
+					Replicas: ptr.To(int32(1)),
+				},
+			}
+			Expect(client.Create(ctx, cluster)).To(Succeed())
+			waitForClusterCreation(ctx, cluster, client)
+		})
+
+		It("does not fetch version if statefulset is not ready", func() {
+			sts := statefulSet(ctx, cluster)
+			sts.Status.ReadyReplicas = 0
+			sts.Status.Replicas = 1
+			Expect(client.Status().Update(ctx, sts)).To(Succeed())
+
+			// Wait for the controller to reconcile and requeue because replicas are not ready
+			// We verify the annotation is not set
+			Consistently(func() map[string]string {
+				rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+				err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
+				Expect(err).ToNot(HaveOccurred())
+				return rmq.ObjectMeta.Annotations
+			}, 5).ShouldNot(HaveKey(rabbitmqv1beta1.RabbitmqVersionAnnotation))
+		})
+
+		It("attempts to fetch version if statefulset is ready and handles error gracefully", func() {
+			fakeRabbitmqFactory.client = &fakeRabbitmqClient{
+				err: fmt.Errorf("connection refused"),
+			}
+
+			sts := statefulSet(ctx, cluster)
+			sts.Status.ReadyReplicas = 1
+			sts.Status.Replicas = 1
+			sts.Status.CurrentReplicas = 1
+			sts.Status.UpdatedReplicas = 1
+			sts.Status.CurrentRevision = sts.Status.UpdateRevision
+			Expect(client.Status().Update(ctx, sts)).To(Succeed())
+
+			// Wait for the controller to reconcile. It will try to fetch the version,
+			// but since the client returns an error, it will fail gracefully.
+			// It will log the error but will not crash.
+			Consistently(func() map[string]string {
+				rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+				err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
+				Expect(err).ToNot(HaveOccurred())
+				return rmq.ObjectMeta.Annotations
+			}, 3).ShouldNot(HaveKey(rabbitmqv1beta1.RabbitmqVersionAnnotation))
+		})
+
+		It("fetches and sets version when overview call is successful", func() {
+			fakeRabbitmqFactory.client = &fakeRabbitmqClient{
+				overview: &rabbithole.Overview{
+					RabbitMQVersion: "3.13.0",
+					ErlangVersion:   "26.2.1",
+				},
+				err: nil,
+			}
+
+			sts := statefulSet(ctx, cluster)
+			sts.Status.ReadyReplicas = 1
+			sts.Status.Replicas = 1
+			sts.Status.CurrentReplicas = 1
+			sts.Status.UpdatedReplicas = 1
+			sts.Status.CurrentRevision = sts.Status.UpdateRevision
+			Expect(client.Status().Update(ctx, sts)).To(Succeed())
+
+			// The controller should reconcile and update the annotations
+			Eventually(func() map[string]string {
+				rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+				err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
+				Expect(err).ToNot(HaveOccurred())
+				return rmq.ObjectMeta.Annotations
+			}, 5).Should(And(
+				HaveKeyWithValue(rabbitmqv1beta1.RabbitmqVersionAnnotation, "3.13.0"),
+				HaveKeyWithValue(rabbitmqv1beta1.ErlangVersionAnnotation, "26.2.1"),
+			))
 		})
 	})
 })

--- a/internal/controller/reconcile_cli_test.go
+++ b/internal/controller/reconcile_cli_test.go
@@ -415,5 +415,42 @@ var _ = Describe("Reconcile CLI", func() {
 				HaveKeyWithValue(rabbitmqv1beta1.ErlangVersionAnnotation, "26.2.1"),
 			))
 		})
+
+		It("updates annotations when RabbitMQ and Erlang versions change after upgrade", func() {
+			rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+			Expect(client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)).To(Succeed())
+			if rmq.Annotations == nil {
+				rmq.Annotations = make(map[string]string)
+			}
+			rmq.Annotations[rabbitmqv1beta1.RabbitmqVersionAnnotation] = "3.12.0"
+			rmq.Annotations[rabbitmqv1beta1.ErlangVersionAnnotation] = "26.1.0"
+			Expect(client.Update(ctx, rmq)).To(Succeed())
+
+			fakeRabbitmqFactory.client = &fakeRabbitmqClient{
+				overview: &rabbithole.Overview{
+					RabbitMQVersion: "3.13.0",
+					ErlangVersion:   "26.2.1",
+				},
+				err: nil,
+			}
+
+			sts := statefulSet(ctx, cluster)
+			sts.Status.ReadyReplicas = 1
+			sts.Status.Replicas = 1
+			sts.Status.CurrentReplicas = 1
+			sts.Status.UpdatedReplicas = 1
+			sts.Status.CurrentRevision = sts.Status.UpdateRevision
+			Expect(client.Status().Update(ctx, sts)).To(Succeed())
+
+			Eventually(func() map[string]string {
+				rmq := &rabbitmqv1beta1.RabbitmqCluster{}
+				err := client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, rmq)
+				Expect(err).ToNot(HaveOccurred())
+				return rmq.ObjectMeta.Annotations
+			}, 5).Should(And(
+				HaveKeyWithValue(rabbitmqv1beta1.RabbitmqVersionAnnotation, "3.13.0"),
+				HaveKeyWithValue(rabbitmqv1beta1.ErlangVersionAnnotation, "26.2.1"),
+			))
+		})
 	})
 })

--- a/internal/controller/reconcile_status.go
+++ b/internal/controller/reconcile_status.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
-	"github.com/rabbitmq/cluster-operator/v2/internal/rabbitmqclient"
 	"github.com/rabbitmq/cluster-operator/v2/internal/resource"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -107,7 +106,7 @@ func (r *RabbitmqClusterReconciler) checkNodeQuorumStatus(ctx context.Context, r
 	logger := ctrl.LoggerFrom(ctx)
 
 	// Get client for this specific pod
-	rabbitClient, err := rabbitmqclient.GetRabbitmqClientForPod(ctx, r.APIReader, rmq, podName)
+	rabbitClient, err := r.RabbitmqClientFactory.GetClientForPod(ctx, r.APIReader, rmq, podName)
 	if err != nil {
 		logger.V(1).Info("Failed to get client for pod", "pod", podName, "error", err)
 		return nodeQuorumCheck{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -20,10 +20,12 @@ import (
 
 	"k8s.io/client-go/util/retry"
 
+	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	controllers "github.com/rabbitmq/cluster-operator/v2/internal/controller"
+	"github.com/rabbitmq/cluster-operator/v2/internal/rabbitmqclient"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -44,13 +46,14 @@ const (
 )
 
 var (
-	testEnv         *envtest.Environment
-	client          runtimeClient.Client
-	clientSet       *kubernetes.Clientset
-	fakeExecutor    *fakePodExecutor
-	ctx             context.Context
-	cancel          context.CancelFunc
-	updateWithRetry = func(cr *rabbitmqv1beta1.RabbitmqCluster, mutateFn func(r *rabbitmqv1beta1.RabbitmqCluster)) error {
+	testEnv             *envtest.Environment
+	client              runtimeClient.Client
+	clientSet           *kubernetes.Clientset
+	fakeExecutor        *fakePodExecutor
+	fakeRabbitmqFactory *fakeRabbitmqClientFactory
+	ctx                 context.Context
+	cancel              context.CancelFunc
+	updateWithRetry     = func(cr *rabbitmqv1beta1.RabbitmqCluster, mutateFn func(r *rabbitmqv1beta1.RabbitmqCluster)) error {
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			if err := client.Get(ctx, runtimeClient.ObjectKeyFromObject(cr), cr); err != nil {
 				return err
@@ -98,6 +101,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	fakeExecutor = &fakePodExecutor{}
+	fakeRabbitmqFactory = &fakeRabbitmqClientFactory{}
+
 	err = (&controllers.RabbitmqClusterReconciler{
 		Client:                  mgr.GetClient(),
 		APIReader:               mgr.GetAPIReader(),
@@ -106,6 +111,7 @@ var _ = BeforeSuite(func() {
 		Namespace:               "rabbitmq-system",
 		Clientset:               clientSet,
 		PodExecutor:             fakeExecutor,
+		RabbitmqClientFactory:   fakeRabbitmqFactory,
 		DefaultRabbitmqImage:    defaultRabbitmqImage,
 		ControlRabbitmqImage:    false,
 		DefaultUserUpdaterImage: defaultUserUpdaterImage,
@@ -143,4 +149,39 @@ func (f *fakePodExecutor) ExecutedCommands() []command { return f.executedComman
 
 func (f *fakePodExecutor) ResetExecutedCommands() { f.executedCommands = []command{} }
 
-var _ = AfterEach(func() { fakeExecutor.ResetExecutedCommands() })
+type fakeRabbitmqClientFactory struct {
+	client *fakeRabbitmqClient
+}
+
+func (f *fakeRabbitmqClientFactory) GetClientForPod(ctx context.Context, k8sClient runtimeClient.Reader, rmq *rabbitmqv1beta1.RabbitmqCluster, podName string) (rabbitmqclient.RabbitmqClient, error) {
+	if f.client == nil {
+		return &fakeRabbitmqClient{}, nil
+	}
+	return f.client, nil
+}
+
+type fakeRabbitmqClient struct {
+	overview *rabbithole.Overview
+	err      error
+}
+
+func (f *fakeRabbitmqClient) Overview() (*rabbithole.Overview, error) {
+	if f.overview == nil && f.err == nil {
+		return &rabbithole.Overview{
+			RabbitMQVersion: "3.13.0",
+			ErlangVersion:   "26.2.1",
+		}, nil
+	}
+	return f.overview, f.err
+}
+
+func (f *fakeRabbitmqClient) HealthCheckNodeIsQuorumCritical() (rabbithole.HealthCheckStatus, error) {
+	// Not used in reconcile_cli_test, mock realistically
+	res := rabbithole.HealthCheckStatus{Status: "ok"}
+	return res, nil
+}
+
+var _ = AfterEach(func() {
+	fakeExecutor.ResetExecutedCommands()
+	fakeRabbitmqFactory.client = nil
+})

--- a/internal/rabbitmqclient/client.go
+++ b/internal/rabbitmqclient/client.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"net/http"
 
-	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,31 +31,6 @@ type ClientInfo struct {
 	Transport *http.Transport
 }
 
-// GetRabbitmqClientForPod creates a rabbithole client for a specific pod using its stable DNS name.
-// It fetches credentials from the default user secret and connects directly to the pod via its stable DNS.
-func GetRabbitmqClientForPod(ctx context.Context, k8sClient client.Reader, rmq *rabbitmqv1beta1.RabbitmqCluster, podName string) (*rabbithole.Client, error) {
-	info, err := GetClientInfoForPod(ctx, k8sClient, rmq, podName)
-	if err != nil {
-		return nil, err
-	}
-
-	var rabbitmqClient *rabbithole.Client
-	if rmq.Spec.TLS.DisableNonTLSListeners {
-		rabbitmqClient, err = rabbithole.NewTLSClient(info.BaseURL, info.Username, info.Password, info.Transport)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create TLS rabbithole client for pod: %w", err)
-		}
-	} else {
-		rabbitmqClient, err = rabbithole.NewClient(info.BaseURL, info.Username, info.Password)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create rabbithole client for pod: %w", err)
-		}
-	}
-
-	return rabbitmqClient, nil
-}
-
-// GetClientInfoForPod creates ClientInfo for a specific pod using its stable DNS name.
 // This is useful for checking individual pods instead of going through the service.
 func GetClientInfoForPod(ctx context.Context, k8sClient client.Reader, rmq *rabbitmqv1beta1.RabbitmqCluster, podName string) (*ClientInfo, error) {
 	// Fetch the default user secret

--- a/internal/rabbitmqclient/client.go
+++ b/internal/rabbitmqclient/client.go
@@ -31,8 +31,9 @@ type ClientInfo struct {
 	Transport *http.Transport
 }
 
+// getClientInfoForPod creates ClientInfo for a specific pod using its stable DNS name.
 // This is useful for checking individual pods instead of going through the service.
-func GetClientInfoForPod(ctx context.Context, k8sClient client.Reader, rmq *rabbitmqv1beta1.RabbitmqCluster, podName string) (*ClientInfo, error) {
+func getClientInfoForPod(ctx context.Context, k8sClient client.Reader, rmq *rabbitmqv1beta1.RabbitmqCluster, podName string) (*ClientInfo, error) {
 	// Fetch the default user secret
 	secretName := rmq.ChildResourceName("default-user")
 	secret := &corev1.Secret{}

--- a/internal/rabbitmqclient/client_test.go
+++ b/internal/rabbitmqclient/client_test.go
@@ -72,7 +72,7 @@ var _ = Describe("RabbitMQ Client", func() {
 
 			It("returns client info with correct credentials", func() {
 				podName := "test-cluster-server-0"
-				info, err := GetClientInfoForPod(ctx, k8sClient, rmq, podName)
+				info, err := getClientInfoForPod(ctx, k8sClient, rmq, podName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(info).NotTo(BeNil())
 				Expect(info.Username).To(Equal("test-user"))
@@ -81,7 +81,7 @@ var _ = Describe("RabbitMQ Client", func() {
 
 			It("returns the correct base URL for non-TLS with pod DNS name", func() {
 				podName := "test-cluster-server-0"
-				info, err := GetClientInfoForPod(ctx, k8sClient, rmq, podName)
+				info, err := getClientInfoForPod(ctx, k8sClient, rmq, podName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(info.BaseURL).To(Equal("http://test-cluster-server-0.test-cluster-nodes.test-namespace.svc:15672"))
 			})
@@ -90,7 +90,7 @@ var _ = Describe("RabbitMQ Client", func() {
 				rmq.Spec.TLS.SecretName = "tls-secret"
 				rmq.Spec.TLS.DisableNonTLSListeners = true
 				podName := "test-cluster-server-1"
-				info, err := GetClientInfoForPod(ctx, k8sClient, rmq, podName)
+				info, err := getClientInfoForPod(ctx, k8sClient, rmq, podName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(info.BaseURL).To(Equal("https://test-cluster-server-1.test-cluster-nodes.test-namespace.svc:15671"))
 			})
@@ -99,7 +99,7 @@ var _ = Describe("RabbitMQ Client", func() {
 				rmq.Spec.TLS.SecretName = "tls-secret"
 				rmq.Spec.TLS.DisableNonTLSListeners = true
 				podName := "test-cluster-server-0"
-				info, err := GetClientInfoForPod(ctx, k8sClient, rmq, podName)
+				info, err := getClientInfoForPod(ctx, k8sClient, rmq, podName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(info.Transport).NotTo(BeNil())
 				Expect(info.Transport.TLSClientConfig).NotTo(BeNil())
@@ -108,7 +108,7 @@ var _ = Describe("RabbitMQ Client", func() {
 
 			It("returns nil transport for non-TLS", func() {
 				podName := "test-cluster-server-0"
-				info, err := GetClientInfoForPod(ctx, k8sClient, rmq, podName)
+				info, err := getClientInfoForPod(ctx, k8sClient, rmq, podName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(info.Transport).To(BeNil())
 			})
@@ -124,15 +124,18 @@ var _ = Describe("RabbitMQ Client", func() {
 
 			It("returns an error", func() {
 				podName := "test-cluster-server-0"
-				_, err := GetClientInfoForPod(ctx, k8sClient, rmq, podName)
+				_, err := getClientInfoForPod(ctx, k8sClient, rmq, podName)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to get default user secret"))
 			})
 		})
 	})
 
-	Describe("GetRabbitmqClientForPod", func() {
+	Describe("DefaultRabbitmqClientFactory", func() {
+		var factory RabbitmqClientFactory
+
 		BeforeEach(func() {
+			factory = &DefaultRabbitmqClientFactory{}
 			k8sClient = fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(rmq).
@@ -143,7 +146,7 @@ var _ = Describe("RabbitMQ Client", func() {
 		Context("when TLS is disabled", func() {
 			It("returns a non-TLS client", func() {
 				podName := "test-cluster-server-0"
-				client, err := GetRabbitmqClientForPod(ctx, k8sClient, rmq, podName)
+				client, err := factory.GetClientForPod(ctx, k8sClient, rmq, podName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(client).NotTo(BeNil())
 			})
@@ -154,7 +157,7 @@ var _ = Describe("RabbitMQ Client", func() {
 				rmq.Spec.TLS.SecretName = "tls-secret"
 				rmq.Spec.TLS.DisableNonTLSListeners = true
 				podName := "test-cluster-server-0"
-				client, err := GetRabbitmqClientForPod(ctx, k8sClient, rmq, podName)
+				client, err := factory.GetClientForPod(ctx, k8sClient, rmq, podName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(client).NotTo(BeNil())
 			})
@@ -170,7 +173,7 @@ var _ = Describe("RabbitMQ Client", func() {
 
 			It("returns an error", func() {
 				podName := "test-cluster-server-0"
-				_, err := GetRabbitmqClientForPod(ctx, k8sClient, rmq, podName)
+				_, err := factory.GetClientForPod(ctx, k8sClient, rmq, podName)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to get default user secret"))
 			})

--- a/internal/rabbitmqclient/factory.go
+++ b/internal/rabbitmqclient/factory.go
@@ -1,0 +1,38 @@
+/*
+RabbitMQ Cluster Operator
+
+Copyright 2020 VMware, Inc. All Rights Reserved.
+
+This product is licensed to you under the Mozilla Public license, Version 2.0 (the "License").  You may not use this product except in compliance with the Mozilla Public License.
+
+This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+*/
+
+package rabbitmqclient
+
+import (
+	"context"
+
+	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
+	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RabbitmqClient represents a subset of the rabbithole.Client that the operator uses.
+type RabbitmqClient interface {
+	Overview() (*rabbithole.Overview, error)
+	HealthCheckNodeIsQuorumCritical() (rabbithole.HealthCheckStatus, error)
+}
+
+// RabbitmqClientFactory creates a RabbitmqClient for a specific pod.
+type RabbitmqClientFactory interface {
+	GetClientForPod(ctx context.Context, k8sClient client.Reader, rmq *rabbitmqv1beta1.RabbitmqCluster, podName string) (RabbitmqClient, error)
+}
+
+// DefaultRabbitmqClientFactory is the default implementation of RabbitmqClientFactory.
+type DefaultRabbitmqClientFactory struct{}
+
+// GetClientForPod creates a real rabbithole client for a specific pod.
+func (f *DefaultRabbitmqClientFactory) GetClientForPod(ctx context.Context, k8sClient client.Reader, rmq *rabbitmqv1beta1.RabbitmqCluster, podName string) (RabbitmqClient, error) {
+	return GetRabbitmqClientForPod(ctx, k8sClient, rmq, podName)
+}

--- a/internal/rabbitmqclient/factory.go
+++ b/internal/rabbitmqclient/factory.go
@@ -12,6 +12,7 @@ package rabbitmqclient
 
 import (
 	"context"
+	"fmt"
 
 	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
@@ -34,5 +35,23 @@ type DefaultRabbitmqClientFactory struct{}
 
 // GetClientForPod creates a real rabbithole client for a specific pod.
 func (f *DefaultRabbitmqClientFactory) GetClientForPod(ctx context.Context, k8sClient client.Reader, rmq *rabbitmqv1beta1.RabbitmqCluster, podName string) (RabbitmqClient, error) {
-	return GetRabbitmqClientForPod(ctx, k8sClient, rmq, podName)
+	info, err := getClientInfoForPod(ctx, k8sClient, rmq, podName)
+	if err != nil {
+		return nil, err
+	}
+
+	var rabbitmqClient *rabbithole.Client
+	if rmq.Spec.TLS.DisableNonTLSListeners {
+		rabbitmqClient, err = rabbithole.NewTLSClient(info.BaseURL, info.Username, info.Password, info.Transport)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create TLS rabbithole client for pod: %w", err)
+		}
+	} else {
+		rabbitmqClient, err = rabbithole.NewClient(info.BaseURL, info.Username, info.Password)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create rabbithole client for pod: %w", err)
+		}
+	}
+
+	return rabbitmqClient, nil
 }


### PR DESCRIPTION
This closes #2049

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Annotate `RabbitmqCluster` with RabbitMQ and Erlang version
- Refactor `rabbitmqclient` module

## Additional Context

This is a first step to further expand the operator to apply version-specific configurations. For example,
the readiness probe. It can be executed as an `eval` or as an HTTP endpoint, but it is version specific.

The refactor allows to mock rabbit-hole library, to better unit-test the operator when it makes HTTP
calls to rabbit API.

## Local Testing

Added integration tests.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

Tested manually in my local k8s:

1. Happy path: deploy and observe version is set
2. Upgrade: deploy a version, observe correct version is annotated, upgrade, observe annotation is updated.

