### PR TITLE
test: fix the flaky persists messages system test

### DIFF
--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -269,8 +269,14 @@ CONSOLE_LOG=new`
 		)
 
 		BeforeEach(func(ctx SpecContext) {
-			cluster = newRabbitmqCluster(namespace, "persistence-rabbit")
-			Expect(createRabbitmqCluster(ctx, rmqClusterClient, cluster)).To(Succeed())
+			// The AfterEach wait can be cut short by the spec deadline, so retry the create too.
+			Eventually(ctx, func() error {
+				cluster = newRabbitmqCluster(namespace, "persistence-rabbit")
+				return createRabbitmqCluster(ctx, rmqClusterClient, cluster)
+			}).
+				WithTimeout(clusterDeletionTimeout).
+				WithPolling(2 * time.Second).
+				Should(Succeed())
 
 			waitForRabbitmqRunning(cluster)
 
@@ -283,7 +289,9 @@ CONSOLE_LOG=new`
 		})
 
 		AfterEach(func(ctx SpecContext) {
-			Expect(rmqClusterClient.Delete(ctx, cluster)).To(Succeed())
+			// A FlakeAttempts retry recreates this name milliseconds after we return, so block
+			// until the cluster is actually gone.
+			deleteRabbitmqClusterAndWait(ctx, rmqClusterClient, cluster)
 		})
 
 		It("persists messages", FlakeAttempts(3), func(ctx SpecContext) {
@@ -304,7 +312,8 @@ CONSOLE_LOG=new`
 				Expect(err).NotTo(HaveOccurred())
 				Expect(message.Payload).To(Equal("hello"))
 			})
-		}, SpecTimeout(time.Minute*3))
+			// The deadline covers the whole attempt, teardown included, and resets on each retry.
+		}, SpecTimeout(time.Minute*5))
 	})
 
 	Context("Persistence expansion", Label("persistence_expansion"), func() {

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -274,7 +274,7 @@ CONSOLE_LOG=new`
 				cluster = newRabbitmqCluster(namespace, "persistence-rabbit")
 				return createRabbitmqCluster(ctx, rmqClusterClient, cluster)
 			}).
-				WithTimeout(clusterDeletionTimeout).
+				WithTimeout(clusterCreationTimeout).
 				WithPolling(2 * time.Second).
 				Should(Succeed())
 

--- a/test/system/utils_test.go
+++ b/test/system/utils_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/message"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -62,6 +63,7 @@ import (
 const podCreationTimeout = 10 * time.Minute
 const portReadinessTimeout = 1 * time.Minute
 const k8sQueryTimeout = 1 * time.Minute
+const clusterDeletionTimeout = 90 * time.Second
 
 type featureFlag struct {
 	Name  string
@@ -505,6 +507,32 @@ func updateRabbitmqCluster(ctx context.Context, client client.Client, name, name
 
 func createRabbitmqCluster(ctx context.Context, client client.Client, rabbitmqCluster *rabbitmqv1beta1.RabbitmqCluster) error {
 	return client.Create(ctx, rabbitmqCluster)
+}
+
+// deleteRabbitmqClusterAndWait deletes a RabbitmqCluster and waits for it to disappear. Delete only
+// marks it: the operator's finalizer keeps the object in Terminating for a few seconds, and
+// recreating the same name before then fails with "object is being deleted ... already exists".
+func deleteRabbitmqClusterAndWait(ctx context.Context, c client.Client, cluster *rabbitmqv1beta1.RabbitmqCluster) {
+	GinkgoHelper()
+
+	Expect(client.IgnoreNotFound(c.Delete(ctx, cluster))).To(Succeed())
+
+	key := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
+	Eventually(ctx, func() error {
+		var current rabbitmqv1beta1.RabbitmqCluster
+		err := c.Get(ctx, key, &current)
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("RabbitmqCluster %s is still present (deletionTimestamp: %v, finalizers: %v)",
+			key, current.DeletionTimestamp, current.Finalizers)
+	}).
+		WithTimeout(clusterDeletionTimeout).
+		WithPolling(2 * time.Second).
+		Should(Succeed())
 }
 
 func statefulSetPodName(cluster *rabbitmqv1beta1.RabbitmqCluster, index int) string {

--- a/test/system/utils_test.go
+++ b/test/system/utils_test.go
@@ -65,6 +65,10 @@ const portReadinessTimeout = 1 * time.Minute
 const k8sQueryTimeout = 1 * time.Minute
 const clusterDeletionTimeout = 90 * time.Second
 
+// A create is rejected while a cluster of the same name is still terminating, so the retry needs
+// to cover a deletion.
+const clusterCreationTimeout = clusterDeletionTimeout
+
 type featureFlag struct {
 	Name  string
 	State string


### PR DESCRIPTION

This closes #2152


## Summary Of Changes

This flake is a teardown race, not a timeout.

`AfterEach` calls Delete and returns right away. But Delete only marks the object, and the operator's finalizer keeps it in Terminating for a couple of seconds. Ginkgo then re-enters `BeforeEach`, creates the same name, and the API server says no:

```text
object is being deleted: rabbitmqclusters.rabbitmq.com "persistence-rabbit" already exists
```

So `FlakeAttempts(3)` is really `FlakeAttempts(1)`. Attempts 2 and 3 never reach the spec body, no matter what broke attempt 1.

Fix is to make teardown wait:

- `AfterEach` uses a new `deleteRabbitmqClusterAndWait` helper that deletes and polls until the object is gone. If it times out it prints the deletion timestamp and remaining finalizers, so if a deletion ever does get stuck we can see why from the CI log instead of waiting for it to happen again.
- The create in `BeforeEach` is wrapped in `Eventually` too, since the teardown wait can get cut short by the spec deadline.

SpecTimeout goes 3m to 5m. Ginkgo counts the whole attempt against that deadline including `AfterEach`, and resets it per attempt, so the extra wait needs to fit. 5m is what the TLS spec in this file already uses.

## Additional Context

I opened #2152 and @MirahImage raised #2212 off it. It's still in draft and I don't think either change in it helps, so this replaces it.

SpecTimeout wasn't the problem, on the run above the body got to its last assertion in 115s out of 180s. And this line:

```go
Eventually(createRabbitmqCluster(ctx, rmqClusterClient, cluster)).Should(Succeed())
```

calls the function once and passes the resulting error to Eventually, so it just polls a value that can't change. The create never gets retried. It needs a closure, which is what I've done here.

@Zerpet mentioned the old cluster might be stuck on something. I couldn't find any sign of that. I timed deletion on kind and a single node cluster goes from Delete to gone in 2s, same UID throughout. It really is just that nothing waits those 2s. The leaked clusters do cause knock on slowness though, the old one keeps running and later specs fight it for memory on the same node, so that may be why this test has felt flaky in a few different ways.

## Local Testing

`make just-unit-tests` and `make just-integration-tests` pass.

For the system test I deployed the operator to a local kind cluster (v1.35.0, cert-manager v1.15.1) and ran the persistence spec with attempt 1 forced to fail so the retry runs every time.

On main the retry reproduces CI almost exactly, BeforeEach fails 15ms and 9ms later with the same 409. On this branch AfterEach finishes its delete and wait in 2.0s and attempt 2 creates the cluster fine. I also ran the old and new teardown as two contexts in the same suite, old one failed on the 409, new one passed on attempt 2.

One caveat, the specs can't fully pass on macOS. The helpers resolve the endpoint to the kind node IP and Docker Desktop won't route that from the host, so `assertHttpReady` always times out. That's what I used to fail attempt 1. So I've verified the create/delete/retry behaviour locally but not the message persistence bits, those need CI.
