### PR TITLE
Sync OperatorHub/RH marketplace forks before opening release PRs

### DIFF
--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -22,6 +22,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  sync-operatorhub-fork:
+    name: Sync OperatorHub fork with upstream
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'release' || inputs.release == true }}
+    steps:
+      - name: Sync rabbitmq/community-operators main with upstream
+        env:
+          GH_TOKEN: ${{ secrets.RABBITMQ_CI_TOKEN }}
+        run: gh repo sync rabbitmq/community-operators --branch main
+
+  sync-redhat-marketplace-fork:
+    name: Sync Openshift Ecosystem fork with upstream
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'release' || inputs.release == true }}
+    steps:
+      - name: Sync rabbitmq/community-operators-prod main with upstream
+        env:
+          GH_TOKEN: ${{ secrets.RABBITMQ_CI_TOKEN }}
+        run: gh repo sync rabbitmq/community-operators-prod --branch main
+
   create-olm-package:
     name: Create the OLM Packaging
     runs-on: ubuntu-latest
@@ -163,7 +183,7 @@ jobs:
     if: ${{ github.event_name == 'release' || inputs.release == true }}
     name: PR OperatorHub repo
     runs-on: ubuntu-latest
-    needs: test-olm-package
+    needs: [test-olm-package, sync-operatorhub-fork]
     steps:
       - name: Checkout community-operators fork (OperatorHub)
         uses: actions/checkout@v7
@@ -205,7 +225,7 @@ jobs:
   publish-bundle-redhat-marketplace:
     name: PR Openshift marketplace
     runs-on: ubuntu-latest
-    needs: test-olm-package
+    needs: [test-olm-package, sync-redhat-marketplace-fork]
     if: ${{ github.event_name == 'release' || inputs.release == true }}
     steps:
       - name: Checkout community-operators-prod fork (Openshift Ecosystem)


### PR DESCRIPTION
## Summary
- `rabbitmq/community-operators` and `rabbitmq/community-operators-prod` (our forks used to open release PRs to OperatorHub and RH Marketplace) drift behind their upstreams, so the release branch created in `publish-bundle-operatorhub` / `publish-bundle-redhat-marketplace` forks off a stale commit, and the resulting PR fails the upstream "branch is up to date with base" check.
- Add two new jobs, `sync-operatorhub-fork` and `sync-redhat-marketplace-fork`, that fast-forward each fork's `main` to its upstream parent via `gh repo sync`. They run with no `needs:`, so they execute in parallel with `create-olm-package` instead of adding sequential latency.
- `publish-bundle-operatorhub` and `publish-bundle-redhat-marketplace` now also depend on their matching sync job, so by the time they check out the fork and branch off it, `main` is guaranteed to be up to date.
- No changes to `olm.mk` — this is a repo-level fork-sync concern, unrelated to the bundle/manifest build.

## Test plan
- [ ] Run the workflow via `gh workflow run olm.yml -f bundle_version=<test-version> -f release=true` (or wait for a real release) and confirm `sync-operatorhub-fork`/`sync-redhat-marketplace-fork` run concurrently with `create-olm-package`/`test-olm-package`.
- [ ] Confirm the resulting PRs opened against `k8s-operatorhub/community-operators` and `redhat-openshift-ecosystem/community-operators-prod` no longer fail the "out of date with base branch" check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)