### PR TITLE
Rename webhook resources with cluster-operator- prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ docker-build-dev:
 .PHONY: wait-for-webhook
 wait-for-webhook: ## Wait for the mutating webhook CA bundle to be injected
 	@echo "Waiting for the mutating webhook CA bundle to be injected..."
-	@timeout 120s bash -c 'until $(KUBECTL) get mutatingwebhookconfigurations.admissionregistration.k8s.io mutating-webhook-configuration -o jsonpath="{.webhooks[0].clientConfig.caBundle}" 2>/dev/null | grep -q "[a-zA-Z0-9]"; do sleep 2; done' || (echo "Timeout waiting for CA bundle injection" && exit 1)
+	@timeout 120s bash -c 'until $(KUBECTL) get mutatingwebhookconfigurations.admissionregistration.k8s.io cluster-operator-mutating-webhook-configuration -o jsonpath="{.webhooks[0].clientConfig.caBundle}" 2>/dev/null | grep -q "[a-zA-Z0-9]"; do sleep 2; done' || (echo "Timeout waiting for CA bundle injection" && exit 1)
 	@echo "Waiting for the webhook service to be reachable..."
 	@timeout 120s bash -c 'until out=$$($(KUBECTL) create --dry-run=server -f config/samples/rabbitmq_v1beta1_rabbitmqcluster.yaml 2>&1); do if echo "$$out" | grep -q "connection refused"; then sleep 2; else break; fi; done' || (echo "Timeout waiting for webhook service" && exit 1)
 

--- a/config/certmanager/certificate-webhook.yaml
+++ b/config/certmanager/certificate-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cluster-operator
     app.kubernetes.io/managed-by: kustomize
-  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  name: cluster-operator-serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
   # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
@@ -17,4 +17,4 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: webhook-server-cert
+  secretName: cluster-operator-webhook-server-cert

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -113,14 +113,14 @@ replacements:
  - source: # Uncomment the following block if you have any webhook
      kind: Service
      version: v1
-     name: webhook-service
+     name: cluster-operator-webhook-service
      fieldPath: .metadata.name # Name of the service
    targets:
      - select:
          kind: Certificate
          group: cert-manager.io
          version: v1
-         name: serving-cert
+         name: cluster-operator-serving-cert
        fieldPaths:
          - .spec.dnsNames.0
          - .spec.dnsNames.1
@@ -131,14 +131,14 @@ replacements:
  - source:
      kind: Service
      version: v1
-     name: webhook-service
+     name: cluster-operator-webhook-service
      fieldPath: .metadata.namespace # Namespace of the service
    targets:
      - select:
          kind: Certificate
          group: cert-manager.io
          version: v1
-         name: serving-cert
+         name: cluster-operator-serving-cert
        fieldPaths:
          - .spec.dnsNames.0
          - .spec.dnsNames.1
@@ -151,7 +151,7 @@ replacements:
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
-#     name: serving-cert # This name should match the one in certificate.yaml
+#     name: cluster-operator-serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.namespace # Namespace of the certificate CR
 #   targets:
 #     - select:
@@ -166,7 +166,7 @@ replacements:
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
-#     name: serving-cert
+#     name: cluster-operator-serving-cert
 #     fieldPath: .metadata.name
 #   targets:
 #     - select:
@@ -182,7 +182,7 @@ replacements:
      kind: Certificate
      group: cert-manager.io
      version: v1
-     name: serving-cert
+     name: cluster-operator-serving-cert
      fieldPath: .metadata.namespace # Namespace of the certificate CR
    targets:
      - select:
@@ -197,7 +197,7 @@ replacements:
      kind: Certificate
      group: cert-manager.io
      version: v1
-     name: serving-cert
+     name: cluster-operator-serving-cert
      fieldPath: .metadata.name
    targets:
      - select:
@@ -213,7 +213,7 @@ replacements:
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
-#     name: serving-cert
+#     name: cluster-operator-serving-cert
 #     fieldPath: .metadata.namespace # Namespace of the certificate CR
 #   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
 # +kubebuilder:scaffold:crdkustomizecainjectionns
@@ -221,7 +221,7 @@ replacements:
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
-#     name: serving-cert
+#     name: cluster-operator-serving-cert
 #     fieldPath: .metadata.name
 #   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
 # +kubebuilder:scaffold:crdkustomizecainjectionname

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -2,7 +2,7 @@
   path: /spec/template/spec/containers/0/volumeMounts
   value:
   - mountPath: /tmp/k8s-webhook-server/serving-certs
-    name: webhook-certs
+    name: cluster-operator-webhook-certs
     readOnly: true
 
 - op: add
@@ -15,6 +15,6 @@
 - op: add
   path: /spec/template/spec/volumes
   value:
-  - name: webhook-certs
+  - name: cluster-operator-webhook-certs
     secret:
-      secretName: webhook-server-cert
+      secretName: cluster-operator-webhook-server-cert

--- a/config/installation/kustomization.yaml
+++ b/config/installation/kustomization.yaml
@@ -32,14 +32,14 @@ replacements:
 - source:
     kind: Service
     version: v1
-    name: webhook-service
+    name: cluster-operator-webhook-service
     fieldPath: .metadata.name
   targets:
   - select:
       kind: Certificate
       group: cert-manager.io
       version: v1
-      name: serving-cert
+      name: cluster-operator-serving-cert
     fieldPaths:
     - .spec.dnsNames.0
     - .spec.dnsNames.1
@@ -50,14 +50,14 @@ replacements:
 - source:
     kind: Service
     version: v1
-    name: webhook-service
+    name: cluster-operator-webhook-service
     fieldPath: .metadata.namespace
   targets:
   - select:
       kind: Certificate
       group: cert-manager.io
       version: v1
-      name: serving-cert
+      name: cluster-operator-serving-cert
     fieldPaths:
     - .spec.dnsNames.0
     - .spec.dnsNames.1
@@ -69,7 +69,7 @@ replacements:
     kind: Certificate
     group: cert-manager.io
     version: v1
-    name: serving-cert
+    name: cluster-operator-serving-cert
     fieldPath: .metadata.namespace
   targets:
   - select:
@@ -84,7 +84,7 @@ replacements:
     kind: Certificate
     group: cert-manager.io
     version: v1
-    name: serving-cert
+    name: cluster-operator-serving-cert
     fieldPath: .metadata.name
   targets:
   - select:

--- a/config/installation/manager_webhook_patch.yaml
+++ b/config/installation/manager_webhook_patch.yaml
@@ -2,7 +2,7 @@
   path: /spec/template/spec/containers/0/volumeMounts
   value:
   - mountPath: /tmp/k8s-webhook-server/serving-certs
-    name: webhook-certs
+    name: cluster-operator-webhook-certs
     readOnly: true
 
 - op: add
@@ -15,6 +15,6 @@
 - op: add
   path: /spec/template/spec/volumes
   value:
-  - name: webhook-certs
+  - name: cluster-operator-webhook-certs
     secret:
-      secretName: webhook-server-cert
+      secretName: cluster-operator-webhook-server-cert

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
 - manifests.yaml
 - service.yaml
+
+namePrefix: cluster-operator-

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -219,7 +219,7 @@ var _ = Describe("Manager", Ordered, func() {
 			By("waiting for the webhook service endpoints to be ready")
 			verifyWebhookEndpointsReady := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "endpointslices.discovery.k8s.io", "-n", namespace,
-					"-l", "kubernetes.io/service-name=webhook-service",
+					"-l", "kubernetes.io/service-name=cluster-operator-webhook-service",
 					"-o", "jsonpath={range .items[*]}{range .endpoints[*]}{.addresses[*]}{end}{end}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "Webhook endpoints should exist")
@@ -230,7 +230,7 @@ var _ = Describe("Manager", Ordered, func() {
 			By("verifying the mutating webhook server is ready")
 			verifyMutatingWebhookReady := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "mutatingwebhookconfigurations.admissionregistration.k8s.io",
-					"mutating-webhook-configuration",
+					"cluster-operator-mutating-webhook-configuration",
 					"-o", "jsonpath={.webhooks[0].clientConfig.caBundle}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "MutatingWebhookConfiguration should exist")
@@ -295,7 +295,7 @@ var _ = Describe("Manager", Ordered, func() {
 		It("should provisioned cert-manager", func() {
 			By("validating that cert-manager has the certificate Secret")
 			verifyCertManager := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "secrets", "webhook-server-cert", "-n", namespace)
+				cmd := exec.Command("kubectl", "get", "secrets", "cluster-operator-webhook-server-cert", "-n", namespace)
 				_, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 			}
@@ -307,7 +307,7 @@ var _ = Describe("Manager", Ordered, func() {
 			verifyCAInjection := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get",
 					"mutatingwebhookconfigurations.admissionregistration.k8s.io",
-					"mutating-webhook-configuration",
+					"cluster-operator-mutating-webhook-configuration",
 					"-o", "go-template={{ range .webhooks }}{{ .clientConfig.caBundle }}{{ end }}")
 				mwhOutput, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())

--- a/test/system/system_suite_test.go
+++ b/test/system/system_suite_test.go
@@ -103,7 +103,7 @@ var _ = SynchronizedBeforeSuite(
 
 		// Wait for the mutating webhook CA bundle to be injected by cert-manager
 		Eventually(func() string {
-			mwc, err := clientSet.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, "mutating-webhook-configuration", metav1.GetOptions{})
+			mwc, err := clientSet.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, "cluster-operator-mutating-webhook-configuration", metav1.GetOptions{})
 			if err != nil || len(mwc.Webhooks) == 0 {
 				return ""
 			}


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

The webhook was using the bootstrapped names e.g. "webhook-service", "webhook-server-cert", "mutating-webhook-configuration", etc. Those names could collide with other operators if installed in the same namespace.

- Adds `cluster-operator-` prefix to all webhook related resources.
- Updates Kustomize overrides and patches in `config/default`, `config/installation` and `config/webhook/kustomization.yaml` using `namePrefix` to avoid modifying the files regenerated by `make manifests`.
- Fixes system tests and Makefile wait steps to reference the correct new mutating webhook name.

## Additional Context

Used Kustomize `namePrefix` inside `config/webhook/kustomization.yaml` to ensure kubebuilder's generated `manifests.yaml` file doesn't get overridden by local renames, ensuring robust regeneration.

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
```

Made with [Cursor](https://cursor.com)