### PR TITLE
Bump kind, k8s, and olm versions.

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -13,10 +13,11 @@ on:
     branches: [ "main" ]
 
 env:
-  # Taken from https://github.com/kubernetes-sigs/kind/releases/tag/v0.18.0
-  # The image here should be listed under 'Images built for this release' for the version of kind in go.mod
-  KIND_NODE_IMAGE: "kindest/node:v1.32.0"
-  KIND_OLDEST_NODE_IMAGE: "kindest/node:v1.29.12"
+  # Taken from https://github.com/kubernetes-sigs/kind/releases/tag/v0.31.0
+  # The image here should be listed under 'Images built for this release' for the version of kind in listed below
+  KIND_VERSION: "v0.31.0"
+  KIND_NODE_IMAGE: "kindest/node:v1.35.0"
+  KIND_OLDEST_NODE_IMAGE: "kindest/node:v1.31.14"
   BASELINE_UPGRADE_VERSION: v2.12.0
 
 jobs:
@@ -49,6 +50,7 @@ jobs:
     - name: Create KinD
       uses: helm/kind-action@v1
       with:
+        version: ${{ env.KIND_VERSION }}
         cluster_name: cluster-operator-testing
         node_image: ${{ env.KIND_NODE_IMAGE }}
 
@@ -287,6 +289,7 @@ jobs:
     - name: Create KinD
       uses: helm/kind-action@v1
       with:
+        version: ${{ env.KIND_VERSION }}
         cluster_name: system-testing
         node_image: ${{ env.KIND_NODE_IMAGE }}
 
@@ -357,6 +360,7 @@ jobs:
     - name: Create KinD
       uses: helm/kind-action@v1
       with:
+        version: ${{ env.KIND_VERSION }}
         cluster_name: system-testing-oldest-k8s
         node_image: ${{ env.KIND_OLDEST_NODE_IMAGE }}
 
@@ -443,6 +447,7 @@ jobs:
     - name: Create KinD
       uses: helm/kind-action@v1
       with:
+        version: ${{ env.KIND_VERSION }}
         cluster_name: examples-testing
         node_image: ${{ env.KIND_NODE_IMAGE }}
 
@@ -512,6 +517,7 @@ jobs:
     - name: Create KinD
       uses: helm/kind-action@v1
       with:
+        version: ${{ env.KIND_VERSION }}
         cluster_name: upgrade-testing
         node_image: ${{ env.KIND_NODE_IMAGE }}
 

--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -125,6 +125,8 @@ jobs:
 
       - name: Kind Cluster
         uses: helm/kind-action@v1
+        with:
+          version: v0.31.0
 
       - name: Install OLM
         run: |
@@ -188,14 +190,14 @@ jobs:
           git config user.email ${{ secrets.RABBITMQ_CI_EMAIL }}
           git branch "rabbitmq-cluster-operator-$BUNDLE_VERSION"
           git checkout "rabbitmq-cluster-operator-$BUNDLE_VERSION"
-          
+
           mkdir -pv operators/rabbitmq-cluster-operator/"$BUNDLE_VERSION"
           rm -v -f olm-package-ci/release-config.yaml
           cp -v -fR olm-package-ci/* ./operators/rabbitmq-cluster-operator/"$BUNDLE_VERSION"/
           git add operators/rabbitmq-cluster-operator
           git commit -s -m "operator rabbitmq-cluster-operator release $BUNDLE_VERSION"
           git push --set-upstream origin "rabbitmq-cluster-operator-$BUNDLE_VERSION"
-          
+
           gh pr create --title "operator rabbitmq-cluster-operator (${{ env.BUNDLE_VERSION }})" \
             --body "Update operator rabbitmq-cluster-operator (${{ needs.test-olm-package.outputs.olm_package_version }})" \
             --repo k8s-operatorhub/community-operators
@@ -240,7 +242,7 @@ jobs:
           git config user.email ${{ secrets.RABBITMQ_CI_EMAIL }}
           git branch "rabbitmq-cluster-operator-$BUNDLE_VERSION"
           git checkout "rabbitmq-cluster-operator-$BUNDLE_VERSION"
-          
+
           mkdir -pv operators/rabbitmq-cluster-operator/"$BUNDLE_VERSION"
           rm -v -f olm-package-ci/bundle.Dockerfile
           cp -v -fR olm-package-ci/* ./operators/rabbitmq-cluster-operator/"$BUNDLE_VERSION"/

--- a/olm/values-release.yaml
+++ b/olm/values-release.yaml
@@ -1,3 +1,3 @@
 ---
 #! See https://access.redhat.com/support/policy/updates/openshift#dates for the list of supported OpenShift versions
-supported_openshift_versions: ["v4.17", "v4.18", "v4.19", "v4.20"]
+supported_openshift_versions: ["v4.18", "v4.19", "v4.20", "v4.21", "v4.22"]


### PR DESCRIPTION
Currently supported VKS versions include k8s up to v1.35
Currently supported OLM versions include 4.18 - 4.22, corresponding to k8s v1.31+
Kind v0.31.0 includes pre-built k8s v1.31 - v1.35