### PR TITLE
Bump default RabbitMQ image tag to 4.3.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Envtest binaries are downloaded to `testbin/`. If asset setup fails: `make clean
 |-----|---------|---------|
 | `OPERATOR_NAMESPACE` | (required) | Namespace where operator runs |
 | `OPERATOR_SCOPE_NAMESPACE` | (all) | Comma-separated namespaces to watch |
-| `DEFAULT_RABBITMQ_IMAGE` | `rabbitmq:4.2.6-management` | Default RabbitMQ image |
+| `DEFAULT_RABBITMQ_IMAGE` | `rabbitmq:4.3.4-management` | Default RabbitMQ image |
 | `DISABLE_DEPRECATED_FEATURES_CHECK` | enabled | Set to disable deprecation checks |
 | `ENABLE_DEBUG_PPROF` | false | Enable pprof endpoints |
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ under `site/kubernetes`.
 
 ## Supported Versions
 
-The operator deploys RabbitMQ `4.2.6` by default, and should work with [any supported RabbitMQ version](https://www.rabbitmq.com/release-information) and [Kubernetes version](https://kubernetes.io/releases/).
+The operator deploys RabbitMQ `4.3.4` by default, and should work with [any supported RabbitMQ version](https://www.rabbitmq.com/release-information) and [Kubernetes version](https://kubernetes.io/releases/).
 
 ## Versioning
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,7 +73,7 @@ func main() {
 		probeAddr               string
 		secureMetrics           bool
 		enableHTTP2             bool
-		defaultRabbitmqImage    = "rabbitmq:4.2.6-management"
+		defaultRabbitmqImage    = "rabbitmq:4.3.4-management"
 		controlRabbitmqImage    = false
 		defaultUserUpdaterImage = "ghcr.io/rabbitmq/default-user-credential-updater:1.0.14"
 		defaultImagePullSecrets = ""


### PR DESCRIPTION
Latest and greatest RabbitMQ version.

Edit: holding merge until 4.2 goes out of community support