### PR TITLE
Pass CA to openssl to fix TLS example test.

### DIFF
--- a/docs/examples/tls/test.sh
+++ b/docs/examples/tls/test.sh
@@ -1,5 +1,19 @@
+#!/bin/bash
+set -euxo pipefail
 
-set -e
-kubectl exec -it tls-server-0 -c rabbitmq -- openssl s_client -connect tls-nodes.examples.svc.cluster.local:5671 </dev/null
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# shellcheck source=../../../scripts/with_retry.sh
+source "$SCRIPT_DIR/../../../scripts/with_retry.sh"
 
-kubectl exec -it tls-server-0 -c rabbitmq -- openssl s_client -connect tls-nodes.examples.svc.cluster.local:15671 </dev/null
+assertTLS() {
+  kubectl exec tls-server-0 -c rabbitmq -- openssl s_client \
+      -connect "$1" \
+      -CAfile /etc/rabbitmq-tls/ca.crt \
+      -verify_return_error \
+      </dev/null
+}
+
+RABBITMQ_NAMESPACE=${RABBITMQ_NAMESPACE:-'examples'}
+
+with_retry 'assertTLS "tls.$RABBITMQ_NAMESPACE.svc.cluster.local:5671"'
+with_retry 'assertTLS "tls.$RABBITMQ_NAMESPACE.svc.cluster.local:15671"'


### PR DESCRIPTION
Previously we used openssl 1.2 in CI, which silently swallowed certificate validation errors. With the CI base image update we updated to openssl 1.3, which validates the CA, thus requiring the CA to be explicitly passed when using a self-signed certificate as in the documented example.

[ai-assisted=yes]