### PR TITLE
feat(olm): add ValidatingAdmissionWebhook to CSV template

### DIFF
--- a/olm/templates/cluster-service-version-generator-openshift.yml
+++ b/olm/templates/cluster-service-version-generator-openshift.yml
@@ -194,3 +194,23 @@ spec:
             - rabbitmqclusters
       sideEffects: None
       webhookPath: /mutate-rabbitmq-com-v1beta1-rabbitmqcluster
+    - type: ValidatingAdmissionWebhook
+      admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      targetPort: 9443
+      deploymentName: rabbitmq-cluster-operator
+      failurePolicy: Fail
+      generateName: vrabbitmqcluster-v1beta1.kb.io
+      rules:
+        - apiGroups:
+            - rabbitmq.com
+          apiVersions:
+            - v1beta1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - rabbitmqclusters
+      sideEffects: None
+      webhookPath: /validate-rabbitmq-com-v1beta1-rabbitmqcluster


### PR DESCRIPTION
## Summary Of Changes

Add validating webhook to OLM package.

## Additional Context

OLM reads webhookdefinitions from the CSV and injects certs automatically, so no separate WebhookConfiguration manifest is needed.