### PR TITLE
feat: move defaulting logic to mutating webhook

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -484,6 +484,8 @@ jobs:
           kubectl config set-context --current --namespace=examples
           [[ -e setup.sh ]] && ./setup.sh
 
+          timeout 120s bash -c 'until out=$(kubectl create --dry-run=server -f rabbitmq.yaml 2>&1); do if echo "$out" | grep -q "connection refused"; then sleep 2; else break; fi; done' || (echo "Timeout waiting for webhook service" && exit 1)
+
           kubectl apply -f rabbitmq.yaml --timeout=30s
           kubectl wait -f rabbitmq.yaml --for=condition=AllReplicasReady --timeout=5m
           kubectl wait -f rabbitmq.yaml --for=condition=ReconcileSuccess --timeout=5m

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -62,6 +62,8 @@ jobs:
         kustomize build config/namespace/base | kubectl apply -f -
         make cert-manager
         kustomize build config/default | bin/ytt -f- -f config/ytt/overlay-manager-image.yaml --data-value operator_image="${IMG}" -f config/ytt/never_pull.yaml | kubectl apply -f -
+        kubectl --namespace=rabbitmq-system wait --for=condition=Available deployment/rabbitmq-cluster-operator
+        make wait-for-webhook
 
     - name: Test kubectl plugin
       working-directory: kubectl-rabbitmq
@@ -320,6 +322,7 @@ jobs:
         make cert-manager
         ytt -f tmp/cluster-operator.yml -f config/ytt/never_pull.yaml | kubectl apply -f-
         kubectl --namespace=rabbitmq-system wait --for=condition=Available deployment/rabbitmq-cluster-operator
+        make wait-for-webhook
 
     - name: System tests
       env:
@@ -391,6 +394,7 @@ jobs:
         make cert-manager
         ytt -f tmp/cluster-operator.yml -f config/ytt/never_pull.yaml | kubectl apply -f-
         kubectl --namespace=rabbitmq-system wait --for=condition=Available deployment/rabbitmq-cluster-operator
+        make wait-for-webhook
 
     - name: System tests
       env:
@@ -464,6 +468,7 @@ jobs:
         make cert-manager
         ytt -f tmp/cluster-operator.yml -f config/ytt/never_pull.yaml | kubectl apply -f-
         kubectl --namespace=rabbitmq-system wait --for=condition=Available deployment/rabbitmq-cluster-operator
+        make wait-for-webhook
 
     - name: Documented example ${{ matrix.example }} test
       env:
@@ -525,6 +530,7 @@ jobs:
     - name: Install Operator build
       run: |
         kind load image-archive ${{ runner.temp }}/operator-image/operator.tar --name upgrade-testing
+        make cert-manager
 
     - name: Get operator manifest
       uses: actions/download-artifact@v8

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -60,6 +60,7 @@ jobs:
       run: |
         kind load image-archive ${{ runner.temp }}/operator.tar --name cluster-operator-testing
         kustomize build config/namespace/base | kubectl apply -f -
+        make cert-manager
         kustomize build config/default | bin/ytt -f- -f config/ytt/overlay-manager-image.yaml --data-value operator_image="${IMG}" -f config/ytt/never_pull.yaml | kubectl apply -f -
 
     - name: Test kubectl plugin
@@ -316,6 +317,7 @@ jobs:
     - name: Install Operator build
       run: |
         kind load image-archive ${{ runner.temp }}/operator-image/operator.tar --name system-testing
+        make cert-manager
         ytt -f tmp/cluster-operator.yml -f config/ytt/never_pull.yaml | kubectl apply -f-
         kubectl --namespace=rabbitmq-system wait --for=condition=Available deployment/rabbitmq-cluster-operator
 
@@ -327,7 +329,6 @@ jobs:
       # 'make deploy-kind' builds the image locally. We should avoid using that target, because we have already built
       # the image in a previous job
       run: |
-        make cert-manager
         SUPPORT_VOLUME_EXPANSION=false make system-tests
 
     - name: Dry-run example YAMLs
@@ -387,6 +388,7 @@ jobs:
     - name: Install Operator build
       run: |
         kind load image-archive ${{ runner.temp }}/operator-image/operator.tar --name system-testing-oldest-k8s
+        make cert-manager
         ytt -f tmp/cluster-operator.yml -f config/ytt/never_pull.yaml | kubectl apply -f-
         kubectl --namespace=rabbitmq-system wait --for=condition=Available deployment/rabbitmq-cluster-operator
 
@@ -397,7 +399,6 @@ jobs:
         RABBITMQ_SERVICE_TYPE: NodePort
       # make system-tests will install required tools e.g. ginkgo
       run: |
-        make cert-manager
         SUPPORT_VOLUME_EXPANSION=false make system-tests
 
   examples_matrix:
@@ -460,6 +461,7 @@ jobs:
     - name: Install Operator build
       run: |
         kind load image-archive ${{ runner.temp }}/operator-image/operator.tar --name examples-testing
+        make cert-manager
         ytt -f tmp/cluster-operator.yml -f config/ytt/never_pull.yaml | kubectl apply -f-
         kubectl --namespace=rabbitmq-system wait --for=condition=Available deployment/rabbitmq-cluster-operator
 
@@ -470,7 +472,6 @@ jobs:
         # Exit early if this example is to be skipped in CI
         [[ -e "$example"/.ci-skip ]] && exit 0
 
-        make cert-manager
         printf "apiVersion: cert-manager.io/v1\nkind: ClusterIssuer\nmetadata:\n  name: selfsigned-issuer\nspec:\n  selfSigned: {}\n" | kubectl apply -f -
 
         pushd "$example"

--- a/Makefile
+++ b/Makefile
@@ -253,9 +253,11 @@ just-integration-tests: kubebuilder-assets ## Run just integration tests without
 .PHONY: manifests
 manifests: controller-gen ## Generate manifests e.g. CRD, RBAC etc.
 	"$(CONTROLLER_GEN)" crd rbac:roleName=rabbitmq-cluster-operator-role paths="./api/...;./internal/controller/..." output:crd:artifacts:config=config/crd/bases
+	"$(CONTROLLER_GEN)" webhook paths="./internal/webhook/..." output:webhook:artifacts:config=config/webhook
 	./hack/remove-override-descriptions.sh
 	./hack/add-notice-to-yaml.sh config/rbac/role.yaml
 	./hack/add-notice-to-yaml.sh config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+	./hack/add-notice-to-yaml.sh config/webhook/manifests.yaml
 
 .PHONY: api-reference
 api-reference: crd-ref-docs ## Generate API reference documentation

--- a/Makefile
+++ b/Makefile
@@ -415,6 +415,8 @@ docker-build-dev:
 wait-for-webhook: ## Wait for the mutating webhook CA bundle to be injected
 	@echo "Waiting for the mutating webhook CA bundle to be injected..."
 	@timeout 120s bash -c 'until $(KUBECTL) get mutatingwebhookconfigurations.admissionregistration.k8s.io mutating-webhook-configuration -o jsonpath="{.webhooks[0].clientConfig.caBundle}" 2>/dev/null | grep -q "[a-zA-Z0-9]"; do sleep 2; done' || (echo "Timeout waiting for CA bundle injection" && exit 1)
+	@echo "Waiting for the webhook service to be reachable..."
+	@timeout 120s bash -c 'until out=$$($(KUBECTL) create --dry-run=server -f config/samples/rabbitmq_v1beta1_rabbitmqcluster.yaml 2>&1); do if echo "$$out" | grep -q "connection refused"; then sleep 2; else break; fi; done' || (echo "Timeout waiting for webhook service" && exit 1)
 
 cert-manager: cmctl ## Setup cert-manager. Use CERT_MANAGER_VERSION to customise the version e.g. CERT_MANAGER_VERSION="v1.15.1"
 	@echo "Installing Cert Manager"

--- a/Makefile
+++ b/Makefile
@@ -411,6 +411,11 @@ docker-build-dev:
 ##@ Cert Manager
 
 .PHONY: cert-manager
+.PHONY: wait-for-webhook
+wait-for-webhook: ## Wait for the mutating webhook CA bundle to be injected
+	@echo "Waiting for the mutating webhook CA bundle to be injected..."
+	@timeout 120s bash -c 'until $(KUBECTL) get mutatingwebhookconfigurations.admissionregistration.k8s.io mutating-webhook-configuration -o jsonpath="{.webhooks[0].clientConfig.caBundle}" 2>/dev/null | grep -q "[a-zA-Z0-9]"; do sleep 2; done' || (echo "Timeout waiting for CA bundle injection" && exit 1)
+
 cert-manager: cmctl ## Setup cert-manager. Use CERT_MANAGER_VERSION to customise the version e.g. CERT_MANAGER_VERSION="v1.15.1"
 	@echo "Installing Cert Manager"
 	$(KUBECTL) apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml

--- a/PROJECT
+++ b/PROJECT
@@ -7,7 +7,7 @@ domain: rabbitmq.com
 layout:
 - go.kubebuilder.io/v4
 projectName: cluster-operator
-repo: github.com/rabbitmq/cluster-operator
+repo: github.com/rabbitmq/cluster-operator/v2
 resources:
 - api:
     crdVersion: v1
@@ -18,6 +18,9 @@ resources:
   domain: rabbitmq.com
   group: rabbitmq.com
   kind: RabbitmqCluster
-  path: github.com/rabbitmq/cluster-operator/api/v1beta1
+  path: github.com/rabbitmq/cluster-operator/v2/api/v1beta1
   version: v1beta1
+  webhooks:
+    defaulting: true
+    webhookVersion: v1
 version: "3"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,9 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
-	controllers "github.com/rabbitmq/cluster-operator/v2/internal/controller"
-	"github.com/rabbitmq/cluster-operator/v2/internal/rabbitmqclient"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
@@ -45,6 +42,11 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
+	controllers "github.com/rabbitmq/cluster-operator/v2/internal/controller"
+	"github.com/rabbitmq/cluster-operator/v2/internal/rabbitmqclient"
+	webhookv1beta1 "github.com/rabbitmq/cluster-operator/v2/internal/webhook/v1beta1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -275,6 +277,16 @@ func main() {
 			Interval:              deprecatedFeaturesCheckInterval,
 		}).SetupWithManager(mgr); err != nil {
 			log.Error(err, "unable to create controller", "controller", "deprecated-feature-controller")
+			os.Exit(1)
+		}
+	}
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err := webhookv1beta1.SetupRabbitmqClusterWebhookWithManager(mgr, webhookv1beta1.RabbitmqClusterCustomDefaulter{
+			DefaultRabbitmqImage:    defaultRabbitmqImage,
+			DefaultImagePullSecrets: defaultImagePullSecrets,
+			DefaultUserUpdaterImage: defaultUserUpdaterImage,
+		}); err != nil {
+			log.Error(err, "unable to create webhook", "webhook", "RabbitmqCluster")
 			os.Exit(1)
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -289,6 +289,10 @@ func main() {
 			log.Error(err, "unable to create webhook", "webhook", "RabbitmqCluster")
 			os.Exit(1)
 		}
+		if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
+			log.Error(err, "unable to set up ready check for webhook")
+			os.Exit(1)
+		}
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/config/certmanager/certificate-metrics.yaml
+++ b/config/certmanager/certificate-metrics.yaml
@@ -1,0 +1,20 @@
+# The following manifests contain a self-signed issuer CR and a metrics certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-certs  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  dnsNames:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert

--- a/config/certmanager/certificate-webhook.yaml
+++ b/config/certmanager/certificate-webhook.yaml
@@ -1,0 +1,20 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  dnsNames:
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert

--- a/config/certmanager/issuer.yaml
+++ b/config/certmanager/issuer.yaml
@@ -1,0 +1,13 @@
+# The following manifest contains a self-signed issuer CR.
+# More information can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- issuer.yaml
+- certificate-webhook.yaml
+- certificate-metrics.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+# This configuration is for teaching kustomize how to update name ref substitution
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -13,9 +13,9 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
@@ -43,13 +43,13 @@ patches:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- path: manager_webhook_patch.yaml
-#  target:
-#    kind: Deployment
+- path: manager_webhook_patch.yaml
+  target:
+    kind: Deployment
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
-#replacements:
+replacements:
 # - source: # Uncomment the following block to enable certificates for metrics
 #     kind: Service
 #     version: v1
@@ -110,42 +110,42 @@ patches:
 #         index: 1
 #         create: true
 
-# - source: # Uncomment the following block if you have any webhook
-#     kind: Service
-#     version: v1
-#     name: webhook-service
-#     fieldPath: .metadata.name # Name of the service
-#   targets:
-#     - select:
-#         kind: Certificate
-#         group: cert-manager.io
-#         version: v1
-#         name: serving-cert
-#       fieldPaths:
-#         - .spec.dnsNames.0
-#         - .spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
-# - source:
-#     kind: Service
-#     version: v1
-#     name: webhook-service
-#     fieldPath: .metadata.namespace # Namespace of the service
-#   targets:
-#     - select:
-#         kind: Certificate
-#         group: cert-manager.io
-#         version: v1
-#         name: serving-cert
-#       fieldPaths:
-#         - .spec.dnsNames.0
-#         - .spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
+ - source: # Uncomment the following block if you have any webhook
+     kind: Service
+     version: v1
+     name: webhook-service
+     fieldPath: .metadata.name # Name of the service
+   targets:
+     - select:
+         kind: Certificate
+         group: cert-manager.io
+         version: v1
+         name: serving-cert
+       fieldPaths:
+         - .spec.dnsNames.0
+         - .spec.dnsNames.1
+       options:
+         delimiter: '.'
+         index: 0
+         create: true
+ - source:
+     kind: Service
+     version: v1
+     name: webhook-service
+     fieldPath: .metadata.namespace # Namespace of the service
+   targets:
+     - select:
+         kind: Certificate
+         group: cert-manager.io
+         version: v1
+         name: serving-cert
+       fieldPaths:
+         - .spec.dnsNames.0
+         - .spec.dnsNames.1
+       options:
+         delimiter: '.'
+         index: 1
+         create: true
 
 # - source: # Uncomment the following block if you have a ValidatingWebhook (--programmatic-validation)
 #     kind: Certificate
@@ -178,36 +178,36 @@ patches:
 #         index: 1
 #         create: true
 
-# - source: # Uncomment the following block if you have a DefaultingWebhook (--defaulting )
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert
-#     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
-#     - select:
-#         kind: MutatingWebhookConfiguration
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 0
-#         create: true
-# - source:
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert
-#     fieldPath: .metadata.name
-#   targets:
-#     - select:
-#         kind: MutatingWebhookConfiguration
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 1
-#         create: true
+ - source: # Uncomment the following block if you have a DefaultingWebhook (--defaulting )
+     kind: Certificate
+     group: cert-manager.io
+     version: v1
+     name: serving-cert
+     fieldPath: .metadata.namespace # Namespace of the certificate CR
+   targets:
+     - select:
+         kind: MutatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 0
+         create: true
+ - source:
+     kind: Certificate
+     group: cert-manager.io
+     version: v1
+     name: serving-cert
+     fieldPath: .metadata.name
+   targets:
+     - select:
+         kind: MutatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 1
+         create: true
 
 # - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
 #     kind: Certificate

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,20 @@
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts
+  value:
+  - mountPath: /tmp/k8s-webhook-server/serving-certs
+    name: webhook-certs
+    readOnly: true
+
+- op: add
+  path: /spec/template/spec/containers/0/ports/-
+  value:
+    containerPort: 9443
+    name: webhook-server
+    protocol: TCP
+
+- op: add
+  path: /spec/template/spec/volumes
+  value:
+  - name: webhook-certs
+    secret:
+      secretName: webhook-server-cert

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -15,3 +15,4 @@ spec:
     targetPort: 8443
   selector:
     app.kubernetes.io/name: rabbitmq-cluster-operator
+    app.kubernetes.io/component: rabbitmq-operator

--- a/config/installation/kustomization.yaml
+++ b/config/installation/kustomization.yaml
@@ -19,4 +19,79 @@ resources:
 - ../crd/
 - ../rbac/
 - ../manager/
+- ../webhook
+- ../certmanager
 - metrics_service.yaml
+
+patches:
+- path: manager_webhook_patch.yaml
+  target:
+    kind: Deployment
+
+replacements:
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+      name: serving-cert
+    fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 0
+      create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+      name: serving-cert
+    fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 1
+      create: true
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert
+    fieldPath: .metadata.namespace
+  targets:
+  - select:
+      kind: MutatingWebhookConfiguration
+    fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+      create: true
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert
+    fieldPath: .metadata.name
+  targets:
+  - select:
+      kind: MutatingWebhookConfiguration
+    fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+      create: true

--- a/config/installation/manager_webhook_patch.yaml
+++ b/config/installation/manager_webhook_patch.yaml
@@ -1,0 +1,20 @@
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts
+  value:
+  - mountPath: /tmp/k8s-webhook-server/serving-certs
+    name: webhook-certs
+    readOnly: true
+
+- op: add
+  path: /spec/template/spec/containers/0/ports/-
+  value:
+    containerPort: 9443
+    name: webhook-server
+    protocol: TCP
+
+- op: add
+  path: /spec/template/spec/volumes
+  value:
+  - name: webhook-certs
+    secret:
+      secretName: webhook-server-cert

--- a/config/installation/metrics_service.yaml
+++ b/config/installation/metrics_service.yaml
@@ -15,3 +15,4 @@ spec:
     targetPort: 8080
   selector:
     app.kubernetes.io/name: rabbitmq-cluster-operator
+    app.kubernetes.io/component: rabbitmq-operator

--- a/config/network-policy/allow-webhook-traffic.yaml
+++ b/config/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,27 @@
+# This NetworkPolicy allows ingress traffic to your webhook server running
+# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
+# will only work when applied in namespaces labeled with 'webhook: enabled'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-webhook-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: cluster-operator
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhook: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled # Only from namespaces with this label
+      ports:
+        - port: 443
+          protocol: TCP

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
+- allow-webhook-traffic.yaml
 - allow-metrics-traffic.yaml

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- manifests.yaml
+- service.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,34 @@
+# RabbitMQ Cluster Operator
+#
+# Copyright 2020 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Mozilla Public license, Version 2.0 (the "License").  You may not use this product except in compliance with the Mozilla Public License.
+#
+# This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-rabbitmq-com-v1beta1-rabbitmqcluster
+  failurePolicy: Fail
+  name: mrabbitmqcluster-v1beta1.kb.io
+  rules:
+  - apiGroups:
+    - rabbitmq.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rabbitmqclusters
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,23 @@
+# RabbitMQ Cluster Operator
+#
+# Copyright 2020 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the Mozilla Public license, Version 2.0 (the "License").  You may not use this product except in compliance with the Mozilla Public License.
+#
+# This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app.kubernetes.io/name: rabbitmq-cluster-operator

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -21,3 +21,4 @@ spec:
       targetPort: 9443
   selector:
     app.kubernetes.io/name: rabbitmq-cluster-operator
+    app.kubernetes.io/component: rabbitmq-operator

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -26,6 +26,8 @@ The script `test.sh` will be executed **after** `AllReplicasReady` condition is 
 object. The script `test.sh` should exit with code 0 if all assertions were successful; the script `test.sh` should
 exit with non-zero code if any test or assertion failed. The same is expected for `setup.sh`.
 
+Note: The testing framework automatically performs a dry-run of the example's `rabbitmq.yaml` before actually applying it. This ensures that the mutating webhook is fully reachable and prevents intermittent "connection refused" errors during test execution.
+
 If the example should not run any tests because of the reasons mentioned above, the folder should contain
 a file `.ci-skip`, so that the example is not considered in our tests.
 

--- a/hack/test-upgrade.sh
+++ b/hack/test-upgrade.sh
@@ -41,6 +41,7 @@ current_generation="$(kubectl --namespace default get sts operator-upgrade-serve
 
 kubectl apply -f $UPGRADE_MANIFEST
 kubectl --namespace=rabbitmq-system wait --for=condition=Available deployment/rabbitmq-cluster-operator
+make wait-for-webhook
 sleep 30
 kubectl wait rabbitmqcluster operator-upgrade --for=condition=AllReplicasReady --timeout=5m
 kubectl wait rabbitmqcluster operator-upgrade --for=condition=ReconcileSuccess --timeout=5m

--- a/internal/controller/reconcile_operator_defaults.go
+++ b/internal/controller/reconcile_operator_defaults.go
@@ -3,46 +3,32 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
+
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
-	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"strings"
-	"time"
 )
 
-// reconcileOperatorDefaults updates current rabbitmqCluster with operator defaults from the Reconciler
-// it handles RabbitMQ image, imagePullSecrets, and user updater image
+// reconcileOperatorDefaults enforces operator-controlled image overrides when ControlRabbitmqImage is enabled.
+// Admission-time defaulting (image, imagePullSecrets, default user updater image) is handled by the mutating webhook.
 func (r *RabbitmqClusterReconciler) reconcileOperatorDefaults(ctx context.Context, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) (time.Duration, error) {
-	// image will be updated image isn't set yet or the image controlled by the operator (experimental).
-	if rabbitmqCluster.Spec.Image == "" || r.ControlRabbitmqImage {
-		rabbitmqCluster.Spec.Image = r.DefaultRabbitmqImage
-		if requeue, err := r.updateRabbitmqCluster(ctx, rabbitmqCluster, "image"); err != nil {
-			return requeue, err
-		}
+	if !r.ControlRabbitmqImage {
+		return 0, nil
 	}
 
-	if rabbitmqCluster.Spec.ImagePullSecrets == nil && r.DefaultImagePullSecrets != "" {
-		// split the comma separated list of default image pull secrets from
-		// the 'DEFAULT_IMAGE_PULL_SECRETS' env var, but ignore empty strings.
-		for reference := range strings.SplitSeq(r.DefaultImagePullSecrets, ",") {
-			if len(reference) > 0 {
-				rabbitmqCluster.Spec.ImagePullSecrets = append(rabbitmqCluster.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: reference})
-			}
-		}
-		if len(rabbitmqCluster.Spec.ImagePullSecrets) > 0 {
-			if requeue, err := r.updateRabbitmqCluster(ctx, rabbitmqCluster, "image pull secrets"); err != nil {
-				return requeue, err
-			}
-		}
+	rabbitmqCluster.Spec.Image = r.DefaultRabbitmqImage
+	if requeue, err := r.updateRabbitmqCluster(ctx, rabbitmqCluster, "image"); err != nil {
+		return requeue, err
 	}
 
-	if rabbitmqCluster.UsesDefaultUserUpdaterImage(r.ControlRabbitmqImage) {
+	if rabbitmqCluster.VaultEnabled() {
 		rabbitmqCluster.Spec.SecretBackend.Vault.DefaultUserUpdaterImage = &r.DefaultUserUpdaterImage
 		if requeue, err := r.updateRabbitmqCluster(ctx, rabbitmqCluster, "default user image"); err != nil {
 			return requeue, err
 		}
 	}
+
 	return 0, nil
 }
 

--- a/internal/controller/reconcile_operator_defaults_internal_test.go
+++ b/internal/controller/reconcile_operator_defaults_internal_test.go
@@ -15,6 +15,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,31 +26,18 @@ import (
 )
 
 var _ = Describe("reconcileOperatorDefaults", func() {
-	When("DEFAULT_IMAGE_PULL_SECRETS is empty", func() {
-		It("does not Update the cluster when ImagePullSecrets is nil", func() {
+	When("ControlRabbitmqImage is false", func() {
+		It("does not call Update", func() {
 			ctx := context.Background()
 
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).To(Succeed())
 			Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
 
-			presetUserUpdaterImage := "preset-uu-image:1.0"
 			cluster := &rabbitmqv1beta1.RabbitmqCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-no-defaults",
+					Name:      "test-no-update",
 					Namespace: "default",
-				},
-				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-					// Pre-set Image and DefaultUserUpdaterImage so the only branch
-					// in reconcileOperatorDefaults that could trigger an Update is
-					// the ImagePullSecrets one we are testing.
-					Image: "preset-image:1.0",
-					SecretBackend: rabbitmqv1beta1.SecretBackend{
-						Vault: &rabbitmqv1beta1.VaultSpec{
-							DefaultUserPath:         "some-path",
-							DefaultUserUpdaterImage: &presetUserUpdaterImage,
-						},
-					},
 				},
 			}
 
@@ -70,25 +58,60 @@ var _ = Describe("reconcileOperatorDefaults", func() {
 				Scheme:                  scheme,
 				DefaultRabbitmqImage:    "default-rabbit-image:stable",
 				DefaultUserUpdaterImage: "default-uu-image:unstable",
-				DefaultImagePullSecrets: "",
+				DefaultImagePullSecrets: "secret-1,secret-2",
+				ControlRabbitmqImage:    false,
 			}
 
-			By("invoking reconcileOperatorDefaults with empty DefaultImagePullSecrets")
 			requeue, err := reconciler.reconcileOperatorDefaults(ctx, cluster)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeue).To(BeZero())
-
-			By("not calling Update on the cluster")
 			Expect(updateCallCount).To(Equal(0))
+		})
+	})
 
-			By("leaving in-memory ImagePullSecrets as nil")
-			Expect(cluster.Spec.ImagePullSecrets).To(BeNil())
+	When("ControlRabbitmqImage is true", func() {
+		It("enforces the default image and user updater image", func() {
+			ctx := context.Background()
 
-			By("leaving the persisted ImagePullSecrets as nil")
-			fetched := &rabbitmqv1beta1.RabbitmqCluster{}
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(cluster), fetched)).To(Succeed())
-			Expect(fetched.Spec.ImagePullSecrets).To(BeNil())
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(rabbitmqv1beta1.AddToScheme(scheme)).To(Succeed())
+
+			cluster := &rabbitmqv1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-control-image",
+					Namespace: "default",
+				},
+				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
+					Image: "user-set-image:1.0",
+					SecretBackend: rabbitmqv1beta1.SecretBackend{
+						Vault: &rabbitmqv1beta1.VaultSpec{
+							DefaultUserPath: "some-path",
+						},
+					},
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(cluster).
+				Build()
+
+			reconciler := &RabbitmqClusterReconciler{
+				Client:                  fakeClient,
+				Scheme:                  scheme,
+				DefaultRabbitmqImage:    "controlled-image:latest",
+				DefaultUserUpdaterImage: "controlled-uu-image:latest",
+				ControlRabbitmqImage:    true,
+			}
+
+			requeue, err := reconciler.reconcileOperatorDefaults(ctx, cluster)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requeue).To(BeZero())
+			Expect(cluster.Spec.Image).To(Equal("controlled-image:latest"))
+			Expect(cluster.Spec.SecretBackend.Vault.DefaultUserUpdaterImage).To(PointTo(Equal("controlled-uu-image:latest")))
 		})
 	})
 })

--- a/internal/controller/reconcile_operator_defaults_internal_test.go
+++ b/internal/controller/reconcile_operator_defaults_internal_test.go
@@ -27,8 +27,7 @@ import (
 
 var _ = Describe("reconcileOperatorDefaults", func() {
 	When("ControlRabbitmqImage is false", func() {
-		It("does not call Update", func() {
-			ctx := context.Background()
+		It("does not call Update", func(ctx SpecContext) {
 
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).To(Succeed())
@@ -71,8 +70,7 @@ var _ = Describe("reconcileOperatorDefaults", func() {
 	})
 
 	When("ControlRabbitmqImage is true", func() {
-		It("enforces the default image and user updater image", func() {
-			ctx := context.Background()
+		It("enforces the default image and user updater image", func(ctx SpecContext) {
 
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).To(Succeed())

--- a/internal/controller/reconcile_operator_defaults_test.go
+++ b/internal/controller/reconcile_operator_defaults_test.go
@@ -11,19 +11,28 @@ import (
 )
 
 var _ = Describe("ReconcileOperatorDefaults", func() {
-	Context("with operator defaults configured", func() {
+	Context("with defaults already applied (as the mutating webhook would)", func() {
 		var cluster *rabbitmqv1beta1.RabbitmqCluster
 
 		BeforeEach(func() {
+			// Simulate what the mutating webhook sets at admission time.
+			userUpdaterImage := defaultUserUpdaterImage
 			cluster = &rabbitmqv1beta1.RabbitmqCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-default",
 					Namespace: "default",
 				},
 				Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
+					Image: defaultRabbitmqImage,
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{Name: "image-secret-1"},
+						{Name: "image-secret-2"},
+						{Name: "image-secret-3"},
+					},
 					SecretBackend: rabbitmqv1beta1.SecretBackend{
 						Vault: &rabbitmqv1beta1.VaultSpec{
-							DefaultUserPath: "some-path",
+							DefaultUserPath:         "some-path",
+							DefaultUserUpdaterImage: &userUpdaterImage,
 						},
 					},
 				},
@@ -33,28 +42,22 @@ var _ = Describe("ReconcileOperatorDefaults", func() {
 			waitForClusterCreation(ctx, cluster, client)
 		})
 
-		It("handles operator defaults correctly", func() {
+		It("propagates defaults to child resources", func() {
 			fetchedCluster := &rabbitmqv1beta1.RabbitmqCluster{}
 			Expect(client.Get(ctx, k8sclient.ObjectKeyFromObject(cluster), fetchedCluster)).To(Succeed())
 
-			By("setting the image spec with the default image")
+			By("preserving the image set by the webhook")
 			Expect(fetchedCluster.Spec.Image).To(Equal(defaultRabbitmqImage))
 
-			By("setting the default user updater image to the controller default")
+			By("preserving the default user updater image set by the webhook")
 			Expect(fetchedCluster.Spec.SecretBackend.Vault.DefaultUserUpdaterImage).To(PointTo(Equal(defaultUserUpdaterImage)))
 
-			By("setting the default imagePullSecrets")
+			By("propagating imagePullSecrets to the StatefulSet")
 			Expect(statefulSet(ctx, cluster).Spec.Template.Spec.ImagePullSecrets).To(ConsistOf(
 				[]corev1.LocalObjectReference{
-					{
-						Name: "image-secret-1",
-					},
-					{
-						Name: "image-secret-2",
-					},
-					{
-						Name: "image-secret-3",
-					},
+					{Name: "image-secret-1"},
+					{Name: "image-secret-2"},
+					{Name: "image-secret-3"},
 				},
 			))
 		})

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"k8s.io/client-go/util/retry"
 
@@ -25,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	controllers "github.com/rabbitmq/cluster-operator/v2/internal/controller"
+	webhookv1beta1 "github.com/rabbitmq/cluster-operator/v2/internal/webhook/v1beta1"
 	"github.com/rabbitmq/cluster-operator/v2/internal/rabbitmqclient"
 
 	"k8s.io/client-go/kubernetes"
@@ -80,6 +82,9 @@ var _ = BeforeSuite(func() {
 		Config: &rest.Config{
 			Host: fmt.Sprintf("http://localhost:218%d", GinkgoParallelProcess()),
 		},
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
+		},
 	}
 
 	cfg, err := testEnv.Start()
@@ -92,11 +97,24 @@ var _ = BeforeSuite(func() {
 	clientSet, err = kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
 
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 		Metrics: server.Options{
 			BindAddress: "0",
 		},
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = webhookv1beta1.SetupRabbitmqClusterWebhookWithManager(mgr, webhookv1beta1.RabbitmqClusterCustomDefaulter{
+		DefaultRabbitmqImage:    defaultRabbitmqImage,
+		DefaultImagePullSecrets: defaultImagePullSecrets,
+		DefaultUserUpdaterImage: defaultUserUpdaterImage,
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -26,8 +26,8 @@ import (
 	. "github.com/onsi/gomega"
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	controllers "github.com/rabbitmq/cluster-operator/v2/internal/controller"
-	webhookv1beta1 "github.com/rabbitmq/cluster-operator/v2/internal/webhook/v1beta1"
 	"github.com/rabbitmq/cluster-operator/v2/internal/rabbitmqclient"
+	webhookv1beta1 "github.com/rabbitmq/cluster-operator/v2/internal/webhook/v1beta1"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/internal/webhook/v1beta1/rabbitmqcluster_webhook.go
+++ b/internal/webhook/v1beta1/rabbitmqcluster_webhook.go
@@ -1,0 +1,73 @@
+/*
+RabbitMQ Cluster Operator
+
+Copyright 2020-2022 VMware, Inc. All Rights Reserved.
+Copyright 2022-2026 Broadcom. All Rights Reserved.
+
+This product is licensed to you under the Mozilla Public license,
+Version 2.0 (the "License").  You may not use this product except in
+compliance with the Mozilla Public License.
+
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of these subcomponents
+is subject to the terms and conditions of the subcomponent's license,
+as noted in the LICENSE file.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	rabbitmqcomv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
+)
+
+var rabbitmqclusterlog = logf.Log.WithName("rabbitmqcluster-resource")
+
+// SetupRabbitmqClusterWebhookWithManager registers the webhook for RabbitmqCluster in the manager.
+func SetupRabbitmqClusterWebhookWithManager(mgr ctrl.Manager, defaulter RabbitmqClusterCustomDefaulter) error {
+	return ctrl.NewWebhookManagedBy(mgr, &rabbitmqcomv1beta1.RabbitmqCluster{}).
+		WithDefaulter(&defaulter).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/mutate-rabbitmq-com-v1beta1-rabbitmqcluster,mutating=true,failurePolicy=fail,sideEffects=None,groups=rabbitmq.com,resources=rabbitmqclusters,verbs=create;update,versions=v1beta1,name=mrabbitmqcluster-v1beta1.kb.io,admissionReviewVersions=v1
+
+// RabbitmqClusterCustomDefaulter sets default values on RabbitmqCluster resources at admission time.
+// Defaults are applied only when the relevant field is unset, preserving any value explicitly configured by the user.
+//
+// +kubebuilder:object:generate=false
+type RabbitmqClusterCustomDefaulter struct {
+	DefaultRabbitmqImage    string
+	DefaultImagePullSecrets string
+	DefaultUserUpdaterImage string
+}
+
+// Default implements webhook.CustomDefaulter.
+func (d *RabbitmqClusterCustomDefaulter) Default(_ context.Context, obj *rabbitmqcomv1beta1.RabbitmqCluster) error {
+	rabbitmqclusterlog.Info("Defaulting for RabbitmqCluster", "name", obj.GetName())
+
+	if obj.Spec.Image == "" {
+		obj.Spec.Image = d.DefaultRabbitmqImage
+	}
+
+	if obj.Spec.ImagePullSecrets == nil && d.DefaultImagePullSecrets != "" {
+		for ref := range strings.SplitSeq(d.DefaultImagePullSecrets, ",") {
+			if ref != "" {
+				obj.Spec.ImagePullSecrets = append(obj.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: ref})
+			}
+		}
+	}
+
+	if obj.VaultEnabled() && obj.Spec.SecretBackend.Vault.DefaultUserUpdaterImage == nil {
+		image := d.DefaultUserUpdaterImage
+		obj.Spec.SecretBackend.Vault.DefaultUserUpdaterImage = &image
+	}
+
+	return nil
+}

--- a/internal/webhook/v1beta1/rabbitmqcluster_webhook.go
+++ b/internal/webhook/v1beta1/rabbitmqcluster_webhook.go
@@ -27,7 +27,7 @@ import (
 	rabbitmqcomv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 )
 
-var rabbitmqclusterlog = logf.Log.WithName("rabbitmqcluster-resource")
+var rabbitmqclusterlog = logf.Log.WithName("rabbitmqcluster-webhook")
 
 // SetupRabbitmqClusterWebhookWithManager registers the webhook for RabbitmqCluster in the manager.
 func SetupRabbitmqClusterWebhookWithManager(mgr ctrl.Manager, defaulter RabbitmqClusterCustomDefaulter) error {

--- a/internal/webhook/v1beta1/rabbitmqcluster_webhook_test.go
+++ b/internal/webhook/v1beta1/rabbitmqcluster_webhook_test.go
@@ -1,0 +1,114 @@
+/*
+RabbitMQ Cluster Operator
+
+Copyright 2020-2022 VMware, Inc. All Rights Reserved.
+Copyright 2022-2026 Broadcom. All Rights Reserved.
+
+This product is licensed to you under the Mozilla Public license,
+Version 2.0 (the "License").  You may not use this product except in
+compliance with the Mozilla Public License.
+
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of these subcomponents
+is subject to the terms and conditions of the subcomponent's license,
+as noted in the LICENSE file.
+*/
+
+package v1beta1
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rabbitmqcomv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
+)
+
+var _ = Describe("RabbitmqCluster Webhook", func() {
+	var (
+		obj       *rabbitmqcomv1beta1.RabbitmqCluster
+		defaulter RabbitmqClusterCustomDefaulter
+	)
+
+	BeforeEach(func() {
+		obj = &rabbitmqcomv1beta1.RabbitmqCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+		}
+		defaulter = RabbitmqClusterCustomDefaulter{
+			DefaultRabbitmqImage:    "rabbitmq:default",
+			DefaultImagePullSecrets: "secret-1,secret-2",
+			DefaultUserUpdaterImage: "credential-updater:default",
+		}
+	})
+
+	Context("image defaulting", func() {
+		It("sets the default image when spec.image is empty", func() {
+			Expect(defaulter.Default(context.Background(), obj)).To(Succeed())
+			Expect(obj.Spec.Image).To(Equal("rabbitmq:default"))
+		})
+
+		It("does not override an image the user has already set", func() {
+			obj.Spec.Image = "rabbitmq:custom"
+			Expect(defaulter.Default(context.Background(), obj)).To(Succeed())
+			Expect(obj.Spec.Image).To(Equal("rabbitmq:custom"))
+		})
+	})
+
+	Context("imagePullSecrets defaulting", func() {
+		It("sets imagePullSecrets from the comma-separated default when spec.imagePullSecrets is nil", func() {
+			Expect(defaulter.Default(context.Background(), obj)).To(Succeed())
+			Expect(obj.Spec.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "secret-1"},
+				corev1.LocalObjectReference{Name: "secret-2"},
+			))
+		})
+
+		It("does not override imagePullSecrets the user has already set", func() {
+			obj.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "user-secret"}}
+			Expect(defaulter.Default(context.Background(), obj)).To(Succeed())
+			Expect(obj.Spec.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "user-secret"}))
+		})
+
+		It("does not set imagePullSecrets when DefaultImagePullSecrets is empty", func() {
+			defaulter.DefaultImagePullSecrets = ""
+			Expect(defaulter.Default(context.Background(), obj)).To(Succeed())
+			Expect(obj.Spec.ImagePullSecrets).To(BeNil())
+		})
+
+		It("ignores empty entries in the comma-separated list", func() {
+			defaulter.DefaultImagePullSecrets = "secret-1,,secret-2"
+			Expect(defaulter.Default(context.Background(), obj)).To(Succeed())
+			Expect(obj.Spec.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "secret-1"},
+				corev1.LocalObjectReference{Name: "secret-2"},
+			))
+		})
+	})
+
+	Context("default user updater image defaulting", func() {
+		It("sets the default user updater image when vault is enabled and the field is nil", func() {
+			obj.Spec.SecretBackend.Vault = &rabbitmqcomv1beta1.VaultSpec{DefaultUserPath: "some-path"}
+			Expect(defaulter.Default(context.Background(), obj)).To(Succeed())
+			Expect(obj.Spec.SecretBackend.Vault.DefaultUserUpdaterImage).To(PointTo(Equal("credential-updater:default")))
+		})
+
+		It("does not override a user updater image the user has already set", func() {
+			custom := "credential-updater:custom"
+			obj.Spec.SecretBackend.Vault = &rabbitmqcomv1beta1.VaultSpec{
+				DefaultUserPath:         "some-path",
+				DefaultUserUpdaterImage: &custom,
+			}
+			Expect(defaulter.Default(context.Background(), obj)).To(Succeed())
+			Expect(obj.Spec.SecretBackend.Vault.DefaultUserUpdaterImage).To(PointTo(Equal("credential-updater:custom")))
+		})
+
+		It("does not set the user updater image when vault is not enabled", func() {
+			Expect(defaulter.Default(context.Background(), obj)).To(Succeed())
+			Expect(obj.Spec.SecretBackend.Vault).To(BeNil())
+		})
+	})
+})

--- a/internal/webhook/v1beta1/webhook_suite_test.go
+++ b/internal/webhook/v1beta1/webhook_suite_test.go
@@ -1,0 +1,169 @@
+/*
+RabbitMQ Cluster Operator
+
+Copyright 2020-2022 VMware, Inc. All Rights Reserved.
+Copyright 2022-2026 Broadcom. All Rights Reserved.
+
+This product is licensed to you under the Mozilla Public license,
+Version 2.0 (the "License").  You may not use this product except in
+compliance with the Mozilla Public License.
+
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of these subcomponents
+is subject to the terms and conditions of the subcomponent's license,
+as noted in the LICENSE file.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	rabbitmqcomv1beta1 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	var err error
+	err = rabbitmqcomv1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	// Retrieve the first found binary directory to allow running tests from IDEs
+	if getFirstFoundEnvTestBinaryDir() != "" {
+		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	}
+
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager.
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = SetupRabbitmqClusterWebhookWithManager(mgr, RabbitmqClusterCustomDefaulter{
+		DefaultRabbitmqImage:    "rabbitmq:test",
+		DefaultImagePullSecrets: "test-secret-1,test-secret-2",
+		DefaultUserUpdaterImage: "credential-updater:test",
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:webhook
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// wait for the webhook server to get ready.
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+
+		return conn.Close()
+	}).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
+})
+
+// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
+// ENVTEST-based tests depend on specific binaries, usually located in paths set by
+// controller-runtime. When running tests directly (e.g., via an IDE) without using
+// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
+//
+// This function streamlines the process by finding the required binaries, similar to
+// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
+// properly set up, run 'make setup-envtest' beforehand.
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -212,6 +212,28 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 			Eventually(verifyMetricsServerStarted, 3*time.Minute, time.Second).Should(Succeed())
 
+			By("waiting for the webhook service endpoints to be ready")
+			verifyWebhookEndpointsReady := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "endpointslices.discovery.k8s.io", "-n", namespace,
+					"-l", "kubernetes.io/service-name=cluster-operator-webhook-service",
+					"-o", "jsonpath={range .items[*]}{range .endpoints[*]}{.addresses[*]}{end}{end}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "Webhook endpoints should exist")
+				g.Expect(output).ShouldNot(BeEmpty(), "Webhook endpoints not yet ready")
+			}
+			Eventually(verifyWebhookEndpointsReady, 3*time.Minute, time.Second).Should(Succeed())
+
+			By("verifying the mutating webhook server is ready")
+			verifyMutatingWebhookReady := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "mutatingwebhookconfigurations.admissionregistration.k8s.io",
+					"cluster-operator-mutating-webhook-configuration",
+					"-o", "jsonpath={.webhooks[0].clientConfig.caBundle}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "MutatingWebhookConfiguration should exist")
+				g.Expect(output).ShouldNot(BeEmpty(), "Mutating webhook CA bundle not yet injected")
+			}
+			Eventually(verifyMutatingWebhookReady, 3*time.Minute, time.Second).Should(Succeed())
+
 			// +kubebuilder:scaffold:e2e-metrics-webhooks-readiness
 
 			By("creating the curl-metrics pod to access the metrics endpoint")
@@ -264,6 +286,30 @@ var _ = Describe("Manager", Ordered, func() {
 				g.Expect(metricsOutput).To(ContainSubstring("< HTTP/1.1 200 OK"))
 			}
 			Eventually(verifyMetricsAvailable, 2*time.Minute).Should(Succeed())
+		})
+
+		It("should provisioned cert-manager", func() {
+			By("validating that cert-manager has the certificate Secret")
+			verifyCertManager := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "secrets", "webhook-server-cert", "-n", namespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			Eventually(verifyCertManager).Should(Succeed())
+		})
+
+		It("should have CA injection for mutating webhooks", func() {
+			By("checking CA injection for mutating webhooks")
+			verifyCAInjection := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get",
+					"mutatingwebhookconfigurations.admissionregistration.k8s.io",
+					"cluster-operator-mutating-webhook-configuration",
+					"-o", "go-template={{ range .webhooks }}{{ .clientConfig.caBundle }}{{ end }}")
+				mwhOutput, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(len(mwhOutput)).To(BeNumerically(">", 10))
+			}
+			Eventually(verifyCAInjection).Should(Succeed())
 		})
 
 		// +kubebuilder:scaffold:e2e-webhooks-checks

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Manager", Ordered, func() {
 			By("waiting for the webhook service endpoints to be ready")
 			verifyWebhookEndpointsReady := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "endpointslices.discovery.k8s.io", "-n", namespace,
-					"-l", "kubernetes.io/service-name=cluster-operator-webhook-service",
+					"-l", "kubernetes.io/service-name=webhook-service",
 					"-o", "jsonpath={range .items[*]}{range .endpoints[*]}{.addresses[*]}{end}{end}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "Webhook endpoints should exist")
@@ -226,7 +226,7 @@ var _ = Describe("Manager", Ordered, func() {
 			By("verifying the mutating webhook server is ready")
 			verifyMutatingWebhookReady := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "mutatingwebhookconfigurations.admissionregistration.k8s.io",
-					"cluster-operator-mutating-webhook-configuration",
+					"mutating-webhook-configuration",
 					"-o", "jsonpath={.webhooks[0].clientConfig.caBundle}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "MutatingWebhookConfiguration should exist")
@@ -303,7 +303,7 @@ var _ = Describe("Manager", Ordered, func() {
 			verifyCAInjection := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get",
 					"mutatingwebhookconfigurations.admissionregistration.k8s.io",
-					"cluster-operator-mutating-webhook-configuration",
+					"mutating-webhook-configuration",
 					"-o", "go-template={{ range .webhooks }}{{ .clientConfig.caBundle }}{{ end }}")
 				mwhOutput, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -81,6 +81,10 @@ var _ = Describe("Manager", Ordered, func() {
 		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
 		_, _ = utils.Run(cmd)
 
+		By("cleaning up the metrics ClusterRoleBinding")
+		cmd = exec.Command("kubectl", "delete", "clusterrolebinding", metricsRoleBindingName, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+
 		By("undeploying the controller-manager")
 		cmd = exec.Command("make", "undeploy-secure-metrics")
 		_, _ = utils.Run(cmd)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -216,6 +216,17 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 			Eventually(verifyMetricsServerStarted, 3*time.Minute, time.Second).Should(Succeed())
 
+			By("waiting for the webhook service endpoints to be ready")
+			verifyWebhookEndpointsReady := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "endpointslices.discovery.k8s.io", "-n", namespace,
+					"-l", "kubernetes.io/service-name=webhook-service",
+					"-o", "jsonpath={range .items[*]}{range .endpoints[*]}{.addresses[*]}{end}{end}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "Webhook endpoints should exist")
+				g.Expect(output).ShouldNot(BeEmpty(), "Webhook endpoints not yet ready")
+			}
+			Eventually(verifyWebhookEndpointsReady, 3*time.Minute, time.Second).Should(Succeed())
+
 			By("verifying the mutating webhook server is ready")
 			verifyMutatingWebhookReady := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "mutatingwebhookconfigurations.admissionregistration.k8s.io",

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -216,17 +216,6 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 			Eventually(verifyMetricsServerStarted, 3*time.Minute, time.Second).Should(Succeed())
 
-			By("waiting for the webhook service endpoints to be ready")
-			verifyWebhookEndpointsReady := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "endpointslices.discovery.k8s.io", "-n", namespace,
-					"-l", "kubernetes.io/service-name=webhook-service",
-					"-o", "jsonpath={range .items[*]}{range .endpoints[*]}{.addresses[*]}{end}{end}")
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred(), "Webhook endpoints should exist")
-				g.Expect(output).ShouldNot(BeEmpty(), "Webhook endpoints not yet ready")
-			}
-			Eventually(verifyWebhookEndpointsReady, 3*time.Minute, time.Second).Should(Succeed())
-
 			By("verifying the mutating webhook server is ready")
 			verifyMutatingWebhookReady := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "mutatingwebhookconfigurations.admissionregistration.k8s.io",

--- a/test/system/system_suite_test.go
+++ b/test/system/system_suite_test.go
@@ -100,6 +100,15 @@ var _ = SynchronizedBeforeSuite(
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 			return operatorDeployment.Status.ReadyReplicas
 		}, 10, 1).Should(BeNumerically("==", 1), "Expected to have Operator Pod Ready")
+
+		// Wait for the mutating webhook CA bundle to be injected by cert-manager
+		Eventually(func() string {
+			mwc, err := clientSet.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, "mutating-webhook-configuration", metav1.GetOptions{})
+			if err != nil || len(mwc.Webhooks) == 0 {
+				return ""
+			}
+			return string(mwc.Webhooks[0].ClientConfig.CABundle)
+		}, 60, 1).ShouldNot(BeEmpty(), "Expected MutatingWebhookConfiguration CA bundle to be injected")
 	},
 )
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2" // nolint:revive,staticcheck
 )
@@ -88,16 +89,28 @@ func InstallCertManager() error {
 	if _, err := Run(cmd); err != nil {
 		return err
 	}
-	// Wait for cert-manager-webhook to be ready, which can take time if cert-manager
-	// was re-installed after uninstalling on a cluster.
-	cmd = exec.Command("kubectl", "wait", "deployment.apps/cert-manager-webhook",
-		"--for", "condition=Available",
-		"--namespace", "cert-manager",
-		"--timeout", "5m",
-	)
-
-	_, err := Run(cmd)
-	return err
+	// Wait for all three cert-manager components to be Available.
+	for _, deployment := range []string{"cert-manager", "cert-manager-cainjector", "cert-manager-webhook"} {
+		cmd = exec.Command("kubectl", "wait", "deployment.apps/"+deployment,
+			"--for", "condition=Available",
+			"--namespace", "cert-manager",
+			"--timeout", "5m",
+		)
+		if _, err := Run(cmd); err != nil {
+			return err
+		}
+	}
+	// Probe until the cert-manager webhook accepts connections. The cainjector needs
+	// extra time after pod readiness to inject the CA bundle into its own webhook config.
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		probe := exec.Command("kubectl", "get", "certificates.cert-manager.io", "--all-namespaces")
+		if _, err := Run(probe); err == nil {
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("cert-manager webhook not ready after 2 minutes")
 }
 
 // IsCertManagerCRDsInstalled checks if any Cert Manager CRDs are installed


### PR DESCRIPTION
This closes #2121

## Summary Of Changes

Defaulting of spec.image, spec.imagePullSecrets, and
spec.secretBackend.vault.defaultUserUpdaterImage has been moved from
reconcileOperatorDefaults into a mutating admission webhook. The webhook
sets a field only when it is unset, so any value the user provides is
preserved.

The reconciler no longer sends a full PUT on every loop to apply
defaults. It now only updates the cluster when ControlRabbitmqImage is
true, which is enforcement rather than defaulting and intentionally
keeps field ownership in that case. This fixes the SSA conflict
described in #2098, where the repeated PUT caused the manager field
manager to take ownership of all fields including resource quantities,
breaking subsequent helm upgrades.

The webhook runs in the same container as the operator, so
failurePolicy: Fail is safe and avoids the need for a fallback path in
the reconciler.

## Additional Context

The PROJECT file had its repo field set to
github.com/rabbitmq/cluster-operator while go.mod declares the module
as github.com/rabbitmq/cluster-operator/v2. This caused kubebuilder to
generate broken import paths when scaffolding the webhook. The fix was
confirmed with Zerpet before proceeding (see issue #2121).

Three issues were found and fixed while testing on a kind cluster:

- config/webhook/manifests.yaml was not generated by make manifests.
  Added a controller-gen webhook invocation to the Makefile.
- manager_webhook_patch.yaml used JSON Patch append on volumeMounts and
  volumes, which do not exist in manager.yaml. Changed to create them
  as new arrays.
- The webhook Service selector used kubebuilder default labels that do
  not match the operator pod. Fixed to use
  app.kubernetes.io/name: rabbitmq-cluster-operator.

## Local Testing

Tested on a kind cluster with cert-manager v1.15.1. Created a
RabbitmqCluster with spec: {} and confirmed spec.image was set to the
default by the webhook at admission time. Unit tests pass with
make just-unit-tests.