### PR TITLE
Update StartupProbe to use HTTP health check for RabbitMQ >= 4.2.4

### DIFF
--- a/docs/examples/additionalPorts/rabbitmq.yaml
+++ b/docs/examples/additionalPorts/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: rabbit
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 1
   override:
     service:

--- a/docs/examples/community-plugins/rabbitmq.yaml
+++ b/docs/examples/community-plugins/rabbitmq.yaml
@@ -2,6 +2,8 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: community-plugins
+  annotations:
+    rabbitmq.com/version: "3.13"
 spec:
   replicas: 1
   image: rabbitmq:3.13-management

--- a/docs/examples/custom-configuration/rabbitmq.yaml
+++ b/docs/examples/custom-configuration/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: custom-configuration
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 1
   rabbitmq:
     additionalConfig: |

--- a/docs/examples/default-security-context/rabbitmq.yaml
+++ b/docs/examples/default-security-context/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: default-security-context
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   override:
     statefulSet:
       spec:

--- a/docs/examples/external-admin-secret-credentials/rabbitmq.yaml
+++ b/docs/examples/external-admin-secret-credentials/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: external-secret-user
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 1
   secretBackend:
     externalSecret: 

--- a/docs/examples/hello-world/rabbitmq.yaml
+++ b/docs/examples/hello-world/rabbitmq.yaml
@@ -2,3 +2,7 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: hello-world
+  annotations:
+    rabbitmq.com/version: "4.3"
+spec:
+  image: rabbitmq:4.3-management

--- a/docs/examples/import-definitions/rabbitmq.yaml
+++ b/docs/examples/import-definitions/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: import-definitions
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 1
   override:
     statefulSet:

--- a/docs/examples/import-https-url-definition/rabbitmq.yaml
+++ b/docs/examples/import-https-url-definition/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: import-https-url-definitions 
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 3
   resources:
     requests:

--- a/docs/examples/import-multiple-definition-files/rabbitmq.yaml
+++ b/docs/examples/import-multiple-definition-files/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: import-multiple-definition-files
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 1
   override:
     statefulSet:

--- a/docs/examples/ipv6/rabbitmq.yaml
+++ b/docs/examples/ipv6/rabbitmq.yaml
@@ -5,7 +5,10 @@ metadata:
   name: rabbit-ipv6
   labels:
     app: rabbitmq
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   rabbitmq:
     erlangInetConfig: |
       {inet6, true}.

--- a/docs/examples/json-log/rabbitmq.yaml
+++ b/docs/examples/json-log/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: json
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   rabbitmq:
     # Disable RABBITMQ_LOGS=- which is set in
     # https://github.com/docker-library/rabbitmq/blob/ece63d4534cc44abd6b1ec35bbd9aa0d21e87e1d/3.9/ubuntu/Dockerfile#L211

--- a/docs/examples/mtls-inter-node/rabbitmq.yaml
+++ b/docs/examples/mtls-inter-node/rabbitmq.yaml
@@ -2,8 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: mtls-inter-node
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
-  image: rabbitmq:4.1.3-management
+  image: rabbitmq:4.3-management
   rabbitmq:
     envConfig: |
       SERVER_ADDITIONAL_ERL_ARGS="-proto_dist inet_tls -ssl_dist_optfile /etc/rabbitmq/inter-node-tls.config"

--- a/docs/examples/mtls/rabbitmq.yaml
+++ b/docs/examples/mtls/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: mtls
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 1
   tls:
     secretName: tls-secret

--- a/docs/examples/multiple-disks/rabbitmq.yaml
+++ b/docs/examples/multiple-disks/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: multiple-disks
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 1
   rabbitmq:
     envConfig: |

--- a/docs/examples/network-policies/rabbitmq.yaml
+++ b/docs/examples/network-policies/rabbitmq.yaml
@@ -2,8 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: network-policies
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
-  image: rabbitmq:3.9.7-management
+  image: rabbitmq:4.3-management
   replicas: 3
   rabbitmq:
     additionalPlugins:

--- a/docs/examples/plugins/rabbitmq.yaml
+++ b/docs/examples/plugins/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: plugins
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 1
   rabbitmq:
     additionalPlugins:

--- a/docs/examples/pod-anti-affinity/rabbitmq.yaml
+++ b/docs/examples/pod-anti-affinity/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: pod-anti-affinity
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 3
   affinity:
     podAntiAffinity:

--- a/docs/examples/priority-class/rabbitmq.yaml
+++ b/docs/examples/priority-class/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: priority-class
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   override:
     statefulSet:
       spec:

--- a/docs/examples/production-ready/rabbitmq.yaml
+++ b/docs/examples/production-ready/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: production-ready
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 3
   resources:
     requests:

--- a/docs/examples/resource-limits/rabbitmq.yaml
+++ b/docs/examples/resource-limits/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: resource-limits
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 1
   resources:
     requests:

--- a/docs/examples/set-login-password-username/rabbitmq.yaml
+++ b/docs/examples/set-login-password-username/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: myrabbitmq
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   rabbitmq:
     additionalConfig: |
       default_user=guest

--- a/docs/examples/sidecar/rabbitmq.yaml
+++ b/docs/examples/sidecar/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: sidecar
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 1
   override:
     statefulSet:

--- a/docs/examples/tls/rabbitmq.yaml
+++ b/docs/examples/tls/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: tls
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 1
   tls:
     secretName: tls-secret

--- a/docs/examples/tolerations/rabbitmq.yaml
+++ b/docs/examples/tolerations/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: tolerations
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   replicas: 1
   tolerations:
     - key: "dedicated"

--- a/docs/examples/vault-default-user/rabbitmq.yaml
+++ b/docs/examples/vault-default-user/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: vault-default-user
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   secretBackend:
     vault:
       role: rabbitmq

--- a/docs/examples/vault-tls/rabbitmq.yaml
+++ b/docs/examples/vault-tls/rabbitmq.yaml
@@ -2,7 +2,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: vault-tls
+  annotations:
+    rabbitmq.com/version: "4.3"
 spec:
+  image: rabbitmq:4.3-management
   secretBackend:
     vault:
       role: rabbitmq

--- a/internal/controller/rabbitmqcluster_controller_test.go
+++ b/internal/controller/rabbitmqcluster_controller_test.go
@@ -93,19 +93,10 @@ var _ = Describe("RabbitmqClusterController", func() {
 				))
 			})
 
-			By("setting the default StartupProbe", func() {
+			By("not setting a default StartupProbe", func() {
 				rabbitmqContainer := sts.Spec.Template.Spec.Containers[0]
 				Expect(rabbitmqContainer.Name).To(Equal("rabbitmq"))
-				Expect(rabbitmqContainer.StartupProbe).NotTo(BeNil())
-				Expect(rabbitmqContainer.StartupProbe.ProbeHandler.Exec).NotTo(BeNil())
-				Expect(rabbitmqContainer.StartupProbe.ProbeHandler.Exec.Command).To(Equal([]string{
-					"/bin/bash", "-c",
-					"rabbitmqctl eval 'rabbit_nodes:reached_target_cluster_size().' | grep -q '^true$'",
-				}))
-				Expect(rabbitmqContainer.StartupProbe.InitialDelaySeconds).To(BeEquivalentTo(10))
-				Expect(rabbitmqContainer.StartupProbe.TimeoutSeconds).To(BeEquivalentTo(5))
-				Expect(rabbitmqContainer.StartupProbe.PeriodSeconds).To(BeEquivalentTo(10))
-				Expect(rabbitmqContainer.StartupProbe.FailureThreshold).To(BeEquivalentTo(30))
+				Expect(rabbitmqContainer.StartupProbe).To(BeNil())
 			})
 
 			By("creating the server conf configmap", func() {

--- a/internal/resource/rabbitmq_resource_builder.go
+++ b/internal/resource/rabbitmq_resource_builder.go
@@ -34,6 +34,10 @@ type ResourceBuilder interface {
 // once at package scope to avoid repeated allocations.
 var peerDiscoveryRBACConstraint = mustNewConstraint(">= 4.1.0")
 
+// targetClusterSizeHealthCheckConstraint is the semver constraint used to determine whether
+// to use the HTTP target cluster size health check.
+var targetClusterSizeHealthCheckConstraint = mustNewConstraint(">= 4.2.4")
+
 // mustNewConstraint creates a semver constraint and panics if parsing fails.
 // This is only used for constant constraint strings that are always valid.
 func mustNewConstraint(c string) *semver.Constraints {
@@ -60,6 +64,22 @@ func ShouldCreatePeerDiscoveryRBAC(rmq *rabbitmqv1beta1.RabbitmqCluster) bool {
 	}
 
 	return !peerDiscoveryRBACConstraint.Check(v)
+}
+
+// ShouldUseHTTPTargetClusterSizeHealthCheck returns true if the HTTP health check
+// for reaching target cluster size should be used (RabbitMQ >= 4.2.4).
+func ShouldUseHTTPTargetClusterSizeHealthCheck(rmq *rabbitmqv1beta1.RabbitmqCluster) bool {
+	version := rmq.GetRabbitMQVersion()
+	if version == rabbitmqv1beta1.VersionNotAnnotated {
+		return false
+	}
+
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false
+	}
+
+	return targetClusterSizeHealthCheckConstraint.Check(v)
 }
 
 func (builder *RabbitmqResourceBuilder) ResourceBuilders() []ResourceBuilder {

--- a/internal/resource/rabbitmq_resource_builder_test.go
+++ b/internal/resource/rabbitmq_resource_builder_test.go
@@ -65,6 +65,48 @@ var _ = Describe("RabbitmqResourceBuilder", func() {
 		})
 	})
 
+	Context("ShouldUseHTTPTargetClusterSizeHealthCheck", func() {
+		It("returns false if version is not annotated", func() {
+			rmq := &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{}},
+			}
+			Expect(resource.ShouldUseHTTPTargetClusterSizeHealthCheck(rmq)).To(BeFalseBecause("version is not annotated"))
+		})
+
+		It("returns false if version cannot be parsed", func() {
+			rmq := &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
+					rabbitmqv1beta1.RabbitmqVersionAnnotation: "invalid",
+				}},
+			}
+			Expect(resource.ShouldUseHTTPTargetClusterSizeHealthCheck(rmq)).To(BeFalseBecause("version cannot be parsed"))
+		})
+
+		It("returns false if version is less than 4.2.4", func() {
+			rmq := &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
+					rabbitmqv1beta1.RabbitmqVersionAnnotation: "3.13.0",
+				}},
+			}
+			Expect(resource.ShouldUseHTTPTargetClusterSizeHealthCheck(rmq)).To(BeFalseBecause("version is less than 4.2.4"))
+
+			rmq.Annotations[rabbitmqv1beta1.RabbitmqVersionAnnotation] = "4.2.3"
+			Expect(resource.ShouldUseHTTPTargetClusterSizeHealthCheck(rmq)).To(BeFalseBecause("version is less than 4.2.4"))
+		})
+
+		It("returns true if version is 4.2.4 or greater", func() {
+			rmq := &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
+					rabbitmqv1beta1.RabbitmqVersionAnnotation: "4.2.4",
+				}},
+			}
+			Expect(resource.ShouldUseHTTPTargetClusterSizeHealthCheck(rmq)).To(BeTrueBecause("version is 4.2.4 or greater"))
+
+			rmq.Annotations[rabbitmqv1beta1.RabbitmqVersionAnnotation] = "4.3.0"
+			Expect(resource.ShouldUseHTTPTargetClusterSizeHealthCheck(rmq)).To(BeTrueBecause("version is 4.2.4 or greater"))
+		})
+	})
+
 	Context("ResourceBuilders", func() {
 		var (
 			instance *rabbitmqv1beta1.RabbitmqCluster

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -575,6 +575,22 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 		volumes = append(volumes, tlsProjectedVolume)
 	}
 
+	var startupProbe *corev1.Probe
+	if ShouldUseHTTPTargetClusterSizeHealthCheck(builder.Instance) {
+		startupProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/api/health/checks/reached-target-cluster-size",
+					Port: intstr.FromInt(15672),
+				},
+			},
+			InitialDelaySeconds: 10,
+			TimeoutSeconds:      5,
+			PeriodSeconds:       10,
+			FailureThreshold:    30,
+		}
+	}
+
 	rabbitmqUID := int64(999)
 	podTemplateSpec := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -641,19 +657,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 						SuccessThreshold:    1,
 						FailureThreshold:    3,
 					},
-					// TODO: Update this probe once we have an HTTP API endpoint for this
-					StartupProbe: &corev1.Probe{
-						ProbeHandler: corev1.ProbeHandler{
-							Exec: &corev1.ExecAction{
-								Command: []string{"/bin/bash", "-c",
-									"rabbitmqctl eval 'rabbit_nodes:reached_target_cluster_size().' | grep -q '^true$'"},
-							},
-						},
-						InitialDelaySeconds: 10,
-						TimeoutSeconds:      5,
-						PeriodSeconds:       10,
-						FailureThreshold:    30,
-					},
+					StartupProbe: startupProbe,
 					Lifecycle: &corev1.Lifecycle{
 						PreStop: &corev1.LifecycleHandler{
 							Exec: &corev1.ExecAction{

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -577,11 +577,19 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 
 	var startupProbe *corev1.Probe
 	if ShouldUseHTTPTargetClusterSizeHealthCheck(builder.Instance) {
+		startupProbePort := 15672
+		startupProbeScheme := corev1.URISchemeHTTP
+		if builder.Instance.DisableNonTLSListeners() {
+			startupProbePort = 15671
+			startupProbeScheme = corev1.URISchemeHTTPS
+		}
+
 		startupProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/api/health/checks/reached-target-cluster-size",
-					Port: intstr.FromInt(15672),
+					Path:   "/api/health/checks/reached-target-cluster-size",
+					Port:   intstr.FromInt(startupProbePort),
+					Scheme: startupProbeScheme,
 				},
 			},
 			InitialDelaySeconds: 10,

--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -584,6 +584,7 @@ func (builder *StatefulSetBuilder) podTemplateSpec(previousPodAnnotations map[st
 			startupProbeScheme = corev1.URISchemeHTTPS
 		}
 
+		// Health check endpoint does not require authentication
 		startupProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -898,21 +898,36 @@ var _ = Describe("StatefulSet", func() {
 			Expect(container.Env).To(ConsistOf(requiredEnvVariables))
 		})
 
-		It("sets default StartupProbe with rabbitmqctl eval command", func() {
+		It("does not set a StartupProbe by default", func() {
 			stsBuilder := builder.StatefulSet()
 			Expect(stsBuilder.Update(statefulSet)).To(Succeed())
 
 			container := extractContainer(statefulSet.Spec.Template.Spec.Containers, "rabbitmq")
-			Expect(container.StartupProbe).NotTo(BeNil())
-			Expect(container.StartupProbe.ProbeHandler.Exec).NotTo(BeNil())
-			Expect(container.StartupProbe.ProbeHandler.Exec.Command).To(Equal([]string{
-				"/bin/bash", "-c",
-				"rabbitmqctl eval 'rabbit_nodes:reached_target_cluster_size().' | grep -q '^true$'",
-			}))
-			Expect(container.StartupProbe.InitialDelaySeconds).To(BeEquivalentTo(10))
-			Expect(container.StartupProbe.TimeoutSeconds).To(BeEquivalentTo(5))
-			Expect(container.StartupProbe.PeriodSeconds).To(BeEquivalentTo(10))
-			Expect(container.StartupProbe.FailureThreshold).To(BeEquivalentTo(30))
+			Expect(container.StartupProbe).To(BeNil())
+		})
+
+		When("RabbitMQ version is 4.2.4 or greater", func() {
+			BeforeEach(func() {
+				if instance.Annotations == nil {
+					instance.Annotations = make(map[string]string)
+				}
+				instance.Annotations[rabbitmqv1beta1.RabbitmqVersionAnnotation] = "4.2.4"
+			})
+
+			It("sets StartupProbe with HTTP target cluster size health check", func() {
+				stsBuilder := builder.StatefulSet()
+				Expect(stsBuilder.Update(statefulSet)).To(Succeed())
+
+				container := extractContainer(statefulSet.Spec.Template.Spec.Containers, "rabbitmq")
+				Expect(container.StartupProbe).NotTo(BeNil())
+				Expect(container.StartupProbe.ProbeHandler.HTTPGet).NotTo(BeNil())
+				Expect(container.StartupProbe.ProbeHandler.HTTPGet.Path).To(Equal("/api/health/checks/reached-target-cluster-size"))
+				Expect(container.StartupProbe.ProbeHandler.HTTPGet.Port.IntValue()).To(Equal(15672))
+				Expect(container.StartupProbe.InitialDelaySeconds).To(BeEquivalentTo(10))
+				Expect(container.StartupProbe.TimeoutSeconds).To(BeEquivalentTo(5))
+				Expect(container.StartupProbe.PeriodSeconds).To(BeEquivalentTo(10))
+				Expect(container.StartupProbe.FailureThreshold).To(BeEquivalentTo(30))
+			})
 		})
 
 		Context("ExternalSecret", func() {

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -923,10 +923,29 @@ var _ = Describe("StatefulSet", func() {
 				Expect(container.StartupProbe.ProbeHandler.HTTPGet).NotTo(BeNil())
 				Expect(container.StartupProbe.ProbeHandler.HTTPGet.Path).To(Equal("/api/health/checks/reached-target-cluster-size"))
 				Expect(container.StartupProbe.ProbeHandler.HTTPGet.Port.IntValue()).To(Equal(15672))
+				Expect(container.StartupProbe.ProbeHandler.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTP))
 				Expect(container.StartupProbe.InitialDelaySeconds).To(BeEquivalentTo(10))
 				Expect(container.StartupProbe.TimeoutSeconds).To(BeEquivalentTo(5))
 				Expect(container.StartupProbe.PeriodSeconds).To(BeEquivalentTo(10))
 				Expect(container.StartupProbe.FailureThreshold).To(BeEquivalentTo(30))
+			})
+
+			When("DisableNonTLSListeners is true", func() {
+				BeforeEach(func() {
+					instance.Spec.TLS.DisableNonTLSListeners = true
+				})
+
+				It("sets StartupProbe with HTTPS target cluster size health check on port 15671", func() {
+					stsBuilder := builder.StatefulSet()
+					Expect(stsBuilder.Update(statefulSet)).To(Succeed())
+
+					container := extractContainer(statefulSet.Spec.Template.Spec.Containers, "rabbitmq")
+					Expect(container.StartupProbe).NotTo(BeNil())
+					Expect(container.StartupProbe.ProbeHandler.HTTPGet).NotTo(BeNil())
+					Expect(container.StartupProbe.ProbeHandler.HTTPGet.Path).To(Equal("/api/health/checks/reached-target-cluster-size"))
+					Expect(container.StartupProbe.ProbeHandler.HTTPGet.Port.IntValue()).To(Equal(15671))
+					Expect(container.StartupProbe.ProbeHandler.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTPS))
+				})
 			})
 		})
 

--- a/kubectl-rabbitmq/cluster.go
+++ b/kubectl-rabbitmq/cluster.go
@@ -57,6 +57,8 @@ type clusterOptions struct {
 	DelayStartSeconds             int32
 	SkipPostDeploySteps           bool
 	AutoEnableAllFeatureFlags     bool
+
+	RabbitmqVersion string
 }
 
 // buildRabbitmqCluster constructs a RabbitmqCluster resource from the provided options
@@ -78,6 +80,15 @@ func buildRabbitmqCluster(name string, opts clusterOptions) (*v1beta1.RabbitmqCl
 	}
 	if opts.Image != "" {
 		cluster.Spec.Image = opts.Image
+	}
+	if opts.RabbitmqVersion != "" {
+		if cluster.Annotations == nil {
+			cluster.Annotations = make(map[string]string)
+		}
+		cluster.Annotations[v1beta1.RabbitmqVersionAnnotation] = opts.RabbitmqVersion
+		if opts.Image == "" {
+			cluster.Spec.Image = fmt.Sprintf("rabbitmq:%s-management", opts.RabbitmqVersion)
+		}
 	}
 	if len(opts.ImagePullSecrets) > 0 {
 		for _, secret := range opts.ImagePullSecrets {

--- a/kubectl-rabbitmq/cluster_test.go
+++ b/kubectl-rabbitmq/cluster_test.go
@@ -243,6 +243,31 @@ func TestBuildRabbitmqCluster(t *testing.T) {
 		assert.True(t, cluster.Spec.AutoEnableAllFeatureFlags)
 	})
 
+	t.Run("with rabbitmq-version and image NOT set", func(t *testing.T) {
+		t.Parallel()
+		opts := clusterOptions{
+			RabbitmqVersion: "4.2.4",
+		}
+		cluster, err := buildRabbitmqCluster("test-cluster", opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, "4.2.4", cluster.Annotations[v1beta1.RabbitmqVersionAnnotation])
+		assert.Equal(t, "rabbitmq:4.2.4-management", cluster.Spec.Image)
+	})
+
+	t.Run("with rabbitmq-version and image set", func(t *testing.T) {
+		t.Parallel()
+		opts := clusterOptions{
+			RabbitmqVersion: "4.2.4",
+			Image:           "my-custom-image:latest",
+		}
+		cluster, err := buildRabbitmqCluster("test-cluster", opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, "4.2.4", cluster.Annotations[v1beta1.RabbitmqVersionAnnotation])
+		assert.Equal(t, "my-custom-image:latest", cluster.Spec.Image)
+	})
+
 	t.Run("marshals to valid YAML", func(t *testing.T) {
 		t.Parallel()
 		opts := clusterOptions{

--- a/kubectl-rabbitmq/commands.go
+++ b/kubectl-rabbitmq/commands.go
@@ -65,6 +65,7 @@ func newCreateCmd(getExecutor func() *kubectlExecutor) *cobra.Command {
 	cmd.Flags().Int32Var(&opts.Replicas, "replicas", 1, "Number of replicas")
 	cmd.Flags().StringVar(&opts.Image, "image", "", "RabbitMQ image")
 	cmd.Flags().StringSliceVar(&opts.ImagePullSecrets, "image-pull-secret", []string{}, "Image pull secret (repeatable)")
+	cmd.Flags().StringVarP(&opts.RabbitmqVersion, "rabbitmq-version", "v", "", "RabbitMQ version to create (e.g. 4.2.4)")
 
 	// Service configuration
 	cmd.Flags().StringVar(&opts.ServiceType, "service", "ClusterIP", "Service type (ClusterIP, LoadBalancer, NodePort)")

--- a/kubectl-rabbitmq/commands.go
+++ b/kubectl-rabbitmq/commands.go
@@ -65,7 +65,7 @@ func newCreateCmd(getExecutor func() *kubectlExecutor) *cobra.Command {
 	cmd.Flags().Int32Var(&opts.Replicas, "replicas", 1, "Number of replicas")
 	cmd.Flags().StringVar(&opts.Image, "image", "", "RabbitMQ image")
 	cmd.Flags().StringSliceVar(&opts.ImagePullSecrets, "image-pull-secret", []string{}, "Image pull secret (repeatable)")
-	cmd.Flags().StringVarP(&opts.RabbitmqVersion, "rabbitmq-version", "v", "", "RabbitMQ version to create (e.g. 4.2.4)")
+	cmd.Flags().StringVar(&opts.RabbitmqVersion, "rabbitmq-version", "", "RabbitMQ version to create (e.g. 4.2.4)")
 
 	// Service configuration
 	cmd.Flags().StringVar(&opts.ServiceType, "service", "ClusterIP", "Service type (ClusterIP, LoadBalancer, NodePort)")

--- a/kubectl-rabbitmq/commands_test.go
+++ b/kubectl-rabbitmq/commands_test.go
@@ -130,7 +130,7 @@ func TestPluginIntegration(t *testing.T) {
 	})
 
 	t.Run("CreateCluster", func(t *testing.T) {
-		runPlugin(t, "create", "bats-default", "--unlimited")
+		runPlugin(t, "create", "bats-default", "--unlimited", "--rabbitmq-version", "4.2.4")
 		require.Eventually(t, func() bool {
 			out := runKubectl(t, "get", "rabbitmqcluster", "bats-default", "-o", "json")
 			var result struct {

--- a/test/system/utils_test.go
+++ b/test/system/utils_test.go
@@ -439,6 +439,11 @@ func newRabbitmqCluster(namespace, instanceName string) *rabbitmqv1beta1.Rabbitm
 
 	if image := os.Getenv("RABBITMQ_IMAGE"); image != "" {
 		cluster.Spec.Image = image
+	} else {
+		if cluster.Annotations == nil {
+			cluster.Annotations = make(map[string]string)
+		}
+		cluster.Annotations["rabbitmq.com/version"] = "4.2.4"
 	}
 	if secret := os.Getenv("RABBITMQ_IMAGE_PULL_SECRET"); secret != "" {
 		cluster.Spec.ImagePullSecrets = []corev1.LocalObjectReference{

--- a/test/system/utils_test.go
+++ b/test/system/utils_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	storagev1 "k8s.io/api/storage/v1"
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -439,6 +440,25 @@ func newRabbitmqCluster(namespace, instanceName string) *rabbitmqv1beta1.Rabbitm
 
 	if image := os.Getenv("RABBITMQ_IMAGE"); image != "" {
 		cluster.Spec.Image = image
+
+		if cluster.Annotations == nil {
+			cluster.Annotations = make(map[string]string)
+		}
+
+		parts := strings.Split(image, ":")
+		if len(parts) > 1 {
+			tag := parts[len(parts)-1]
+			versionStr := strings.Split(tag, "-")[0]
+
+			if versionStr == "management" || versionStr == "latest" || versionStr == "main" {
+				cluster.Annotations["rabbitmq.com/version"] = "4.2.4"
+			} else {
+				_, err := semver.NewVersion(versionStr)
+				if err == nil {
+					cluster.Annotations["rabbitmq.com/version"] = versionStr
+				}
+			}
+		}
 	} else {
 		if cluster.Annotations == nil {
 			cluster.Annotations = make(map[string]string)


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Replaces the legacy `exec`-based `StartupProbe` (`rabbitmqctl eval`) with an `HTTPGet` probe targeting `/api/health/checks/reached-target-cluster-size` on the management UI port.
- The new HTTP `StartupProbe` is only used when the RabbitMQ version annotation is `>= 4.2.4`.
- For versions below `4.2.4` or if the version is unannotated, the `StartupProbe` is now omitted entirely.
- Dynamic TLS support: The probe correctly targets port `15671` via `HTTPS` if `DisableNonTLSListeners` is enabled, otherwise port `15672` via `HTTP`.
- Refactored `rabbitmq_resource_builder.go` to include a version constraint helper (`ShouldUseHTTPTargetClusterSizeHealthCheck`) with unit tests.
- System tests (`test/system/utils_test.go`) have been updated to inject the `rabbitmq.com/version: "4.2.4"` annotation when `RABBITMQ_IMAGE` is unset, so the new probe logic is exercised by default.
- Added `--rabbitmq-version` flag to the `kubectl-rabbitmq` plugin `create` command to inject the version annotation when scaffolding a cluster.

## Impact on UX

After this change, when a user creates a new `RabbitmqCluster` using `kubectl apply` or similar, it lacks the rabbitmq-version annotation. Because of this, the operator will be conservative and it won't template a startup probe. Then as soon as all replicas are ready, the operator will query rabbitmq API to determine the version and it will annotate `RabbitmqCluster` object. As consequence, a reconcile loop will trigger, now with the rabbitmq-version, and it will update the STS template to include the startup probe. This change in template will cause a rolling restart.

The above is alleviated with the `kubectl-rabbitmq` plugin, because it now has the `--rabbitmq-version` flag, which will template the rabbitmq version annotation at creation time. However, not all `RabbitmqCluster` objects are created with the plugin.

In a few words, unless the rabbitmq-version annotation is set at creation time, the Pods will do a rolling restart right after initial deployment.

## Additional Context

The previous `rabbitmqctl eval` command was an experiment, causing shell overhead and occasional context deadline errors, so it should not be part of the production implementation. The new `/api/health/checks/reached-target-cluster-size` HTTP endpoint provides a robust alternative.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
```

Made with [Cursor](https://cursor.com)