### PR TITLE
Add Pod to object cache by label

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -206,6 +206,7 @@ func main() {
 	options.Cache.ByObject = map[client.Object]cache.ByObject{
 		&rabbitmqv1beta1.RabbitmqCluster{}: {},
 		&appsv1.StatefulSet{}:              {Label: rmqSelector},
+		&corev1.Pod{}:                      {Label: rmqSelector},
 		&corev1.Service{}:                  {Label: rmqSelector},
 		&corev1.ConfigMap{}:                {Label: rmqSelector},
 		&corev1.Secret{}:                   {Label: rmqSelector},


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Add Pod to object cache by label

## Additional Context

Because function `addRabbitmqDeletionLabel` lists all Pods for a specific `RabbitmqCluster` instance using the manager client. This client silently spins up a shared informer cache if missing. This cache caches the objects in ALL namespaces. Pods are a high volume resource in clusters, therefore this could run into memory issues in the Operator long-term. By adding a label filter to the cache options, the informer only adds a very small subset of relevant objects to the cache.

This change was inspired by Red Hat developers blog post: https://developers.redhat.com/articles/2026/07/06/5-anti-patterns-cause-kubernetes-operator-vulnerabilities#

## Local Testing

Run unit and integration tests.
