### PR TITLE
Stop setting owner reference on PVCs

### DIFF
--- a/internal/resource/statefulset.go
+++ b/internal/resource/statefulset.go
@@ -70,6 +70,10 @@ func (builder *StatefulSetBuilder) Build() (client.Object, error) {
 			},
 			VolumeClaimTemplates: pvc,
 			PodManagementPolicy:  appsv1.ParallelPodManagement,
+			PersistentVolumeClaimRetentionPolicy: &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+			},
 		},
 	}
 
@@ -313,11 +317,6 @@ func persistentVolumeClaim(instance *rabbitmqv1beta1.RabbitmqCluster, scheme *ru
 			StorageClassName: instance.Spec.Persistence.StorageClassName,
 		},
 	}
-
-	if err := controllerutil.SetControllerReference(instance, &pvc, scheme); err != nil {
-		return []corev1.PersistentVolumeClaim{}, fmt.Errorf("failed setting controller reference: %w", err)
-	}
-	disableBlockOwnerDeletion(pvc)
 
 	return []corev1.PersistentVolumeClaim{pvc}, nil
 }

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -102,6 +102,19 @@ var _ = Describe("StatefulSet", func() {
 			q, _ := k8sresource.ParseQuantity("21Gi")
 			Expect(statefulSet.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests["storage"]).To(Equal(q))
 		})
+
+		It("sets the persistent volume claim retention policy", func() {
+			obj, err := stsBuilder.Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			statefulSet := obj.(*appsv1.StatefulSet)
+			Expect(statefulSet.Spec.PersistentVolumeClaimRetentionPolicy).ToNot(BeNil())
+			Expect(statefulSet.Spec.PersistentVolumeClaimRetentionPolicy).
+				To(HaveField("WhenDeleted", BeEquivalentTo("Delete")))
+			Expect(statefulSet.Spec.PersistentVolumeClaimRetentionPolicy).
+				To(HaveField("WhenScaled", BeEquivalentTo("Retain")))
+		})
+
 		Context("PVC template", func() {
 			It("creates the required PersistentVolumeClaim", func() {
 				q, _ := k8sresource.ParseQuantity("10Gi")
@@ -119,17 +132,8 @@ var _ = Describe("StatefulSet", func() {
 							"app.kubernetes.io/component": "rabbitmq",
 							"app.kubernetes.io/part-of":   "rabbitmq",
 						},
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion:         "rabbitmq.com/v1beta1",
-								Kind:               "RabbitmqCluster",
-								Name:               instance.Name,
-								UID:                "",
-								Controller:         new(true),
-								BlockOwnerDeletion: new(false),
-							},
-						},
-						Annotations: map[string]string{},
+						Annotations:     map[string]string{},
+						OwnerReferences: nil, // expecting nil explicitly, to check that it is not set
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -177,6 +181,7 @@ var _ = Describe("StatefulSet", func() {
 				Expect(statefulSet.Spec.VolumeClaimTemplates).To(BeEmpty())
 			})
 		})
+
 		Context("Override", func() {
 			It("overrides statefulSet.spec.selector", func() {
 				builder.Instance.Spec.Override.StatefulSet = &rabbitmqv1beta1.StatefulSet{
@@ -1693,67 +1698,68 @@ default_pass = {{ .Data.data.password }}
 			Expect(*statefulSet.Spec.Replicas).To(Equal(int32(3)))
 		})
 
-		It("updates the PersistentVolumeClaim storage capacity", func() {
-			defaultCapacity, _ := k8sresource.ParseQuantity("10Gi")
+		Context("Persistent Volume Claim template", func() {
+			It("updates the PersistentVolumeClaim storage capacity", func() {
+				defaultCapacity, _ := k8sresource.ParseQuantity("10Gi")
 
-			statefulSet.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "persistence",
-						Namespace: instance.Namespace,
-					},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-						Resources: corev1.VolumeResourceRequirements{
-							Requests: map[corev1.ResourceName]k8sresource.Quantity{
-								corev1.ResourceStorage: defaultCapacity,
-							},
+				statefulSet.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "persistence",
+							Namespace: instance.Namespace,
 						},
-					},
-				},
-			}
-
-			newCapacity, _ := k8sresource.ParseQuantity("21Gi")
-			stsBuilder.Instance.Spec.Persistence.Storage = &newCapacity
-			Expect(stsBuilder.Update(statefulSet)).To(Succeed())
-			Expect(statefulSet.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests["storage"]).To(Equal(newCapacity))
-		})
-
-		When("spec.persistence.storage is provided and the default pvc is also configured in override", func() {
-			It("sets the default pvc to what's provided in override", func() {
-				seven := k8sresource.MustParse("7Gi")
-				builder.Instance.Spec.Override.StatefulSet = &rabbitmqv1beta1.StatefulSet{
-					Spec: &rabbitmqv1beta1.StatefulSetSpec{
-						VolumeClaimTemplates: []rabbitmqv1beta1.PersistentVolumeClaim{
-							{
-								EmbeddedObjectMeta: rabbitmqv1beta1.EmbeddedObjectMeta{
-									Name:      "persistence",
-									Namespace: instance.Namespace,
-								},
-								Spec: corev1.PersistentVolumeClaimSpec{
-									Resources: corev1.VolumeResourceRequirements{
-										Requests: corev1.ResourceList{
-											corev1.ResourceStorage: seven,
-										},
-									},
-									StorageClassName: nil,
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: map[corev1.ResourceName]k8sresource.Quantity{
+									corev1.ResourceStorage: defaultCapacity,
 								},
 							},
 						},
 					},
 				}
-				stsBuilder := builder.StatefulSet()
-				obj, err := stsBuilder.Build()
-				Expect(err).NotTo(HaveOccurred())
-				statefulSet := obj.(*appsv1.StatefulSet)
 
 				newCapacity, _ := k8sresource.ParseQuantity("21Gi")
 				stsBuilder.Instance.Spec.Persistence.Storage = &newCapacity
 				Expect(stsBuilder.Update(statefulSet)).To(Succeed())
-
-				Expect(statefulSet.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests["storage"]).To(Equal(seven))
+				Expect(statefulSet.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests["storage"]).To(Equal(newCapacity))
 			})
 
+			When("spec.persistence.storage is provided and the default pvc is also configured in override", func() {
+				It("sets the default pvc to what's provided in override", func() {
+					seven := k8sresource.MustParse("7Gi")
+					builder.Instance.Spec.Override.StatefulSet = &rabbitmqv1beta1.StatefulSet{
+						Spec: &rabbitmqv1beta1.StatefulSetSpec{
+							VolumeClaimTemplates: []rabbitmqv1beta1.PersistentVolumeClaim{
+								{
+									EmbeddedObjectMeta: rabbitmqv1beta1.EmbeddedObjectMeta{
+										Name:      "persistence",
+										Namespace: instance.Namespace,
+									},
+									Spec: corev1.PersistentVolumeClaimSpec{
+										Resources: corev1.VolumeResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceStorage: seven,
+											},
+										},
+										StorageClassName: nil,
+									},
+								},
+							},
+						},
+					}
+					stsBuilder := builder.StatefulSet()
+					obj, err := stsBuilder.Build()
+					Expect(err).NotTo(HaveOccurred())
+					statefulSet := obj.(*appsv1.StatefulSet)
+
+					newCapacity, _ := k8sresource.ParseQuantity("21Gi")
+					stsBuilder.Instance.Spec.Persistence.Storage = &newCapacity
+					Expect(stsBuilder.Update(statefulSet)).To(Succeed())
+
+					Expect(statefulSet.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests["storage"]).To(Equal(seven))
+				})
+			})
 		})
 
 		When("stateful set override are provided", func() {

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -304,14 +304,6 @@ CONSOLE_LOG=new`
 				Expect(err).NotTo(HaveOccurred())
 				Expect(message.Payload).To(Equal("hello"))
 			})
-
-			By("setting owner reference to persistence volume claim successfully", func() {
-				pvcName := "persistence-" + statefulSetPodName(cluster, 0)
-				pvc, err := clientSet.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pvc.OwnerReferences).To(HaveLen(1))
-				Expect(pvc.OwnerReferences[0].Name).To(Equal(cluster.Name))
-			})
 		}, SpecTimeout(time.Minute*3))
 	})
 


### PR DESCRIPTION
## Summary
- The operator no longer sets an owner reference on the PVCs it creates, since it no longer owns their lifecycle.
- The StatefulSet spec now sets `persistentVolumeClaimRetentionPolicy`, defaulting to `whenDeleted: Delete` / `whenScaled: Retain` to preserve existing behaviour.

Previously, the operator set an owner reference on PVCs, which caused Kubernetes garbage collection to delete the PVCs whenever the `RabbitmqCluster` was deleted — regardless of the `persistentVolumeClaimRetentionPolicy` configured on the StatefulSet (via `override`). This defeated the purpose of `whenDeleted: Retain`.

Fixes #1992

## Test plan
- [x] Unit tests updated in `internal/resource/statefulset_test.go` to assert PVCs have no owner reference and that the default retention policy is set on the StatefulSet.
- [x] `gmake just-unit-tests`
- [x] Manually deployed a dev build of the operator: created, scaled to 0, scaled up and deleted.