### PR TITLE
Fix release-config.yaml to stop inventing catalog templates per OCP version

### DIFF
--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -257,6 +257,12 @@ jobs:
         # https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_autorelease/
         #
         # The script removed the bundle.Dockerfile file because it is not needed for the FBC workflow.
+        #
+        # NOTE: enabling support for a new OpenShift minor version that reuses an existing catalog
+        # template is NOT done here. It requires a separate, manual PR against the fork's
+        # operators/rabbitmq-cluster-operator/ci.yaml, adding the new version to the relevant
+        # `fbc.catalog_mapping[].catalog_names` entry. See olm/values-release.yaml and
+        # https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/operator-ci-yaml/
         run: |
           git config user.name "rabbitmq-ci"
           git config user.email ${{ secrets.RABBITMQ_CI_EMAIL }}

--- a/olm/templates/release-config-template.yaml
+++ b/olm/templates/release-config-template.yaml
@@ -3,7 +3,7 @@
 
 ---
 catalog_templates:
-#@ for version in data.values.supported_openshift_versions:
+#@ for version in data.values.catalog_template_names:
   - template_name: #@ version + ".yaml"
     channels: [stable]
     #@ replaces = data.values.replaces

--- a/olm/values-release.yaml
+++ b/olm/values-release.yaml
@@ -1,3 +1,8 @@
 ---
-#! See https://access.redhat.com/support/policy/updates/openshift#dates for the list of supported OpenShift versions
-supported_openshift_versions: ["v4.18", "v4.19", "v4.20", "v4.21", "v4.22"]
+#! Must mirror the `template_name` entries under `fbc.catalog_mapping` in the RH fork's
+#! operators/rabbitmq-cluster-operator/ci.yaml — NOT the full list of OCP versions we support.
+#! Adding support for a new OCP minor that reuses an existing template (the common case) is done
+#! by editing `catalog_names` on that template's entry in the fork's ci.yaml directly — no change
+#! needed here. Only add a new entry here (and a matching new template + catalog_mapping entry in
+#! the fork) when a genuinely new/incompatible catalog template must be introduced.
+catalog_template_names: ["v4.18", "v4.19", "v4.20"]

--- a/olm/values.example.yaml
+++ b/olm/values.example.yaml
@@ -4,5 +4,10 @@ createdAt: '2025-05-02T09:11:31'
 image: quay.io/rabbitmqoperator/cluster-operator:2.14.0
 version: 2.14.0
 replaces: rabbitmq-cluster-operator.v2.13.0
-#! See https://access.redhat.com/support/policy/updates/openshift#dates for the list of supported OpenShift versions
-supported_openshift_versions: ["4.17", "4.18", "4.19"]
+#! Must mirror the `template_name` entries under `fbc.catalog_mapping` in the RH fork's
+#! operators/rabbitmq-cluster-operator/ci.yaml — NOT the full list of OCP versions we support.
+#! Adding support for a new OCP minor that reuses an existing template (the common case) is done
+#! by editing `catalog_names` on that template's entry in the fork's ci.yaml directly — no change
+#! needed here. Only add a new entry here (and a matching new template + catalog_mapping entry in
+#! the fork) when a genuinely new/incompatible catalog template must be introduced.
+catalog_template_names: ["v4.17", "v4.18"]


### PR DESCRIPTION
## Summary
- `olm/values-release.yaml`'s `supported_openshift_versions` list has drifted to enumerate every OCP minor RH still supports (`v4.18`-`v4.22`), so the generated `release-config.yaml` fabricated `template_name: v4.21.yaml` / `v4.22.yaml` entries that don't exist as real catalog template files in the RH fork (`community-operators-prod`'s `operators/rabbitmq-cluster-operator/ci.yaml`). That fork only defines 3 templates (`v4.18.yaml`, `v4.19.yaml`, `v4.20.yaml`), with `v4.20.yaml` covering `v4.20`-`v4.22` via `catalog_names`.
- Renamed the list to `catalog_template_names` in `olm/values-release.yaml` and `olm/values.example.yaml`, trimmed to the 3 actual template files, with a comment clarifying it must mirror the fork's `ci.yaml` `fbc.catalog_mapping[].template_name` entries rather than the full set of supported OpenShift versions.
- Updated `olm/templates/release-config-template.yaml`'s ytt reference accordingly.
- Added a comment in `.github/workflows/olm.yml` noting that adding support for a new OCP minor version that reuses an existing template is a separate manual PR against the fork's `ci.yaml`, not something this workflow does.

## Test plan
- [x] Ran `gmake -f olm.mk olm-release-config BUNDLE_REPLACES=rabbitmq-cluster-operator.v2.22.1` and confirmed `olm/release-config.yaml` now contains exactly 3 `catalog_templates` entries (`v4.18.yaml`, `v4.19.yaml`, `v4.20.yaml`), matching the correct upstream schema.
- [x] CI: `Test & Publish OLM Package` workflow runs `make -f olm.mk all` end-to-end with the renamed key.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>