### PR TITLE
Add --rabbitmq-version flag to kubectl-rabbitmq create

### DIFF
--- a/kubectl-rabbitmq/cluster.go
+++ b/kubectl-rabbitmq/cluster.go
@@ -57,6 +57,8 @@ type clusterOptions struct {
 	DelayStartSeconds             int32
 	SkipPostDeploySteps           bool
 	AutoEnableAllFeatureFlags     bool
+
+	RabbitmqVersion string
 }
 
 // buildRabbitmqCluster constructs a RabbitmqCluster resource from the provided options
@@ -78,6 +80,15 @@ func buildRabbitmqCluster(name string, opts clusterOptions) (*v1beta1.RabbitmqCl
 	}
 	if opts.Image != "" {
 		cluster.Spec.Image = opts.Image
+	}
+	if opts.RabbitmqVersion != "" {
+		if cluster.Annotations == nil {
+			cluster.Annotations = make(map[string]string)
+		}
+		cluster.Annotations[v1beta1.RabbitmqVersionAnnotation] = opts.RabbitmqVersion
+		if opts.Image == "" {
+			cluster.Spec.Image = fmt.Sprintf("rabbitmq:%s-management", opts.RabbitmqVersion)
+		}
 	}
 	if len(opts.ImagePullSecrets) > 0 {
 		for _, secret := range opts.ImagePullSecrets {

--- a/kubectl-rabbitmq/cluster_test.go
+++ b/kubectl-rabbitmq/cluster_test.go
@@ -243,6 +243,31 @@ func TestBuildRabbitmqCluster(t *testing.T) {
 		assert.True(t, cluster.Spec.AutoEnableAllFeatureFlags)
 	})
 
+	t.Run("with rabbitmq-version and image NOT set", func(t *testing.T) {
+		t.Parallel()
+		opts := clusterOptions{
+			RabbitmqVersion: "4.2.4",
+		}
+		cluster, err := buildRabbitmqCluster("test-cluster", opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, "4.2.4", cluster.Annotations[v1beta1.RabbitmqVersionAnnotation])
+		assert.Equal(t, "rabbitmq:4.2.4-management", cluster.Spec.Image)
+	})
+
+	t.Run("with rabbitmq-version and image set", func(t *testing.T) {
+		t.Parallel()
+		opts := clusterOptions{
+			RabbitmqVersion: "4.2.4",
+			Image:           "my-custom-image:latest",
+		}
+		cluster, err := buildRabbitmqCluster("test-cluster", opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, "4.2.4", cluster.Annotations[v1beta1.RabbitmqVersionAnnotation])
+		assert.Equal(t, "my-custom-image:latest", cluster.Spec.Image)
+	})
+
 	t.Run("marshals to valid YAML", func(t *testing.T) {
 		t.Parallel()
 		opts := clusterOptions{

--- a/kubectl-rabbitmq/commands.go
+++ b/kubectl-rabbitmq/commands.go
@@ -65,6 +65,7 @@ func newCreateCmd(getExecutor func() *kubectlExecutor) *cobra.Command {
 	cmd.Flags().Int32Var(&opts.Replicas, "replicas", 1, "Number of replicas")
 	cmd.Flags().StringVar(&opts.Image, "image", "", "RabbitMQ image")
 	cmd.Flags().StringSliceVar(&opts.ImagePullSecrets, "image-pull-secret", []string{}, "Image pull secret (repeatable)")
+	cmd.Flags().StringVarP(&opts.RabbitmqVersion, "rabbitmq-version", "v", "", "RabbitMQ version to create (e.g. 4.2.4)")
 
 	// Service configuration
 	cmd.Flags().StringVar(&opts.ServiceType, "service", "ClusterIP", "Service type (ClusterIP, LoadBalancer, NodePort)")


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

Rescued this bit of functionality from #2147 

- Added `--rabbitmq-version` (and `-v` shorthand) flag to the `kubectl-rabbitmq create` command.
- If `--rabbitmq-version` is provided, the `rabbitmq.com/version` annotation is set on the `RabbitmqCluster`.
- If `--image` is not provided, the image is automatically templated as `rabbitmq:<version>-management`.
- Added unit tests to verify the new flag's behavior with and without the `--image` flag.

## Additional Context

This feature allows users to easily specify the RabbitMQ version when creating a cluster using the CLI, automatically setting the correct annotation and image unless an image is explicitly overridden.

## Local Testing

Unit tests passing locally.