### PR TITLE
feat: integrate mutating webhook into OLM package

### DIFF
--- a/olm.mk
+++ b/olm.mk
@@ -42,7 +42,7 @@ deployment: ## Extract deployment spec. Customise using QUAY_IO_OPERATOR_IMAGE
 			--data-value operator_image=$(QUAY_IO_OPERATOR_IMAGE) \
 			-f olm/templates/cluster-operator-namespace-scope-overlay.yml \
 		> tmp/cluster-operator.yml
-	yq '{"spec": .spec}' tmp/cluster-operator.yml > tmp/spec.yaml
+	yq 'select(.kind == "Deployment") | {"spec": .spec}' tmp/cluster-operator.yml > tmp/spec.yaml
 
 BUNDLE_CREATED_AT ?= $(shell date +'%Y-%m-%dT%H:%M:%S')
 BUNDLE_VERSION ?= 0.0.0

--- a/olm.mk
+++ b/olm.mk
@@ -108,17 +108,50 @@ catalog-push: ## Push catalog image. Customise using REGISTRY and CATALOG_IMAGE
 
 catalog-deploy: ## Deploy a catalog source to an existing k8s
 	kubectl apply -f $(CURDIR)/olm/assets/operator-group.yaml
-	ytt -f $(CURDIR)/olm/assets/catalog-source.yaml --data-value image="$(REGISTRY)/$(CATALOG_IMAGE)" | kubectl apply -f-
+	ytt -f $(CURDIR)/olm/assets/catalog-source.yaml \
+		-f $(CURDIR)/olm/assets/catalog-source-overlay.yml \
+		--data-value image="$(REGISTRY)/$(CATALOG_IMAGE)" \
+		--data-value secret_name="$(DOCKER_REGISTRY_SECRET)" | kubectl apply -f-
 	kubectl apply -f $(CURDIR)/olm/assets/subscription.yaml
 
 catalog-undeploy: ## Delete all catalog assets from k8s
 	kubectl delete -f $(CURDIR)/olm/assets/subscription.yaml --ignore-not-found
 	kubectl delete -f $(CURDIR)/olm/manifests/ --ignore-not-found
 	kubectl delete -f $(CURDIR)/olm/assets/operator-group.yaml --ignore-not-found
-	ytt -f $(CURDIR)/olm/assets/catalog-source.yaml --data-value image="$(REGISTRY)/$(CATALOG_IMAGE)" | kubectl delete -f- --ignore-not-found
+	ytt -f $(CURDIR)/olm/assets/catalog-source.yaml \
+		-f $(CURDIR)/olm/assets/catalog-source-overlay.yml \
+		--data-value image="$(REGISTRY)/$(CATALOG_IMAGE)" \
+		--data-value secret_name="$(DOCKER_REGISTRY_SECRET)" | kubectl delete -f- --ignore-not-found
 
 catalog-clean: ## Delete manifest files for catalog
 	rm -v -f $(CURDIR)/olm/catalog/*.y*ml
+
+.PHONY: catalog-pull-secret
+catalog-pull-secret: ## Create a docker registry secret and export it to ns-1 namespace
+	kubectl create namespace secrets --dry-run=client -o yaml | kubectl apply -f -
+	kubectl create namespace ns-1 --dry-run=client -o yaml | kubectl apply -f -
+	kubectl create secret docker-registry $(DOCKER_REGISTRY_SECRET) \
+		--docker-server=$(DOCKER_REGISTRY_SERVER) \
+		--docker-username=$(DOCKER_REGISTRY_USERNAME) \
+		--docker-password=$(DOCKER_REGISTRY_PASSWORD) \
+		--namespace secrets \
+		--dry-run=client -o yaml | kubectl apply -f -
+	echo "apiVersion: secretgen.carvel.dev/v1alpha1" > tmp/secret-export.yaml
+	echo "kind: SecretExport" >> tmp/secret-export.yaml
+	echo "metadata:" >> tmp/secret-export.yaml
+	echo "  name: $(DOCKER_REGISTRY_SECRET)" >> tmp/secret-export.yaml
+	echo "  namespace: secrets" >> tmp/secret-export.yaml
+	echo "spec:" >> tmp/secret-export.yaml
+	echo "  toNamespace: ns-1" >> tmp/secret-export.yaml
+	echo "---" >> tmp/secret-export.yaml
+	echo "apiVersion: secretgen.carvel.dev/v1alpha1" >> tmp/secret-export.yaml
+	echo "kind: SecretImport" >> tmp/secret-export.yaml
+	echo "metadata:" >> tmp/secret-export.yaml
+	echo "  name: $(DOCKER_REGISTRY_SECRET)" >> tmp/secret-export.yaml
+	echo "  namespace: ns-1" >> tmp/secret-export.yaml
+	echo "spec:" >> tmp/secret-export.yaml
+	echo "  fromNamespace: secrets" >> tmp/secret-export.yaml
+	kubectl apply -f tmp/secret-export.yaml
 
 catalog-all::catalog-replace-bundle
 catalog-all::catalog-build

--- a/olm/assets/catalog-source-overlay.yml
+++ b/olm/assets/catalog-source-overlay.yml
@@ -1,0 +1,11 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@ if getattr(data.values, "secret_name", "") != "":
+#@overlay/match by=overlay.subset({"kind": "CatalogSource"})
+---
+spec:
+  #@overlay/match missing_ok=True
+  secrets:
+    - #@ data.values.secret_name
+#@ end

--- a/olm/templates/cluster-operator-namespace-scope-overlay.yml
+++ b/olm/templates/cluster-operator-namespace-scope-overlay.yml
@@ -7,6 +7,11 @@
 spec:
   template:
     spec:
+      #@overlay/match missing_ok=True
+      volumes:
+      #@overlay/match by=overlay.subset({"name": "webhook-certs"}),expects="0+"
+      #@overlay/remove
+      -
       containers:
       #@overlay/match by=overlay.subset({"name": "operator"}),expects="1+"
       -
@@ -16,3 +21,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['olm.targetNamespaces']
+        #! Required to remove the webhook-certs volume mount
+        #! because upstream operator has it, and OLM handles
+        #! the volume mounts
+        #@overlay/match missing_ok=True
+        volumeMounts:
+        #@overlay/match by=overlay.subset({"name": "webhook-certs"}),expects="0+"
+        #@overlay/remove
+        -

--- a/olm/templates/cluster-operator-namespace-scope-overlay.yml
+++ b/olm/templates/cluster-operator-namespace-scope-overlay.yml
@@ -9,7 +9,7 @@ spec:
     spec:
       #@overlay/match missing_ok=True
       volumes:
-      #@overlay/match by=overlay.subset({"name": "webhook-certs"}),expects="0+"
+      #@overlay/match by=overlay.subset({"name": "cluster-operator-webhook-certs"}),expects="0+"
       #@overlay/remove
       -
       containers:
@@ -26,6 +26,6 @@ spec:
         #! the volume mounts
         #@overlay/match missing_ok=True
         volumeMounts:
-        #@overlay/match by=overlay.subset({"name": "webhook-certs"}),expects="0+"
+        #@overlay/match by=overlay.subset({"name": "cluster-operator-webhook-certs"}),expects="0+"
         #@overlay/remove
         -

--- a/olm/templates/cluster-service-version-generator-openshift.yml
+++ b/olm/templates/cluster-service-version-generator-openshift.yml
@@ -172,3 +172,25 @@ spec:
       supported: true
     - type: AllNamespaces
       supported: true
+
+  webhookdefinitions:
+    - type: MutatingAdmissionWebhook
+      admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      targetPort: 9443
+      deploymentName: rabbitmq-cluster-operator
+      failurePolicy: Fail
+      generateName: mrabbitmqcluster-v1beta1.kb.io
+      rules:
+        - apiGroups:
+            - rabbitmq.com
+          apiVersions:
+            - v1beta1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - rabbitmqclusters
+      sideEffects: None
+      webhookPath: /mutate-rabbitmq-com-v1beta1-rabbitmqcluster

--- a/scripts/test-olm-e2e.sh
+++ b/scripts/test-olm-e2e.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Loading environment variables..."
+source .envrc
+
+export REGISTRY="${DOCKER_REGISTRY_SERVER}"
+export OPERATOR_IMG="${REGISTRY}/${DOCKER_REGISTRY_USERNAME}/cluster-operator:latest"
+export BUNDLE_IMG_NAME="${DOCKER_REGISTRY_USERNAME}/cluster-operator-bundle:latest"
+export CATALOG_IMG_NAME="${DOCKER_REGISTRY_USERNAME}/cluster-operator-catalog:latest"
+
+echo "==> Building and pushing Operator image..."
+make docker-build docker-push IMG="${OPERATOR_IMG}"
+
+echo "==> Generating OLM manifests..."
+make -f olm.mk all QUAY_IO_OPERATOR_IMAGE="${OPERATOR_IMG}" BUNDLE_REPLACES="rabbitmq-cluster-operator.v0.0.0"
+
+echo "==> Building and pushing bundle image..."
+make -f olm.mk docker-build docker-push REGISTRY="${REGISTRY}" IMAGE="${BUNDLE_IMG_NAME}"
+
+echo "==> Generating catalog manifests..."
+make -f olm.mk catalog-replace-bundle REGISTRY="${REGISTRY}" IMAGE="${BUNDLE_IMG_NAME}"
+
+echo "==> Building and pushing catalog image..."
+make -f olm.mk catalog-build catalog-push REGISTRY="${REGISTRY}" CATALOG_IMAGE="${CATALOG_IMG_NAME}"
+
+echo "==> Setting up pull secrets..."
+make -f olm.mk catalog-pull-secret
+
+echo "==> Patching service accounts in ns-1 to use the image pull secret..."
+# The operator pod will need this secret to pull the operator image
+kubectl patch serviceaccount default -n ns-1 -p "{\"imagePullSecrets\": [{\"name\": \"${DOCKER_REGISTRY_SECRET}\"}]}" || true
+
+echo "==> Deploying catalog and subscription..."
+make -f olm.mk catalog-deploy REGISTRY="${REGISTRY}" CATALOG_IMAGE="${CATALOG_IMG_NAME}"
+
+echo "==> Waiting for CatalogSource pod to be created..."
+retries=30
+while [[ $retries -gt 0 ]]; do
+    POD_NAME=$(kubectl get pod -l olm.catalogSource=cool-catalog -n ns-1 --field-selector=status.phase!=Terminating -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+    if [[ -n "$POD_NAME" ]]; then
+        echo "Found CatalogSource pod: $POD_NAME"
+        break
+    fi
+    echo "Waiting for CatalogSource pod..."
+    sleep 5
+    retries=$((retries - 1))
+done
+
+echo "==> Waiting for CatalogSource pod to be ready..."
+kubectl wait --for=condition=ready pod -l olm.catalogSource=cool-catalog -n ns-1 --timeout=120s || {
+    echo "CatalogSource pod failed to become ready. Fetching logs..."
+    kubectl get pods -n ns-1
+    kubectl describe catalogsource cool-catalog -n ns-1
+    exit 1
+}
+
+echo "==> Waiting for Subscription to generate CSV..."
+retries=30
+CSV_NAME=""
+while [[ $retries -gt 0 ]]; do
+    CSV_NAME=$(kubectl get sub rabbitmq-cluster-operator -n ns-1 -o jsonpath='{.status.installedCSV}' 2>/dev/null || echo "")
+    if [[ -n "$CSV_NAME" ]]; then
+        echo "Found CSV: $CSV_NAME"
+        break
+    fi
+    echo "Waiting for CSV to be created..."
+    sleep 5
+    retries=$((retries - 1))
+done
+
+if [[ -z "$CSV_NAME" ]]; then
+    echo "Timed out waiting for Subscription to create CSV."
+    kubectl get sub rabbitmq-cluster-operator -n ns-1 -o yaml
+    exit 1
+fi
+
+echo "==> Patching ServiceAccount created by OLM..."
+# OLM overwrites the SA, so we patch it after CSV creation
+kubectl patch serviceaccount rabbitmq-cluster-operator -n ns-1 -p "{\"imagePullSecrets\": [{\"name\": \"${DOCKER_REGISTRY_SECRET}\"}]}" || true
+# Delete the failing pod so it gets recreated with the new SA credentials
+kubectl delete pod -l app.kubernetes.io/name=rabbitmq-cluster-operator -n ns-1 || true
+
+echo "==> Waiting for CSV to succeed..."
+kubectl wait --for=condition=Succeeded csv/"$CSV_NAME" -n ns-1 --timeout=120s || {
+    echo "CSV failed to succeed."
+    kubectl get csv/"$CSV_NAME" -n ns-1 -o yaml
+    kubectl get pods -n ns-1
+    exit 1
+}
+
+echo "==> Verifying Operator Pods..."
+kubectl get pods -n ns-1
+
+echo "==> E2E Test Completed Successfully!"


### PR DESCRIPTION
## Summary
- Extract deployment spec using correct yq filter in olm.mk
- Remove webhook-certs volume and volumeMounts in OLM overlay
- Add webhookdefinitions to ClusterServiceVersion template

## Test plan
- Validated locally by generating the OLM bundle and deploying it to a local k3s cluster.
- Verified that the `RabbitmqCluster` custom resource is successfully mutated by the webhook when deployed via OLM.


Made with [Cursor](https://cursor.com)