### PR TITLE
More strict envConfig validation

### DIFF
--- a/api/v1beta1/rabbitmqcluster_types.go
+++ b/api/v1beta1/rabbitmqcluster_types.go
@@ -401,6 +401,7 @@ type RabbitmqClusterConfigurationSpec struct {
 	// Modify to add to the rabbitmq-env.conf file. Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime.
 	// For more information on env config, see https://www.rabbitmq.com/man/rabbitmq-env.conf.5.html
 	// +kubebuilder:validation:MaxLength:=100000
+	// +kubebuilder:validation:XValidation:rule="!self.contains('$(') && !self.contains('`')",message="envConfig must not contain shell command substitution ('$(...)' or backticks)"
 	EnvConfig string `json:"envConfig,omitempty"`
 	// Erlang Inet configuration to apply to the Erlang VM running rabbit.
 	// See also: https://www.erlang.org/doc/apps/erts/inet_cfg.html

--- a/api/v1beta1/rabbitmqcluster_types_test.go
+++ b/api/v1beta1/rabbitmqcluster_types_test.go
@@ -142,6 +142,26 @@ var _ = Describe("RabbitmqCluster", func() {
 				invalidSvc.Spec.Service.IPFamilyPolicy = &policy
 				Expect(apierrors.IsInvalid(k8sClient.Create(context.Background(), invalidSvc))).To(BeTrue())
 			})
+
+			By("rejecting envConfig with dollar-paren command substitution", func() {
+				invalid := generateRabbitmqClusterObject("rabbit-inject-dollar-paren")
+				invalid.Spec.Rabbitmq.EnvConfig = `NODENAME=rabbit@$(hostname)`
+				Expect(apierrors.IsInvalid(k8sClient.Create(context.Background(), invalid))).To(BeTrue())
+				Expect(k8sClient.Create(context.Background(), invalid)).To(MatchError(ContainSubstring("shell command substitution")))
+			})
+
+			By("rejecting envConfig with backtick command substitution", func() {
+				invalid := generateRabbitmqClusterObject("rabbit-inject-backtick")
+				invalid.Spec.Rabbitmq.EnvConfig = "NODENAME=rabbit@`hostname`"
+				Expect(apierrors.IsInvalid(k8sClient.Create(context.Background(), invalid))).To(BeTrue())
+				Expect(k8sClient.Create(context.Background(), invalid)).To(MatchError(ContainSubstring("shell command substitution")))
+			})
+
+			By("allowing envConfig with plain variable expansion", func() {
+				valid := generateRabbitmqClusterObject("rabbit-envconfig-plain-var")
+				valid.Spec.Rabbitmq.EnvConfig = "NODENAME=rabbit@$HOSTNAME"
+				Expect(k8sClient.Create(context.Background(), valid)).To(Succeed())
+			})
 		})
 
 		It("can be created with Erlang configuration", func() {

--- a/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+++ b/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
@@ -5151,6 +5151,9 @@ spec:
                         For more information on env config, see https://www.rabbitmq.com/man/rabbitmq-env.conf.5.html
                       maxLength: 100000
                       type: string
+                      x-kubernetes-validations:
+                        - message: envConfig must not contain shell command substitution ('$(...)' or backticks)
+                          rule: '!self.contains(''$('') && !self.contains(''`'')'
                     erlangInetConfig:
                       description: |-
                         Erlang Inet configuration to apply to the Erlang VM running rabbit.

--- a/internal/controller/rabbitmqcluster_controller.go
+++ b/internal/controller/rabbitmqcluster_controller.go
@@ -186,14 +186,14 @@ func (r *RabbitmqClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	builders := resourceBuilder.ResourceBuilders()
 
 	for _, builder := range builders {
-		resource, err := builder.Build()
+		obj, err := builder.Build()
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 
 		// only StatefulSetBuilder returns true
 		if builder.UpdateMayRequireStsRecreate() {
-			sts := resource.(*appsv1.StatefulSet)
+			sts := obj.(*appsv1.StatefulSet)
 
 			current, err := r.statefulSet(ctx, rabbitmqCluster)
 			if client.IgnoreNotFound(err) != nil {
@@ -236,13 +236,17 @@ func (r *RabbitmqClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		var operationResult controllerutil.OperationResult
 		err = clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 			var apiError error
-			operationResult, apiError = controllerutil.CreateOrUpdate(ctx, r.Client, resource, func() error {
-				return builder.Update(resource)
+			operationResult, apiError = controllerutil.CreateOrUpdate(ctx, r.Client, obj, func() error {
+				return builder.Update(obj)
 			})
 			return apiError
 		})
-		r.logAndRecordOperationResult(logger, rabbitmqCluster, resource, operationResult, err)
+		r.logAndRecordOperationResult(logger, rabbitmqCluster, obj, operationResult, err)
 		if err != nil {
+			if errors.Is(err, resource.ErrInvalidEnvConfig) {
+				r.setReconcileSuccess(ctx, rabbitmqCluster, corev1.ConditionFalse, "InvalidConfiguration", err.Error())
+				return ctrl.Result{}, nil
+			}
 			r.setReconcileSuccess(ctx, rabbitmqCluster, corev1.ConditionFalse, "Error", err.Error())
 			return ctrl.Result{}, err
 		}

--- a/internal/resource/configmap.go
+++ b/internal/resource/configmap.go
@@ -10,6 +10,7 @@
 package resource
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -287,6 +288,10 @@ func (builder *ServerConfigMapBuilder) Update(object client.Object) error {
 
 	configMap.Data["userDefinedConfiguration.conf"] = rmqConfBuffer.String()
 
+	if err := validateEnvConfig(rmqProperties.EnvConfig); err != nil {
+		return err
+	}
+
 	updateProperty(configMap.Data, "advanced.config", rmqProperties.AdvancedConfig)
 	updateProperty(configMap.Data, "rabbitmq-env.conf", rmqProperties.EnvConfig)
 	updateProperty(configMap.Data, "erl_inetrc", rmqProperties.ErlangInetConfig)
@@ -366,4 +371,13 @@ func areAuthMechanismsConfigued(additionalConfig string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+var ErrInvalidEnvConfig = errors.New("spec.rabbitmq.envConfig must not contain shell command substitution ('$(...)' or backticks)")
+
+func validateEnvConfig(envConfig string) error {
+	if strings.Contains(envConfig, "$(") || strings.Contains(envConfig, "`") {
+		return ErrInvalidEnvConfig
+	}
+	return nil
 }

--- a/internal/resource/configmap_test.go
+++ b/internal/resource/configmap_test.go
@@ -257,6 +257,30 @@ CONSOLE_LOG=new`
 					})
 				})
 			})
+
+			Context("shell command substitution", func() {
+			DescribeTable("rejects envConfig containing command substitution",
+				func(envConfig string) {
+					instance.Spec.Rabbitmq.EnvConfig = envConfig
+					Expect(configMapBuilder.Update(configMap)).To(MatchError(resource.ErrInvalidEnvConfig))
+				},
+					Entry("dollar-paren substitution", `NODENAME=rabbit@$(hostname)`),
+					Entry("backtick substitution", "NODENAME=rabbit@`hostname`"),
+					Entry("multiline with dollar-paren", "USE_LONGNAME=true\nNODENAME=$(hostname)"),
+					Entry("embedded dollar-paren", `SECRET=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)`),
+				)
+
+				DescribeTable("allows envConfig with plain variable expansion",
+					func(envConfig string) {
+						instance.Spec.Rabbitmq.EnvConfig = envConfig
+						Expect(configMapBuilder.Update(configMap)).To(Succeed())
+					},
+					Entry("dollar-brace expansion", `NODENAME=rabbit@${HOSTNAME}`),
+					Entry("dollar expansion", `NODENAME=rabbit@$HOSTNAME`),
+					Entry("plain key=value", `USE_LONGNAME=true`),
+					Entry("multiple plain assignments", "USE_LONGNAME=true\nCONSOLE_LOG=new"),
+				)
+			})
 		})
 
 		Context("TLS", func() {


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
