### PR TITLE
Enable metrics protection with certManager patch

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -37,9 +37,9 @@ patches:
 # Uncomment the patches line if you enable Metrics and CertManager
 # [METRICS-WITH-CERTS] To enable metrics protected with certManager, uncomment the following line.
 # This patch will protect the metrics with certManager self-signed certs.
-#- path: cert_metrics_manager_patch.yaml
-#  target:
-#    kind: Deployment
+- path: cert_metrics_manager_patch.yaml
+  target:
+    kind: Deployment
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml


### PR DESCRIPTION
## Summary Of Changes

Uncomment cert_metrics_manager_patch.yaml to enable metrics protection.

## Additional Context

2.20.0 introduced a [metrics-cert](https://github.com/rabbitmq/cluster-operator/blob/main/config/certmanager/certificate-metrics.yaml) but didn't wire it into the the deployment for usage.

Similar to what is done in topology-operator: https://github.com/rabbitmq/messaging-topology-operator/blob/main/config/default/kustomization.yaml#L44-L47


Side note: it would be good have a `namePrefix` somewhere in the kustomization for `certmanager` resources. Right now the issuer is just called `selfsigned-issuer` in the release, which is not ideal IMO. Again in toplogy-operator it's nicely prefixed with `messaging-topology-selfsigned-issuer`. I'm not sure exactly where to change it for it to take effect.